### PR TITLE
perf: 优化补丁生成算法

### DIFF
--- a/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
+++ b/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
@@ -241,7 +241,7 @@ namespace GeneralUpdate.Differential
                 {
                     var extensionName = Path.GetExtension(file.FullName);
                     if (FileProvider.GetBlackFileFormats().Contains(extensionName)) continue;
-                    var targetFileName = file.FullName.Replace(patchPath, "").TrimStart("\\".ToCharArray());
+                    var targetFileName = file.FullName.Replace(patchPath, string.Empty).TrimStart('\\');
                     var targetPath = Path.Combine(appPath, targetFileName);
                     var parentFolder = Directory.GetParent(targetPath);
                     if (!parentFolder.Exists) parentFolder.Create();

--- a/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
+++ b/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
@@ -81,8 +81,10 @@ namespace GeneralUpdate.Differential
                 //Binary differencing of like terms .
                 foreach (var file in nodes.Item3)
                 {
-                    var dirSeparatorChar = Path.DirectorySeparatorChar.ToString().ToCharArray();
-                    var tempPath = file.FullName.Replace(targetPath, "").Replace(Path.GetFileName(file.FullName), "").TrimStart(dirSeparatorChar).TrimEnd(dirSeparatorChar);
+                    var tempPath = file.FullName
+                        .Replace(targetPath, string.Empty)
+                        .Replace(Path.GetFileName(file.FullName), string.Empty)
+                        .Trim(Path.DirectorySeparatorChar);
                     var tempPath0 = string.Empty;
                     var tempDir = string.Empty;
                     if (string.IsNullOrEmpty(tempPath))
@@ -98,7 +100,7 @@ namespace GeneralUpdate.Differential
                     }
                     
                     var finOldFile = nodes.Item1.FirstOrDefault(i => i.Name.Equals(file.Name));
-                    var oldFile = finOldFile == null ? "" : finOldFile.FullName;
+                    var oldFile = finOldFile == null ? string.Empty : finOldFile.FullName;
                     var newFile = file.FullName;
                     var extensionName = Path.GetExtension(file.FullName);
                     if (File.Exists(oldFile) && File.Exists(newFile) && !FileProvider.GetBlackFileFormats().Contains(extensionName))
@@ -155,7 +157,7 @@ namespace GeneralUpdate.Differential
                     var hashAlgorithm = new Sha256HashAlgorithm();
                     foreach (var file in deleteFiles)
                     {
-                        var resultFile = oldFiles.FirstOrDefault(i => 
+                        var resultFile = oldFiles.Find(i => 
                             string.Equals(hashAlgorithm.ComputeHash(i.FullName), file.Hash, StringComparison.OrdinalIgnoreCase));
                         if (resultFile == null)
                         {
@@ -171,7 +173,7 @@ namespace GeneralUpdate.Differential
                 foreach (var oldFile in oldFiles)
                 {
                     //Only the difference file (.patch) can be updated here.
-                    var findFile = patchFiles.FirstOrDefault(f =>
+                    var findFile = patchFiles.Find(f =>
                     {
                         var tempName = Path.GetFileNameWithoutExtension(f.Name).Replace(PATCH_FORMAT, "");
                         return tempName.Equals(oldFile.Name);


### PR DESCRIPTION
1. 将 `""` 替换为`string.Empty`
2. 将`TrimStart`和`TrimEnd`组合调用改为调用`Trim`
3. 将 Linq 的`FirstOrDefault`方法替换为`List`上的`Find`方法以提高查找性能