### PR TITLE
Use application assets as EmbeddedResource

### DIFF
--- a/src/c#/GeneralUpdate.Bowl/GeneralUpdate.Bowl.csproj
+++ b/src/c#/GeneralUpdate.Bowl/GeneralUpdate.Bowl.csproj
@@ -7,27 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <None Update="Applications\Windows\procdump.exe">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Windows\procdump64.exe">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Windows\procdump64a.exe">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Linux\procdump-3.3.0-0.cm2.x86_64.rpm">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Linux\procdump-3.3.0-0.el8.x86_64.rpm">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Linux\procdump_3.3.0_amd64.deb">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Applications\Windows\export.bat">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
+        <EmbeddedResource Include="Applications\**\*">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </EmbeddedResource>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Use application assets as `EmbeddedResource`

packed dll contents:

![image](https://github.com/user-attachments/assets/1b62fbd8-8657-4374-84a0-7b6f234061c1)
