### PR TITLE
feat(vela): Sub-Issue #1 — Rust workspace scaffolding

### DIFF
--- a/src/vela/vela-core/.gitignore
+++ b/src/vela/vela-core/.gitignore
@@ -1,0 +1,5 @@
+target/
+Cargo.lock
+**/*.rs.bk
+*.pdb
+.DS_Store

--- a/src/vela/vela-core/Cargo.toml
+++ b/src/vela/vela-core/Cargo.toml
@@ -1,0 +1,61 @@
+[workspace]
+members = [
+    "crates/vela-crypto",
+    "crates/vela-flashpack",
+    "crates/vela-attestation",
+    "crates/vela-lifecycle",
+    "crates/vela-slotmgr",
+    "crates/vela-pulse",
+    "crates/vela-ffi",
+    "crates/vela-core",
+]
+resolver = "3"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+license = "Apache-2.0"
+repository = "https://github.com/GeneralLibrary/GeneralUpdate"
+
+[workspace.dependencies]
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Error handling
+thiserror = "2"
+# Structured logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+# Crypto
+ring = "0.17"
+x509-cert = "0.25"
+# HTTP client
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+# JWT
+jsonwebtoken = "9"
+# Archive/compression
+tar = "0.4"
+flate2 = "1"
+# Hashing
+sha2 = "0.10"
+hex = "0.4"
+# ECDSA / RSA traits
+p256 = "0.13"
+rsa = "0.9"
+pkcs8 = "0.10"
+# Async trait
+async-trait = "0.1"
+# UUID
+uuid = { version = "1", features = ["v4"] }
+# Time
+chrono = { version = "0.4", features = ["serde"] }
+# Cross-platform syscalls
+libc = "0.2"
+# FFI binding generation (build-dependency)
+csbindgen = "2"
+# Testing
+mockall = "0.13"
+tempfile = "3"

--- a/src/vela/vela-core/crates/vela-attestation/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-attestation/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vela-attestation"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["time"] }
+reqwest.workspace = true
+jsonwebtoken.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+vela-crypto = { path = "../vela-crypto" }
+
+[dev-dependencies]
+tempfile.workspace = true
+mockall.workspace = true

--- a/src/vela/vela-core/crates/vela-attestation/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-attestation/src/lib.rs
@@ -1,0 +1,69 @@
+#![forbid(unsafe_code)]
+#![doc = "Device attestation: identity proof and session token management."]
+
+use thiserror::Error;
+use tracing::instrument;
+
+/// Errors during attestation.
+#[derive(Error, Debug)]
+pub enum AttestationError {
+    #[error("Device identity not configured")]
+    IdentityNotConfigured,
+
+    #[error("Attestation challenge failed: {0}")]
+    ChallengeFailed(String),
+
+    #[error("Token expired")]
+    TokenExpired,
+
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    #[error("Invalid response from Hub: {0}")]
+    InvalidResponse(String),
+}
+
+/// Result type alias for attestation operations.
+pub type AttestationResult<T> = Result<T, AttestationError>;
+
+/// Unique device identity, burned at factory.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeviceIdentity {
+    pub serial: String,
+    pub hardware_fingerprint: String,
+    pub model: String,
+    pub manufacturer: String,
+}
+
+/// Challenge from Hub for anti-replay.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AttestationChallenge {
+    pub nonce: String,
+    pub expires_at: String,
+}
+
+/// Short-lived JWT session token.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionToken {
+    pub jwt_token: String,
+    pub expires_at: String,
+    pub refresh_token: String,
+}
+
+impl SessionToken {
+    /// Check if token expires within the given duration.
+    pub fn is_expiring_soon(&self, _within: std::time::Duration) -> bool {
+        // TODO: parse expires_at and compare with Utc::now()
+        false
+    }
+}
+
+/// Initiate device attestation with the Vela Hub.
+#[instrument(skip(identity))]
+pub async fn request_attestation(
+    identity: &DeviceIdentity,
+    hub_url: &str,
+) -> AttestationResult<SessionToken> {
+    tracing::debug!(serial = %identity.serial, "Initiating device attestation");
+    Err(AttestationError::IdentityNotConfigured)
+}

--- a/src/vela/vela-core/crates/vela-core/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vela-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+serde.workspace = true
+vela-flashpack = { path = "../vela-flashpack" }
+vela-lifecycle = { path = "../vela-lifecycle" }
+vela-slotmgr = { path = "../vela-slotmgr" }
+vela-attestation = { path = "../vela-attestation" }
+vela-pulse = { path = "../vela-pulse" }
+vela-crypto = { path = "../vela-crypto" }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/src/vela/vela-core/crates/vela-core/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-core/src/lib.rs
@@ -1,0 +1,67 @@
+#![forbid(unsafe_code)]
+#![doc = "Vela Core: top-level orchestration crate for the Vela OTA system."]
+#![doc = ""]
+#![doc = "Provides initialization, logging setup, and integration of all sub-crates."]
+
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+/// Initialize structured JSON logging for the Vela OTA system.
+///
+/// When `verbose` is true, sets the log level to `trace` for detailed
+/// diagnostics. Otherwise defaults to `info` level for production use.
+pub fn init_logging(verbose: bool) {
+    let filter = if verbose {
+        EnvFilter::new("vela=trace")
+    } else {
+        EnvFilter::new("vela=info")
+    };
+
+    let subscriber = fmt::layer()
+        .json()
+        .with_current_span(true)
+        .with_span_list(true)
+        .with_target(true);
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(subscriber)
+        .init();
+
+    tracing::info!("Vela Core logging initialized (verbose={verbose})");
+}
+
+/// Top-level error type for the Vela Core orchestration layer.
+#[derive(Debug, thiserror::Error)]
+pub enum VelaError {
+    #[error("Initialization failed: {0}")]
+    InitError(String),
+
+    #[error("FlashPack error: {0}")]
+    FlashPack(#[from] vela_flashpack::FlashPackError),
+
+    #[error("Lifecycle error: {0}")]
+    Lifecycle(#[from] vela_lifecycle::LifecycleError),
+
+    #[error("Slot error: {0}")]
+    Slot(#[from] vela_slotmgr::SlotError),
+
+    #[error("Attestation error: {0}")]
+    Attestation(#[from] vela_attestation::AttestationError),
+
+    #[error("Pulse error: {0}")]
+    Pulse(#[from] vela_pulse::PulseError),
+}
+
+/// Result type alias for Vela Core operations.
+pub type VelaResult<T> = Result<T, VelaError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_logging_init() {
+        init_logging(false);
+        tracing::info!("Logging test passed");
+    }
+}

--- a/src/vela/vela-core/crates/vela-crypto/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-crypto/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vela-crypto"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+ring.workspace = true
+x509-cert.workspace = true
+sha2.workspace = true
+hex.workspace = true
+p256.workspace = true
+rsa.workspace = true
+pkcs8.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/src/vela/vela-core/crates/vela-crypto/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-crypto/src/lib.rs
@@ -1,0 +1,69 @@
+#![forbid(unsafe_code)]
+#![doc = "Vela cryptographic primitives: signing, hashing, and key management."]
+
+use thiserror::Error;
+use tracing::instrument;
+
+/// Errors that can occur during cryptographic operations.
+#[derive(Error, Debug)]
+pub enum CryptoError {
+    #[error("Signing failed: {0}")]
+    SigningFailed(String),
+
+    #[error("Verification failed: {0}")]
+    VerificationFailed(String),
+
+    #[error("Key parsing error: {0}")]
+    KeyParsingError(String),
+
+    #[error("Unsupported algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+
+    #[error("Hash computation failed: {0}")]
+    HashingFailed(String),
+}
+
+/// Result type alias for crypto operations.
+pub type CryptoResult<T> = Result<T, CryptoError>;
+
+/// Supported signature algorithms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SignatureAlgorithm {
+    RsaPssSha256,
+    EcdsaP256Sha256,
+}
+
+/// A parsed public key for bundle validation.
+#[derive(Debug, Clone)]
+pub struct PublicKey {
+    pub algorithm: SignatureAlgorithm,
+    pub raw: Vec<u8>,
+}
+
+/// A parsed private key for bundle signing.
+#[derive(Debug)]
+pub struct SigningKey {
+    pub algorithm: SignatureAlgorithm,
+    pub raw: Vec<u8>,
+}
+
+/// Trait for signing FlashPack bundles.
+pub trait BundleSigner: Send + Sync {
+    fn algorithm(&self) -> SignatureAlgorithm;
+    fn sign(&self, data: &[u8]) -> CryptoResult<Vec<u8>>;
+}
+
+/// Trait for verifying FlashPack signatures.
+pub trait BundleVerifier: Send + Sync {
+    fn algorithm(&self) -> SignatureAlgorithm;
+    fn verify(&self, data: &[u8], signature: &[u8]) -> CryptoResult<bool>;
+}
+
+/// Compute SHA-256 hash of data.
+#[instrument(skip(data), fields(size = data.len()))]
+pub fn sha256(data: &[u8]) -> CryptoResult<Vec<u8>> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    Ok(hasher.finalize().to_vec())
+}

--- a/src/vela/vela-core/crates/vela-ffi/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-ffi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "vela-ffi"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+vela-flashpack = { path = "../vela-flashpack" }
+vela-lifecycle = { path = "../vela-lifecycle" }
+vela-slotmgr = { path = "../vela-slotmgr" }
+vela-attestation = { path = "../vela-attestation" }
+vela-pulse = { path = "../vela-pulse" }
+vela-crypto = { path = "../vela-crypto" }
+
+[build-dependencies]
+csbindgen.workspace = true

--- a/src/vela/vela-core/crates/vela-ffi/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-ffi/src/lib.rs
@@ -1,0 +1,91 @@
+//! FFI layer: exports Vela Core functionality via C ABI for C# consumption.
+//! This is the ONLY place where `unsafe` is permitted in the Vela workspace.
+
+use std::sync::Mutex;
+use tracing::{error, info, trace};
+
+// Global last-error slot (thread-safe).
+static LAST_ERROR: Mutex<Option<String>> = Mutex::new(None);
+
+fn set_last_error(e: impl std::fmt::Display) {
+    if let Ok(mut guard) = LAST_ERROR.lock() {
+        *guard = Some(e.to_string());
+    }
+}
+
+/// Opaque handle types for FFI.
+pub struct FpkHandle {
+    // inner: vela_flashpack::FlashPackReader,
+}
+pub struct EngineHandle {
+    // inner: vela_lifecycle::LifecycleEngine,
+}
+
+/// Get the last error message. Caller must free the returned string.
+/// Returns null if no error recorded.
+#[no_mangle]
+pub unsafe extern "C" fn vela_last_error() -> *mut std::os::raw::c_char {
+    let err = LAST_ERROR.lock().ok().and_then(|g| g.clone());
+    match err {
+        Some(msg) => {
+            let c_str = std::ffi::CString::new(msg).unwrap_or_default();
+            c_str.into_raw()
+        }
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Clear the last error.
+#[no_mangle]
+pub unsafe extern "C" fn vela_clear_error() {
+    if let Ok(mut guard) = LAST_ERROR.lock() {
+        *guard = None;
+    }
+}
+
+/// Initialize the Vela Core engine. Returns engine handle or null on error.
+#[no_mangle]
+pub unsafe extern "C" fn vela_init() -> *mut EngineHandle {
+    trace!("FFI: vela_init called");
+    info!("Vela Core engine initialized");
+    Box::into_raw(Box::new(EngineHandle {}))
+}
+
+/// Shut down and release the engine handle.
+#[no_mangle]
+pub unsafe extern "C" fn vela_shutdown(handle: *mut EngineHandle) -> i32 {
+    if handle.is_null() {
+        trace!("FFI: vela_shutdown called with null handle");
+        return 1;
+    }
+    let _dropped = unsafe { Box::from_raw(handle) };
+    info!("Vela Core engine shut down");
+    0
+}
+
+/// Open a FlashPack file. Returns handle or null on error.
+#[no_mangle]
+pub unsafe extern "C" fn vela_fpk_open(path: *const std::os::raw::c_char) -> *mut FpkHandle {
+    let path_str = match unsafe { std::ffi::CStr::from_ptr(path) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = %e, "vela_fpk_open: invalid UTF-8 path");
+            return std::ptr::null_mut();
+        }
+    };
+    trace!(path = %path_str, "FFI: vela_fpk_open called");
+    // TODO: delegate to vela_flashpack::FlashPackReader::open
+    set_last_error("vela_fpk_open: not yet implemented");
+    std::ptr::null_mut()
+}
+
+/// Close a FlashPack handle and release resources.
+#[no_mangle]
+pub unsafe extern "C" fn vela_fpk_close(handle: *mut FpkHandle) -> i32 {
+    if handle.is_null() {
+        return 1;
+    }
+    let _dropped = unsafe { Box::from_raw(handle) };
+    trace!("FFI: vela_fpk_close — handle released");
+    0
+}

--- a/src/vela/vela-core/crates/vela-flashpack/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-flashpack/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vela-flashpack"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tar.workspace = true
+flate2.workspace = true
+sha2.workspace = true
+hex.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+vela-crypto = { path = "../vela-crypto" }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/src/vela/vela-core/crates/vela-flashpack/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-flashpack/src/lib.rs
@@ -1,0 +1,88 @@
+#![forbid(unsafe_code)]
+#![doc = "FlashPack (.fpk) update bundle format parsing, building, and validation."]
+
+use thiserror::Error;
+use tracing::instrument;
+use vela_crypto::CryptoError;
+
+/// Errors specific to FlashPack operations.
+#[derive(Error, Debug)]
+pub enum FlashPackError {
+    #[error("Invalid FlashPack format: {0}")]
+    InvalidFormat(String),
+
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+
+    #[error("Version requirement not met: current {current}, required {required}")]
+    VersionTooLow { current: String, required: String },
+
+    #[error("Format version {format_version} is not compatible (min reader: {min_reader})")]
+    FormatIncompatible {
+        format_version: String,
+        min_reader: String,
+    },
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Crypto error: {0}")]
+    Crypto(#[from] CryptoError),
+
+    #[error("JSON parse error: {0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
+/// Result type alias for FlashPack operations.
+pub type FpkResult<T> = Result<T, FlashPackError>;
+
+/// Payload type classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PayloadType {
+    FullImage,
+    Delta,
+    Application,
+}
+
+/// FlashPack bundle header metadata.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FpkHeader {
+    pub format_version: String,
+    pub min_reader_version: String,
+    pub bundle_name: String,
+    pub bundle_version: String,
+    pub compatible_slots: Vec<String>,
+    pub payload_type: PayloadType,
+    pub payload_size: u64,
+    pub requires_version: String,
+    pub created_at: String,
+    pub builder_id: String,
+    pub compat_flags: Vec<String>,
+}
+
+/// Parsed FlashPack bundle ready for validation.
+#[derive(Debug)]
+pub struct FlashPackReader {
+    pub header: FpkHeader,
+    pub checksums: Vec<u8>,
+    pub signature: Vec<u8>,
+    pub payload_path: String,
+}
+
+/// Result of bundle validation.
+#[derive(Debug, Clone)]
+pub struct BundleHash {
+    pub sha256: [u8; 32],
+}
+
+impl FlashPackReader {
+    /// Open and parse a .fpk file.
+    #[instrument(fields(path = %path))]
+    pub fn open(path: &str) -> FpkResult<Self> {
+        tracing::trace!("Opening FlashPack file");
+        Err(FlashPackError::InvalidFormat(
+            "FlashPackReader::open not yet implemented".into(),
+        ))
+    }
+}

--- a/src/vela/vela-core/crates/vela-lifecycle/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-lifecycle/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vela-lifecycle"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true, features = ["time", "sync"] }
+serde.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+vela-flashpack = { path = "../vela-flashpack" }
+vela-slotmgr = { path = "../vela-slotmgr" }
+vela-crypto = { path = "../vela-crypto" }
+
+[dev-dependencies]
+tempfile.workspace = true
+mockall.workspace = true

--- a/src/vela/vela-core/crates/vela-lifecycle/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-lifecycle/src/lib.rs
@@ -1,0 +1,141 @@
+#![forbid(unsafe_code)]
+#![doc = "Update lifecycle state machine for Vela OTA."]
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::instrument;
+
+/// Errors during the update lifecycle.
+#[derive(Error, Debug, Clone)]
+pub enum LifecycleError {
+    #[error("Phase timeout: {0:?}")]
+    PhaseTimeout(UpdatePhase),
+
+    #[error("Invalid state transition from {from:?} to {to:?}")]
+    InvalidTransition { from: UpdatePhase, to: UpdatePhase },
+
+    #[error("Hook execution failed in phase {phase:?}: {message}")]
+    HookError { phase: UpdatePhase, message: String },
+
+    #[error("Operation aborted")]
+    Aborted,
+}
+
+/// Result type alias for lifecycle operations.
+pub type LifecycleResult<T> = Result<T, LifecycleError>;
+
+/// Update lifecycle phases (strict state machine).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum UpdatePhase {
+    Idle,
+    Polling,
+    Acquiring,
+    Validating,
+    Installing,
+    Rebooting,
+    Verifying,
+    Committing,
+    FallbackRecovery,
+}
+
+/// Possible outcomes of an update lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LifecycleOutcome {
+    Success,
+    FallbackRecovery { reason: String, phase: UpdatePhase },
+    Aborted,
+}
+
+/// Observable metrics collected during an update.
+#[derive(Debug, Clone, Default)]
+pub struct LifecycleMetrics {
+    pub phase_durations: HashMap<UpdatePhase, u64>,
+    pub phase_attempts: HashMap<UpdatePhase, u32>,
+    pub retry_count: u32,
+    pub total_elapsed_ms: u64,
+    pub bytes_downloaded: u64,
+    pub bytes_written: u64,
+    pub validation_time_ms: u64,
+    pub outcome: Option<LifecycleOutcome>,
+}
+
+/// Shared context carried through all phases.
+pub struct LifecycleContext {
+    pub update_id: String,
+    pub metrics: Mutex<LifecycleMetrics>,
+}
+
+/// Hook trait for injecting custom logic per phase.
+#[async_trait::async_trait]
+pub trait PhaseHook: Send + Sync {
+    fn phase(&self) -> UpdatePhase;
+    async fn on_enter(&self, _ctx: &LifecycleContext) -> LifecycleResult<()> { Ok(()) }
+    async fn on_exit(&self, _ctx: &LifecycleContext) -> LifecycleResult<()> { Ok(()) }
+    async fn on_error(&self, _ctx: &LifecycleContext, _err: &LifecycleError) -> LifecycleResult<()> { Ok(()) }
+}
+
+/// RAII timer for tracking phase durations.
+pub struct PhaseTimer {
+    phase: UpdatePhase,
+    start: std::time::Instant,
+}
+
+impl PhaseTimer {
+    #[instrument(skip_all, fields(phase = ?phase))]
+    pub fn begin(phase: UpdatePhase, _ctx: &LifecycleContext) -> Self {
+        tracing::info!(?phase, "Entering phase");
+        Self { phase, start: std::time::Instant::now() }
+    }
+
+    pub fn complete(self, _ctx: &LifecycleContext) {
+        let elapsed = self.start.elapsed().as_millis() as u64;
+        tracing::info!(phase = ?self.phase, elapsed_ms = elapsed, "Phase completed");
+    }
+}
+
+/// Hub-issued update instruction.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RolloutManifest {
+    pub rollout_id: String,
+    pub flashpack_url: String,
+    pub flashpack_checksum: String,
+    pub target_version: String,
+    pub force_install: bool,
+    pub deadline: Option<String>,
+}
+
+/// The lifecycle engine drives phase transitions.
+pub struct LifecycleEngine {
+    pub config: LifecycleConfig,
+}
+
+/// Configuration for the lifecycle engine.
+#[derive(Debug, Clone)]
+pub struct LifecycleConfig {
+    pub phase_timeouts: HashMap<UpdatePhase, Duration>,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        let mut phase_timeouts = HashMap::new();
+        phase_timeouts.insert(UpdatePhase::Polling, Duration::from_secs(30));
+        phase_timeouts.insert(UpdatePhase::Acquiring, Duration::from_secs(3600));
+        phase_timeouts.insert(UpdatePhase::Validating, Duration::from_secs(120));
+        phase_timeouts.insert(UpdatePhase::Installing, Duration::from_secs(1800));
+        phase_timeouts.insert(UpdatePhase::Rebooting, Duration::from_secs(300));
+        phase_timeouts.insert(UpdatePhase::Verifying, Duration::from_secs(120));
+        Self { phase_timeouts }
+    }
+}
+
+impl LifecycleEngine {
+    pub fn new(config: LifecycleConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn phase_timeout(&self, phase: UpdatePhase) -> Duration {
+        self.config.phase_timeouts.get(&phase).copied().unwrap_or(Duration::from_secs(600))
+    }
+}

--- a/src/vela/vela-core/crates/vela-pulse/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-pulse/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vela-pulse"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+vela-attestation = { path = "../vela-attestation" }
+
+[dev-dependencies]
+tempfile.workspace = true
+mockall.workspace = true

--- a/src/vela/vela-core/crates/vela-pulse/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-pulse/src/lib.rs
@@ -1,0 +1,66 @@
+#![forbid(unsafe_code)]
+#![doc = "Health pulse: periodic status reporting from device to Vela Hub."]
+
+use thiserror::Error;
+use tracing::instrument;
+
+/// Errors during health pulse operations.
+#[derive(Error, Debug)]
+pub enum PulseError {
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    #[error("Hub rejected pulse (status {0}): {1}")]
+    Rejected(u16, String),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("Max retries exceeded ({attempts} attempts)")]
+    MaxRetriesExceeded { attempts: u32 },
+}
+
+/// Result type alias for pulse operations.
+pub type PulseResult<T> = Result<T, PulseError>;
+
+/// Retry configuration with exponential backoff.
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub initial_delay: std::time::Duration,
+    pub max_delay: std::time::Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 5,
+            initial_delay: std::time::Duration::from_secs(1),
+            max_delay: std::time::Duration::from_secs(60),
+        }
+    }
+}
+
+/// Health pulse report sent from device to Hub.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HealthPulseReport {
+    pub sequence: u64,
+    pub timestamp: String,
+    pub device_serial: String,
+    pub current_version: String,
+    pub lifecycle_phase: String,
+    pub cpu_percent: f32,
+    pub memory_used_mb: u64,
+    pub disk_free_mb: u64,
+    pub temperature_celsius: Option<f32>,
+    pub last_update_result: Option<String>,
+    pub network_connected: bool,
+}
+
+/// Send a single health pulse to the Hub.
+#[instrument(skip(report), fields(sequence = report.sequence))]
+pub async fn send_pulse_single(_report: &HealthPulseReport) -> PulseResult<()> {
+    tracing::trace!("Sending health pulse");
+    // TODO: HTTP POST to hub
+    Ok(())
+}

--- a/src/vela/vela-core/crates/vela-slotmgr/Cargo.toml
+++ b/src/vela/vela-core/crates/vela-slotmgr/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vela-slotmgr"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+libc.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+mockall.workspace = true

--- a/src/vela/vela-core/crates/vela-slotmgr/src/lib.rs
+++ b/src/vela/vela-core/crates/vela-slotmgr/src/lib.rs
@@ -1,0 +1,96 @@
+#![forbid(unsafe_code)]
+#![doc = "Dual-slot partition management for Vela OTA devices."]
+
+use thiserror::Error;
+use tracing::instrument;
+
+/// Errors during slot management operations.
+#[derive(Error, Debug)]
+pub enum SlotError {
+    #[error("Slot layout detection failed: {0}")]
+    DetectionFailed(String),
+
+    #[error("Insufficient space on {device}: need {required}, have {available}")]
+    InsufficientSpace {
+        device: String,
+        required: u64,
+        available: u64,
+    },
+
+    #[error("Boot flag write failed: {0}")]
+    BootFlagWriteError(String),
+
+    #[error("Slot swap failed: {0}")]
+    SwapFailed(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+/// Result type alias for slot operations.
+pub type SlotResult<T> = Result<T, SlotError>;
+
+/// A/B slot identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum SlotId {
+    Primary,
+    Alternate,
+}
+
+/// Filesystem types recognized by the slot manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSystemType {
+    Ext4,
+    Btrfs,
+    Xfs,
+    F2fs,
+    SquashFs,
+    Unknown,
+}
+
+/// Information about a single slot.
+#[derive(Debug, Clone)]
+pub struct SlotInfo {
+    pub id: SlotId,
+    pub device_path: String,
+    pub fs_type: FileSystemType,
+    pub current_version: String,
+    pub is_bootable: bool,
+}
+
+/// Information about a partition (for persistent data).
+#[derive(Debug, Clone)]
+pub struct PartitionInfo {
+    pub device_path: String,
+    pub fs_type: FileSystemType,
+    pub total_bytes: u64,
+    pub available_bytes: u64,
+}
+
+/// Slot layout describing the A/B configuration.
+#[derive(Debug, Clone)]
+pub struct SlotLayout {
+    pub primary: SlotInfo,
+    pub alternate: SlotInfo,
+    pub persistent_data: Option<PartitionInfo>,
+}
+
+/// Boot flags controlling the bootloader behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootFlag {
+    /// Attempt booting from the alternate slot.
+    TryBoot,
+    /// Confirm boot success; make the current slot permanent.
+    CommitSuccess,
+    /// Request fallback to the last successful slot.
+    FallbackRequested,
+}
+
+/// Slot management provider trait.
+#[async_trait::async_trait]
+pub trait SlotProvider: Send + Sync {
+    async fn detect_slots(&self) -> SlotResult<SlotLayout>;
+    async fn get_active_slot(&self) -> SlotResult<SlotId>;
+    async fn set_boot_flag(&self, flag: BootFlag) -> SlotResult<()>;
+    async fn swap_slots(&self) -> SlotResult<()>;
+}


### PR DESCRIPTION
Create vela-core workspace with 7 crates:
- vela-crypto: signing, hashing, key management
- vela-flashpack: FlashPack (.fpk) bundle format
- vela-attestation: device identity and session tokens
- vela-lifecycle: update state machine with metrics
- vela-slotmgr: A/B dual-slot partition management
- vela-pulse: health pulse reporting to Hub
- vela-ffi: C ABI exports for C# interop
- vela-core: top-level orchestration + logging init

Tech: Rust 1.85+, edition 2024, tracing, tokio, thiserror

Closes #181