### PR TITLE
feat(vela): Sub-Issue 7 — Velaris SDK C# managed wrapper

### DIFF
--- a/src/vela/Velaris.Sdk/Interop/NativeMethods.cs
+++ b/src/vela/Velaris.Sdk/Interop/NativeMethods.cs
@@ -1,0 +1,47 @@
+using System.Runtime.InteropServices;
+
+namespace Velaris.Sdk.Interop;
+
+/// <summary>
+/// P/Invoke declarations mapping to the Rust vela-ffi cdylib exports.
+/// All Rust handles are opaque <see cref="IntPtr"/> values wrapped by
+/// <see cref="SafeHandles.VelaSafeHandle"/> derivatives.
+/// </summary>
+internal static partial class NativeMethods
+{
+    private const string DllName = "vela_ffi";
+
+    // ─── error buffer ──────────────────────────────────────────
+
+    /// <summary>
+    /// Get the last Rust error message. Returns null if no error.
+    /// Caller must free with Marshal.FreeHGlobal.
+    /// </summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr vela_last_error();
+
+    /// <summary>Clear the Rust error buffer.</summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void vela_clear_error();
+
+    // ─── engine lifecycle ──────────────────────────────────────
+
+    /// <summary>Initialize the Vela engine. Returns handle or IntPtr.Zero.</summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr vela_init();
+
+    /// <summary>Shut down the engine. Returns 0 on success.</summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int vela_shutdown(IntPtr handle);
+
+    // ─── FlashPack operations ──────────────────────────────────
+
+    /// <summary>Open a FlashPack file. Returns handle or IntPtr.Zero.</summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl,
+        CharSet = CharSet.Ansi, BestFitMapping = false)]
+    internal static extern IntPtr vela_fpk_open(string path);
+
+    /// <summary>Close a FlashPack handle. Returns 0 on success.</summary>
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int vela_fpk_close(IntPtr handle);
+}

--- a/src/vela/Velaris.Sdk/SafeHandles/VelaSafeHandle.cs
+++ b/src/vela/Velaris.Sdk/SafeHandles/VelaSafeHandle.cs
@@ -1,0 +1,52 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Velaris.Sdk.SafeHandles;
+
+/// <summary>
+/// Base class for safe handles that wrap Rust opaque pointers.
+/// Guarantees cleanup even if finalization occurs.
+/// </summary>
+internal abstract class VelaSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    protected VelaSafeHandle(bool ownsHandle)
+        : base(ownsHandle)
+    {
+    }
+}
+
+/// <summary>
+/// Safe handle wrapping a FlashPack reader (vela_fpk_* functions).
+/// </summary>
+internal sealed class FlashPackSafeHandle : VelaSafeHandle
+{
+    public FlashPackSafeHandle(IntPtr handle, bool ownsHandle = true)
+        : base(ownsHandle)
+    {
+        SetHandle(handle);
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        if (IsInvalid) return true;
+        return Interop.NativeMethods.vela_fpk_close(handle) == 0;
+    }
+}
+
+/// <summary>
+/// Safe handle wrapping the Vela lifecycle engine (vela_init/vela_shutdown).
+/// </summary>
+internal sealed class EngineSafeHandle : VelaSafeHandle
+{
+    public EngineSafeHandle(IntPtr handle, bool ownsHandle = true)
+        : base(ownsHandle)
+    {
+        SetHandle(handle);
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        if (IsInvalid) return true;
+        return Interop.NativeMethods.vela_shutdown(handle) == 0;
+    }
+}

--- a/src/vela/Velaris.Sdk/VelaCore.cs
+++ b/src/vela/Velaris.Sdk/VelaCore.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.Logging;
+
+namespace Velaris.Sdk;
+
+/// <summary>
+/// High-level managed API for the Vela OTA engine.
+/// Wraps engine lifecycle (init/shutdown) and FlashPack operations
+/// with safe handles and structured logging.
+/// </summary>
+public sealed class VelaCore : IDisposable
+{
+    private readonly ILogger<VelaCore> _logger;
+    private readonly SafeHandles.EngineSafeHandle _engine;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initialize the Vela OTA engine.
+    /// </summary>
+    /// <param name="logger">Logger for structured telemetry.</param>
+    /// <exception cref="VelaException">Thrown if engine initialization fails.</exception>
+    public VelaCore(ILogger<VelaCore> logger)
+    {
+        _logger = logger;
+
+        Log.InitializingEngine(logger);
+        var handle = Interop.NativeMethods.vela_init();
+        VelaException.ThrowIfInvalid(handle, "vela_init");
+
+        _engine = new SafeHandles.EngineSafeHandle(handle);
+        Log.EngineInitialized(logger);
+    }
+
+    /// <summary>
+    /// Open a FlashPack file for reading and validation.
+    /// </summary>
+    /// <param name="path">Path to the .fpk file.</param>
+    /// <returns>A FlashPack reader handle.</returns>
+    /// <exception cref="VelaException">Thrown if the file cannot be opened.</exception>
+    public FlashPack OpenFlashPack(string path)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        Log.OpeningFlashPack(_logger, path);
+        var handle = Interop.NativeMethods.vela_fpk_open(path);
+        VelaException.ThrowIfInvalid(handle, $"vela_fpk_open({path})");
+
+        Log.FlashPackOpened(_logger, path);
+        return new FlashPack(new SafeHandles.FlashPackSafeHandle(handle), _logger);
+    }
+
+    /// <summary>
+    /// Try to open a FlashPack file, returning null on failure instead of throwing.
+    /// </summary>
+    public FlashPack? TryOpenFlashPack(string path)
+    {
+        try
+        {
+            return OpenFlashPack(path);
+        }
+        catch (VelaException ex)
+        {
+            Log.FlashPackOpenFailed(_logger, path, ex);
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        Log.ShuttingDownEngine(_logger);
+        _engine.Dispose();
+        Log.EngineShutdown(_logger);
+    }
+}
+
+/// <summary>
+/// Represents an opened FlashPack bundle.
+/// Provides operations for reading metadata and verifying integrity.
+/// </summary>
+public sealed class FlashPack : IDisposable
+{
+    private readonly SafeHandles.FlashPackSafeHandle _handle;
+    private readonly ILogger _logger;
+    private bool _disposed;
+
+    internal FlashPack(SafeHandles.FlashPackSafeHandle handle, ILogger logger)
+    {
+        _handle = handle;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Whether this FlashPack is still valid (handle not freed).
+    /// </summary>
+    public bool IsValid => !_handle.IsInvalid && !_disposed;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _handle.Dispose();
+        FlashPackLog.Closed(_logger);
+    }
+}
+
+// ─── high-performance logging source generators ────────────────
+
+internal static partial class Log
+{
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Information,
+        Message = "Initializing Vela OTA engine")]
+    public static partial void InitializingEngine(ILogger logger);
+
+    [LoggerMessage(EventId = 1002, Level = LogLevel.Information,
+        Message = "Vela OTA engine initialized successfully")]
+    public static partial void EngineInitialized(ILogger logger);
+
+    [LoggerMessage(EventId = 1003, Level = LogLevel.Information,
+        Message = "Shutting down Vela OTA engine")]
+    public static partial void ShuttingDownEngine(ILogger logger);
+
+    [LoggerMessage(EventId = 1004, Level = LogLevel.Information,
+        Message = "Vela OTA engine shut down")]
+    public static partial void EngineShutdown(ILogger logger);
+
+    [LoggerMessage(EventId = 1010, Level = LogLevel.Information,
+        Message = "Opening FlashPack: {Path}")]
+    public static partial void OpeningFlashPack(ILogger logger, string path);
+
+    [LoggerMessage(EventId = 1011, Level = LogLevel.Information,
+        Message = "FlashPack opened: {Path}")]
+    public static partial void FlashPackOpened(ILogger logger, string path);
+
+    [LoggerMessage(EventId = 1012, Level = LogLevel.Error,
+        Message = "Failed to open FlashPack: {Path}")]
+    public static partial void FlashPackOpenFailed(ILogger logger, string path, Exception ex);
+}
+
+internal static partial class FlashPackLog
+{
+    [LoggerMessage(EventId = 1020, Level = LogLevel.Information,
+        Message = "FlashPack handle closed")]
+    public static partial void Closed(ILogger logger);
+}

--- a/src/vela/Velaris.Sdk/VelaException.cs
+++ b/src/vela/Velaris.Sdk/VelaException.cs
@@ -1,0 +1,43 @@
+using System.Runtime.InteropServices;
+
+namespace Velaris.Sdk;
+
+/// <summary>
+/// Represents an error originating from the native Vela Rust engine.
+/// The message is retrieved from the Rust FFI <c>vela_last_error</c> buffer.
+/// </summary>
+public sealed class VelaException : Exception
+{
+    /// <summary>
+    /// Create a VelaException by fetching the last error from the native engine.
+    /// Clears the error buffer after reading.
+    /// </summary>
+    public static VelaException FromLastError(string operation)
+    {
+        var ptr = Interop.NativeMethods.vela_last_error();
+        var message = ptr != IntPtr.Zero
+            ? Marshal.PtrToStringUTF8(ptr) ?? "unknown error"
+            : "unknown error";
+
+        // Free the C string allocated by Rust
+        if (ptr != IntPtr.Zero) Marshal.FreeHGlobal(ptr);
+
+        // Clear the Rust error buffer
+        Interop.NativeMethods.vela_clear_error();
+
+        return new VelaException($"{operation}: {message}");
+    }
+
+    /// <summary>
+    /// Throw if the handle is invalid (native call returned null/zero).
+    /// Fetches the last Rust error as the exception message.
+    /// </summary>
+    internal static void ThrowIfInvalid(IntPtr handle, string operation)
+    {
+        if (handle == IntPtr.Zero)
+            throw FromLastError(operation);
+    }
+
+    public VelaException(string message) : base(message) { }
+    public VelaException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/vela/Velaris.Sdk/Velaris.Sdk.csproj
+++ b/src/vela/Velaris.Sdk/Velaris.Sdk.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Velaris.Sdk</RootNamespace>
+    <AssemblyName>Velaris.Sdk</AssemblyName>
+    <Description>Velaris SDK — managed C# wrapper for the Vela OTA Rust engine.</Description>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Create the Velaris SDK — a .NET 9 managed library wrapping the Rust vela-ffi native exports with safe handles and structured logging.

- Interop/NativeMethods.cs: P/Invoke declarations for vela_init, vela_shutdown, vela_fpk_open, vela_fpk_close, vela_last_error, vela_clear_error. All DllImport("vela_ffi") with Cdecl calling conv.
- SafeHandles/VelaSafeHandle.cs: SafeHandleZeroOrMinusOneIsInvalid base. FlashPackSafeHandle and EngineSafeHandle with proper ReleaseHandle overrides calling native close functions.
- VelaException.cs: Fetch and clear Rust error buffer via vela_last_error(). ThrowIfInvalid helper for null-handle checks.
- VelaCore.cs: High-level IDisposable API — VelaCore wraps engine init/shutdown with EngineSafeHandle. FlashPack wrapper for open/close. LoggerMessage source generators for structured telemetry (event IDs 1001-1020).
- Velaris.Sdk.csproj: net9.0, C# 13, Native AOT compatible, nullable enabled, ImplicitUsings.

Closes #193