### PR TITLE
[Vela OTA] Sub-Issue 17: NuGet packaging + CI/CD pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,72 @@
+name: .NET CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/vela/Velaris.Sdk/**'
+      - 'src/vela/Velaris.Sdk.Tests/**'
+      - '.github/workflows/dotnet.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/vela/Velaris.Sdk/**'
+      - 'src/vela/Velaris.Sdk.Tests/**'
+      - '.github/workflows/dotnet.yml'
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  build-test:
+    name: Build + Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore src/vela/Velaris.Sdk/Velaris.Sdk.csproj
+
+      - name: Build SDK
+        run: dotnet build src/vela/Velaris.Sdk/Velaris.Sdk.csproj --configuration Release --no-restore
+
+      - name: Build Tests
+        run: dotnet build src/vela/Velaris.Sdk.Tests/Velaris.Sdk.Tests.csproj --configuration Release
+
+      - name: Run Tests
+        run: dotnet test src/vela/Velaris.Sdk.Tests/Velaris.Sdk.Tests.csproj --configuration Release --no-build --verbosity normal
+
+  pack:
+    name: Pack NuGet
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Pack NuGet
+        run: dotnet pack src/vela/Velaris.Sdk/Velaris.Sdk.csproj --configuration Release --output ./artifacts
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          path: ./artifacts/*.nupkg

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,96 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/vela/vela-core/**'
+      - '.github/workflows/rust.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/vela/vela-core/**'
+      - '.github/workflows/rust.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check:
+    name: Check (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src/vela/vela-core/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check compilation
+        working-directory: src/vela/vela-core
+        run: cargo check --workspace --exclude vela-ffi
+
+  test:
+    name: Test (stable)
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('src/vela/vela-core/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        working-directory: src/vela/vela-core
+        run: cargo test --workspace --exclude vela-ffi
+
+  lint:
+    name: Clippy + Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('src/vela/vela-core/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        working-directory: src/vela/vela-core
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        working-directory: src/vela/vela-core
+        run: cargo clippy --workspace --exclude vela-ffi -- -D warnings


### PR DESCRIPTION
## Summary

Adds automated CI/CD pipelines for Vela OTA Rust and C# projects.

### Added

- **Rust CI** (.github/workflows/rust.yml) — check, test, clippy, fmt
- **.NET CI** (.github/workflows/dotnet.yml) — build + test (ubuntu/windows) + NuGet pack

### Preserved
- Existing NuGet publish workflow (dotnet-ci.yaml)

Closes #215