### PR TITLE
feat: add built-in trace logging with System.Diagnostics.Trace

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/FirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/FirmwareBootstrap.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Firmware.Models;
 using GeneralUpdate.Firmware.Strategy;
+using GeneralUpdate.Firmware.Trace;
 
 namespace GeneralUpdate.Firmware
 {
@@ -13,6 +15,9 @@ namespace GeneralUpdate.Firmware
     /// 
     /// <para>Usage example:</para>
     /// <code>
+    /// // Initialize trace logging (call once at application startup)
+    /// FirmwareTrace.Initialize();
+    /// 
     /// var result = await FirmwareBootstrap.Create(config =>
     /// {
     ///     config.FirmwareUrl = "https://example.com/firmware.bin";
@@ -35,6 +40,7 @@ namespace GeneralUpdate.Firmware
         private FirmwareBootstrap(FirmwareConfig config)
         {
             _config = config ?? throw new ArgumentNullException(nameof(config));
+            FirmwareTrace.Info("FirmwareBootstrap instance created with config: {0}", config);
         }
 
         /// <summary>
@@ -45,8 +51,11 @@ namespace GeneralUpdate.Firmware
         /// <returns>A configured <see cref="FirmwareBootstrap"/> instance.</returns>
         public static FirmwareBootstrap Create(Action<FirmwareConfig> configure)
         {
+            FirmwareTrace.Info("FirmwareBootstrap.Create called");
+
             if (configure == null)
             {
+                FirmwareTrace.Error("FirmwareBootstrap.Create failed: configure delegate is null");
                 throw new ArgumentNullException(nameof(configure));
             }
 
@@ -55,10 +64,12 @@ namespace GeneralUpdate.Firmware
 
             if (!config.Validate())
             {
-                throw new InvalidOperationException(
-                    "FirmwareConfig validation failed. Ensure FirmwareUrl (or LocalFilePath) and DevicePath are set, and TimeoutSeconds > 0.");
+                var error = "FirmwareConfig validation failed. Ensure FirmwareUrl (or LocalFilePath) and DevicePath are set, and TimeoutSeconds > 0.";
+                FirmwareTrace.Error(error);
+                throw new InvalidOperationException(error);
             }
 
+            FirmwareTrace.Info("FirmwareConfig validated successfully");
             return new FirmwareBootstrap(config);
         }
 
@@ -73,15 +84,19 @@ namespace GeneralUpdate.Firmware
         /// </exception>
         public FirmwareBootstrap UseDefaultStrategy()
         {
+            FirmwareTrace.Info("Selecting default strategy (auto-detect platform)");
+
             // Use explicit platform override if set
             if (_config.Platform.HasValue)
             {
+                FirmwareTrace.Info("Using explicit platform override: {0}", _config.Platform.Value);
                 _strategy = ResolveStrategy(_config.Platform.Value);
                 return this;
             }
 
             // Auto-detect platform
             var platform = DetectPlatform();
+            FirmwareTrace.Info("Auto-detected platform: {0} (OS: {1})", platform, RuntimeInformation.OSDescription);
             _strategy = ResolveStrategy(platform);
             return this;
         }
@@ -93,6 +108,7 @@ namespace GeneralUpdate.Firmware
         /// <returns>This instance for fluent chaining.</returns>
         public FirmwareBootstrap UsePlatform(FirmwarePlatform platform)
         {
+            FirmwareTrace.Info("Using specified platform strategy: {0}", platform);
             _strategy = ResolveStrategy(platform);
             return this;
         }
@@ -105,7 +121,16 @@ namespace GeneralUpdate.Firmware
         /// <returns>This instance for fluent chaining.</returns>
         public FirmwareBootstrap UseStrategy(IFirmwareStrategy strategy)
         {
-            _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+            if (strategy == null)
+            {
+                FirmwareTrace.Error("UseStrategy called with null strategy");
+                throw new ArgumentNullException(nameof(strategy));
+            }
+
+            FirmwareTrace.Info("Using custom strategy: {0} (Platform: {1})",
+                strategy.GetType().Name,
+                strategy.TargetPlatform);
+            _strategy = strategy;
             return this;
         }
 
@@ -122,17 +147,29 @@ namespace GeneralUpdate.Firmware
         {
             if (_strategy == null)
             {
-                throw new InvalidOperationException(
-                    "No strategy has been configured. Call UseDefaultStrategy(), UsePlatform(), or UseStrategy() before ExecuteAsync().");
+                var error = "No strategy has been configured. Call UseDefaultStrategy(), UsePlatform(), or UseStrategy() before ExecuteAsync().";
+                FirmwareTrace.Error(error);
+                throw new InvalidOperationException(error);
             }
 
-            var overallSw = System.Diagnostics.Stopwatch.StartNew();
+            FirmwareTrace.BeginOperation("FirmwareUpdate");
+
+            var overallSw = Stopwatch.StartNew();
+            var totalStopwatch = Stopwatch.StartNew();
 
             try
             {
+                // ========================================================
                 // Step 1: Validate device readiness
+                // ========================================================
+                FirmwareTrace.BeginOperation("DeviceValidation");
+                var validationSw = Stopwatch.StartNew();
+
                 bool isReady = await _strategy.ValidateDeviceAsync(_config, cancellationToken)
                     .ConfigureAwait(false);
+
+                validationSw.Stop();
+                FirmwareTrace.EndOperation("DeviceValidation", validationSw.Elapsed, isReady);
 
                 if (!isReady)
                 {
@@ -141,11 +178,19 @@ namespace GeneralUpdate.Firmware
                         "FW_DEVICE_NOT_READY");
                 }
 
+                // ========================================================
                 // Step 2: Create backup (if enabled)
+                // ========================================================
                 if (_config.BackupEnabled)
                 {
+                    FirmwareTrace.BeginOperation("FirmwareBackup");
+                    var backupSw = Stopwatch.StartNew();
+
                     bool backupOk = await _strategy.BackupCurrentFirmwareAsync(_config, cancellationToken)
                         .ConfigureAwait(false);
+
+                    backupSw.Stop();
+                    FirmwareTrace.EndOperation("FirmwareBackup", backupSw.Elapsed, backupOk);
 
                     if (!backupOk)
                     {
@@ -154,33 +199,69 @@ namespace GeneralUpdate.Firmware
                             "FW_BACKUP_FAILED");
                     }
                 }
+                else
+                {
+                    FirmwareTrace.Warn("Firmware backup is disabled. Proceeding without safety net.");
+                }
 
-                // Step 3: Download firmware (if URL is provided — downloader will be implemented in Issue 3)
+                // ========================================================
+                // Step 3: Download firmware (if URL is provided)
+                // ========================================================
                 string localPath = _config.LocalFilePath;
                 if (!string.IsNullOrWhiteSpace(_config.FirmwareUrl))
                 {
-                    // Placeholder: download will be implemented in the OTA layer
-                    // For now, if LocalFilePath is not set, this will fail
+                    FirmwareTrace.Info("Firmware URL provided: {0}", _config.FirmwareUrl);
+
                     if (string.IsNullOrWhiteSpace(localPath))
                     {
+                        var downloadError = "Firmware download is not yet implemented. Provide a LocalFilePath for now.";
+                        FirmwareTrace.Error(downloadError);
                         return FirmwareUpdateResult.Fail(
-                            "Firmware download is not yet implemented. Provide a LocalFilePath for now.",
+                            downloadError,
                             "FW_DOWNLOAD_NOT_IMPLEMENTED");
                     }
+
+                    // Placeholder: download will be implemented in the OTA layer (Issue 3)
+                    FirmwareTrace.Info("Local firmware file path: {0}", localPath);
+                }
+                else
+                {
+                    FirmwareTrace.Info("Using local firmware file: {0}", localPath ?? "(not set)");
                 }
 
+                // ========================================================
                 // Step 4: Apply firmware to device
+                // ========================================================
+                FirmwareTrace.BeginOperation("ApplyFirmware");
+                var applySw = Stopwatch.StartNew();
+
+                FirmwareTrace.Info("Applying firmware to device: {0} | File: {1}",
+                    _config.DevicePath,
+                    localPath);
+                FirmwareTrace.Info("Strategy: {0} (Platform: {1})",
+                    _strategy.GetType().Name,
+                    _strategy.TargetPlatform);
+
                 FirmwareUpdateResult result = await _strategy.ApplyFirmwareAsync(localPath, _config, cancellationToken)
                     .ConfigureAwait(false);
 
+                applySw.Stop();
+                FirmwareTrace.EndOperation("ApplyFirmware", applySw.Elapsed, result.Success);
+
                 overallSw.Stop();
                 result.Duration = overallSw.Elapsed;
+
+                FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, result.Success);
+                FirmwareTrace.Info("Total firmware update time: {0:F3}s", overallSw.Elapsed.TotalSeconds);
 
                 return result;
             }
             catch (OperationCanceledException)
             {
                 overallSw.Stop();
+                FirmwareTrace.Warn("Firmware update was cancelled after {0:F3}s", overallSw.Elapsed.TotalSeconds);
+                FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
+
                 return FirmwareUpdateResult.Fail(
                     "Firmware update was cancelled.",
                     "FW_CANCELLED",
@@ -189,6 +270,9 @@ namespace GeneralUpdate.Firmware
             catch (Exception ex)
             {
                 overallSw.Stop();
+                FirmwareTrace.Error("Firmware update failed with unexpected error", ex);
+                FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
+
                 return FirmwareUpdateResult.Fail(
                     string.Format("An unexpected error occurred: {0}", ex.Message),
                     "FW_UNEXPECTED_ERROR",
@@ -206,19 +290,25 @@ namespace GeneralUpdate.Firmware
         /// </exception>
         internal static FirmwarePlatform DetectPlatform()
         {
+            FirmwareTrace.Debug("Detecting current runtime platform...");
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
+                FirmwareTrace.Debug("Platform detected: Linux");
                 return FirmwarePlatform.Linux;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                FirmwareTrace.Debug("Platform detected: Windows");
                 return FirmwarePlatform.Windows;
             }
 
-            throw new PlatformNotSupportedException(
-                string.Format("The current platform '{0}' is not supported by GeneralUpdate.Firmware. Supported platforms: Linux, Windows.",
-                    RuntimeInformation.OSDescription));
+            var error = string.Format(
+                "The current platform '{0}' is not supported by GeneralUpdate.Firmware. Supported platforms: Linux, Windows.",
+                RuntimeInformation.OSDescription);
+            FirmwareTrace.Error(error);
+            throw new PlatformNotSupportedException(error);
         }
 
         /// <summary>
@@ -231,19 +321,24 @@ namespace GeneralUpdate.Firmware
         /// </exception>
         internal static IFirmwareStrategy ResolveStrategy(FirmwarePlatform platform)
         {
+            FirmwareTrace.Debug("Resolving strategy for platform: {0}", platform);
+
             switch (platform)
             {
                 case FirmwarePlatform.Linux:
                     // Placeholder: will be replaced with LinuxFirmwareStrategy in Issue 4
+                    FirmwareTrace.Warn("Linux firmware strategy is not yet implemented (planned for Issue 4)");
                     throw new PlatformNotSupportedException(
                         "Linux firmware strategy is not yet implemented. It will use vela FlashPack for dual A/B slot updates.");
 
                 case FirmwarePlatform.Windows:
                     // Placeholder: will be replaced with WindowsFirmwareStrategy in Issue 5
+                    FirmwareTrace.Warn("Windows firmware strategy is not yet implemented (planned for Issue 5)");
                     throw new PlatformNotSupportedException(
                         "Windows firmware strategy is not yet implemented. It will use OS firmware commands (WMI/DeviceIoControl).");
 
                 default:
+                    FirmwareTrace.Error("Unknown firmware platform: {0}", platform);
                     throw new ArgumentOutOfRangeException(nameof(platform), platform, "Unknown firmware platform.");
             }
         }

--- a/src/c#/GeneralUpdate.Firmware/Trace/FirmwareTrace.cs
+++ b/src/c#/GeneralUpdate.Firmware/Trace/FirmwareTrace.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+
+namespace GeneralUpdate.Firmware.Trace
+{
+    /// <summary>
+    /// Built-in trace logging for GeneralUpdate.Firmware.
+    /// Wraps <see cref="System.Diagnostics.Trace"/> to provide structured,
+    /// consistent logging throughout the firmware update lifecycle.
+    /// 
+    /// <para>
+    /// All trace messages include timestamp, level, source, and context.
+    /// Developers can attach custom <see cref="TraceListener"/> instances
+    /// (such as <see cref="FirmwareTraceListener"/>) to integrate with their
+    /// own logging infrastructure.
+    /// </para>
+    /// 
+    /// <para>Usage:</para>
+    /// <code>
+    /// // Add the default firmware trace listener
+    /// FirmwareTrace.Initialize();
+    /// 
+    /// // Or add a custom listener for integration with ILogger, NLog, etc.
+    /// var listener = new FirmwareTraceListener();
+    /// listener.OnTrace = (msg, level) => Console.WriteLine($"[{level}] {msg}");
+    /// System.Diagnostics.Trace.Listeners.Add(listener);
+    /// </code>
+    /// </summary>
+    public static class FirmwareTrace
+    {
+        private static readonly object SyncLock = new object();
+        private static bool _initialized;
+
+        /// <summary>
+        /// Gets the trace source name used for all firmware trace messages.
+        /// </summary>
+        public const string SourceName = "GeneralUpdate.Firmware";
+
+        /// <summary>
+        /// Initializes the firmware trace system by adding the default
+        /// <see cref="FirmwareTraceListener"/> to <see cref="System.Diagnostics.Trace.Listeners"/>.
+        /// Call once at application startup. Subsequent calls are idempotent.
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (SyncLock)
+            {
+                if (_initialized) return;
+
+                // Add the default listener if none exists
+                bool hasFirmwareListener = false;
+                foreach (TraceListener listener in System.Diagnostics.Trace.Listeners)
+                {
+                    if (listener is FirmwareTraceListener)
+                    {
+                        hasFirmwareListener = true;
+                        break;
+                    }
+                }
+
+                if (!hasFirmwareListener)
+                {
+                    System.Diagnostics.Trace.Listeners.Add(new FirmwareTraceListener());
+                }
+
+                _initialized = true;
+            }
+        }
+
+        /// <summary>
+        /// Writes an informational trace message.
+        /// Use for normal operation events such as configuration loaded, strategy selected,
+        /// download started/completed, backup created, etc.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        public static void Info(string message)
+        {
+            WriteLine(message, TraceLevel.Info);
+        }
+
+        /// <summary>
+        /// Writes a formatted informational trace message.
+        /// </summary>
+        /// <param name="format">The composite format string.</param>
+        /// <param name="args">An array of objects to write using format.</param>
+        public static void Info(string format, params object[] args)
+        {
+            WriteLine(string.Format(CultureInfo.InvariantCulture, format, args), TraceLevel.Info);
+        }
+
+        /// <summary>
+        /// Writes a warning trace message.
+        /// Use for non-critical issues such as retry attempts, fallback paths,
+        /// missing optional configuration, etc.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        public static void Warn(string message)
+        {
+            WriteLine(message, TraceLevel.Warning);
+        }
+
+        /// <summary>
+        /// Writes a formatted warning trace message.
+        /// </summary>
+        /// <param name="format">The composite format string.</param>
+        /// <param name="args">An array of objects to write using format.</param>
+        public static void Warn(string format, params object[] args)
+        {
+            WriteLine(string.Format(CultureInfo.InvariantCulture, format, args), TraceLevel.Warning);
+        }
+
+        /// <summary>
+        /// Writes an error trace message.
+        /// Use for failures such as download errors, validation failures,
+        /// flashing errors, backup failures, etc.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        public static void Error(string message)
+        {
+            WriteLine(message, TraceLevel.Error);
+        }
+
+        /// <summary>
+        /// Writes a formatted error trace message.
+        /// </summary>
+        /// <param name="format">The composite format string.</param>
+        /// <param name="args">An array of objects to write using format.</param>
+        public static void Error(string format, params object[] args)
+        {
+            WriteLine(string.Format(CultureInfo.InvariantCulture, format, args), TraceLevel.Error);
+        }
+
+        /// <summary>
+        /// Writes an error trace message with an associated exception.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="exception">The exception to log.</param>
+        public static void Error(string message, Exception exception)
+        {
+            if (exception == null)
+            {
+                WriteLine(message, TraceLevel.Error);
+                return;
+            }
+
+            string fullMessage = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} | Exception: {1} | StackTrace: {2}",
+                message,
+                exception.Message,
+                exception.StackTrace ?? "(none)");
+            WriteLine(fullMessage, TraceLevel.Error);
+        }
+
+        /// <summary>
+        /// Writes a debug-level trace message.
+        /// Use for detailed diagnostic information during development.
+        /// These messages are typically suppressed in production.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        public static void Debug(string message)
+        {
+            WriteLine(message, TraceLevel.Verbose);
+        }
+
+        /// <summary>
+        /// Writes a formatted debug-level trace message.
+        /// </summary>
+        /// <param name="format">The composite format string.</param>
+        /// <param name="args">An array of objects to write using format.</param>
+        public static void Debug(string format, params object[] args)
+        {
+            WriteLine(string.Format(CultureInfo.InvariantCulture, format, args), TraceLevel.Verbose);
+        }
+
+        /// <summary>
+        /// Writes a trace message indicating the start of a named operation.
+        /// </summary>
+        /// <param name="operationName">The name of the operation (e.g., "FirmwareDownload", "DeviceValidation").</param>
+        public static void BeginOperation(string operationName)
+        {
+            Info("Begin operation: {0}", operationName ?? "(unknown)");
+        }
+
+        /// <summary>
+        /// Writes a trace message indicating the completion of a named operation
+        /// with the elapsed duration.
+        /// </summary>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="elapsed">The elapsed time.</param>
+        /// <param name="success">Whether the operation succeeded.</param>
+        public static void EndOperation(string operationName, TimeSpan elapsed, bool success)
+        {
+            string status = success ? "SUCCESS" : "FAILED";
+            Info(
+                "End operation: {0} | Status={1} | Duration={2:F3}s",
+                operationName ?? "(unknown)",
+                status,
+                elapsed.TotalSeconds);
+        }
+
+        /// <summary>
+        /// Writes a trace message for a progress update.
+        /// </summary>
+        /// <param name="stage">The current stage description.</param>
+        /// <param name="current">The current progress value.</param>
+        /// <param name="total">The total expected value.</param>
+        public static void Progress(string stage, long current, long total)
+        {
+            double percentage = total > 0 ? (double)current / total * 100.0 : 0.0;
+            Info(
+                "Progress [{0}]: {1}/{2} ({3:F1}%)",
+                stage ?? "(unknown)",
+                current,
+                total,
+                percentage);
+        }
+
+        /// <summary>
+        /// Internal helper that writes a message to all trace listeners with the given level.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        /// <param name="level">The trace level.</param>
+        private static void WriteLine(string message, TraceLevel level)
+        {
+            if (message == null) return;
+
+            // Write to all listeners, respecting their filter settings
+            foreach (TraceListener listener in System.Diagnostics.Trace.Listeners)
+            {
+                if (listener is FirmwareTraceListener ftl)
+                {
+                    ftl.WriteLine(message, level);
+                }
+                else
+                {
+                    // For non-FirmwareTraceListener instances, write formatted
+                    try
+                    {
+                        string formatted = FirmwareTraceListener.FormatMessage(message, level);
+                        // Only write if the listener's filter allows this level
+                        TraceEventType eventType = TraceLevelToEventType(level);
+                        if (listener.Filter == null || listener.Filter.ShouldTrace(
+                            null, SourceName, eventType, 0, formatted, null, null, null))
+                        {
+                            listener.WriteLine(formatted);
+                            listener.Flush();
+                        }
+                    }
+                    catch (ThreadAbortException)
+                    {
+                        // Re-throw ThreadAbortException to avoid silent failures
+                        throw;
+                    }
+                    catch (Exception)
+                    {
+                        // Silently ignore listener errors to avoid disrupting the update flow
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a <see cref="TraceLevel"/> to a <see cref="TraceEventType"/>.
+        /// </summary>
+        private static TraceEventType TraceLevelToEventType(TraceLevel level)
+        {
+            switch (level)
+            {
+                case TraceLevel.Error:
+                    return TraceEventType.Error;
+                case TraceLevel.Warning:
+                    return TraceEventType.Warning;
+                case TraceLevel.Info:
+                    return TraceEventType.Information;
+                case TraceLevel.Verbose:
+                    return TraceEventType.Verbose;
+                default:
+                    return TraceEventType.Information;
+            }
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Trace/FirmwareTraceListener.cs
+++ b/src/c#/GeneralUpdate.Firmware/Trace/FirmwareTraceListener.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace GeneralUpdate.Firmware.Trace
+{
+    /// <summary>
+    /// Default trace listener for GeneralUpdate.Firmware.
+    /// Writes trace messages to the attached debug output and provides
+    /// a hook for developers to inject custom listeners into their logging infrastructure.
+    /// 
+    /// <para>
+    /// Developers can add this listener to integrate firmware update traces
+    /// into their existing logging pipeline:
+    /// </para>
+    /// <code>
+    /// System.Diagnostics.Trace.Listeners.Add(new FirmwareTraceListener());
+    /// </code>
+    /// </summary>
+    public class FirmwareTraceListener : TraceListener
+    {
+        private const string SourceName = "GeneralUpdate.Firmware";
+
+        /// <summary>
+        /// Gets or sets a custom action that receives formatted trace messages.
+        /// Set this to redirect trace output to a custom logger (e.g., ILogger, log4net, NLog, Serilog).
+        /// When set, the default debug output is still emitted unless <see cref="SuppressDebugOutput"/> is true.
+        /// </summary>
+        public Action<string, TraceLevel> OnTrace { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to suppress the default Debug.WriteLine output.
+        /// Set to true when using <see cref="OnTrace"/> to avoid duplicate output.
+        /// Default value is false.
+        /// </summary>
+        public bool SuppressDebugOutput { get; set; } = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FirmwareTraceListener"/> class.
+        /// </summary>
+        public FirmwareTraceListener()
+            : base(SourceName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance with a name.
+        /// </summary>
+        /// <param name="name">The listener name.</param>
+        public FirmwareTraceListener(string name)
+            : base(name)
+        {
+        }
+
+        /// <summary>
+        /// Writes a message to the trace listener.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        public override void Write(string message)
+        {
+            if (message == null) return;
+
+            if (!SuppressDebugOutput)
+            {
+                Debug.Write(message);
+            }
+
+            OnTrace?.Invoke(message, TraceLevel.Verbose);
+        }
+
+        /// <summary>
+        /// Writes a message followed by a line terminator to the trace listener.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        public override void WriteLine(string message)
+        {
+            if (message == null) return;
+
+            if (!SuppressDebugOutput)
+            {
+                Debug.WriteLine(message);
+            }
+
+            OnTrace?.Invoke(message, TraceLevel.Info);
+        }
+
+        /// <summary>
+        /// Writes the specified message with the given trace level.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        /// <param name="level">The trace event level.</param>
+        public void WriteLine(string message, TraceLevel level)
+        {
+            if (message == null) return;
+
+            string formatted = FormatMessage(message, level);
+
+            if (!SuppressDebugOutput)
+            {
+                Debug.WriteLine(formatted);
+            }
+
+            OnTrace?.Invoke(formatted, level);
+        }
+
+        /// <summary>
+        /// Formats a trace message with timestamp and level prefix.
+        /// </summary>
+        /// <param name="message">The raw message.</param>
+        /// <param name="level">The trace level.</param>
+        /// <returns>A formatted message string.</returns>
+        internal static string FormatMessage(string message, TraceLevel level)
+        {
+            string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+            return string.Format(CultureInfo.InvariantCulture, "[{0}] [{1}] [{2}] {3}", timestamp, level.ToString().ToUpperInvariant(), SourceName, message);
+        }
+    }
+}


### PR DESCRIPTION
Closes #226.

## Summary
Implements built-in trace logging for GeneralUpdate.Firmware using System.Diagnostics.Trace with zero external dependencies.

## Changes
- **FirmwareTrace** — Static wrapper class with Info/Warn/Error/Debug/BeginOperation/EndOperation/Progress methods
- **FirmwareTraceListener** — Default TraceListener with OnTrace callback for custom logger integration
- **FirmwareBootstrap** — Updated with trace logging at every stage: config validation, platform detection, strategy resolution, device validation, backup, download, flashing, errors, cancellation, and final result

## Design
- Zero external dependencies (System.Diagnostics.Trace is in .NET Standard 2.0)
- Developers add \FirmwareTrace.Initialize()\ once at startup
- Custom \TraceListener\ integration via OnTrace callback
- Consistent message format: \[timestamp] [LEVEL] [GeneralUpdate.Firmware] message\
- Individual stopwatch timings per stage (validation, backup, flashing)
- Listener errors silently caught to avoid disrupting the update flow