### PR TITLE
feat: implement OTA firmware download and validation

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/FirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/FirmwareBootstrap.cs
@@ -155,7 +155,6 @@ namespace GeneralUpdate.Firmware
             FirmwareTrace.BeginOperation("FirmwareUpdate");
 
             var overallSw = Stopwatch.StartNew();
-            var totalStopwatch = Stopwatch.StartNew();
 
             try
             {
@@ -212,21 +211,53 @@ namespace GeneralUpdate.Firmware
                 {
                     FirmwareTrace.Info("Firmware URL provided: {0}", _config.FirmwareUrl);
 
+                    // If no local path specified, generate one in temp directory
                     if (string.IsNullOrWhiteSpace(localPath))
                     {
-                        var downloadError = "Firmware download is not yet implemented. Provide a LocalFilePath for now.";
-                        FirmwareTrace.Error(downloadError);
-                        return FirmwareUpdateResult.Fail(
-                            downloadError,
-                            "FW_DOWNLOAD_NOT_IMPLEMENTED");
+                        string tempDir = System.IO.Path.GetTempPath();
+                        string fileName = string.Format(
+                            "firmware_{0}.bin",
+                            Guid.NewGuid().ToString("N"));
+                        localPath = System.IO.Path.Combine(tempDir, fileName);
+                        FirmwareTrace.Info("No LocalFilePath specified; using temp path: {0}", localPath);
                     }
 
-                    // Placeholder: download will be implemented in the OTA layer (Issue 3)
-                    FirmwareTrace.Info("Local firmware file path: {0}", localPath);
+                    // Download the firmware
+                    var downloader = new OTA.FirmwareDownloader(_config);
+                    try
+                    {
+                        localPath = await downloader.DownloadAsync(localPath, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch (Exception downloadEx)
+                    {
+                        FirmwareTrace.Error("Firmware download failed", downloadEx);
+                        return FirmwareUpdateResult.Fail(
+                            string.Format("Firmware download failed: {0}", downloadEx.Message),
+                            "FW_DOWNLOAD_FAILED",
+                            downloadEx);
+                    }
+
+                    // Set the resolved local path back to config for downstream use
+                    _config.LocalFilePath = localPath;
                 }
                 else
                 {
                     FirmwareTrace.Info("Using local firmware file: {0}", localPath ?? "(not set)");
+                }
+
+                // ========================================================
+                // Step 3.5: Validate firmware integrity
+                // ========================================================
+                var validator = new OTA.FirmwareValidator(_config);
+                bool isValid = await validator.ValidateAsync(localPath, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (!isValid)
+                {
+                    return FirmwareUpdateResult.Fail(
+                        "Firmware validation failed. The downloaded file does not match the expected SHA256 hash.",
+                        "FW_VALIDATION_FAILED");
                 }
 
                 // ========================================================

--- a/src/c#/GeneralUpdate.Firmware/OTA/FirmwareDownloader.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/FirmwareDownloader.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.OTA
+{
+    /// <summary>
+    /// Handles over-the-air firmware file download with progress reporting,
+    /// automatic retry, and configurable timeout.
+    /// 
+    /// <para>
+    /// The downloader reads the firmware binary in configurable chunks,
+    /// reports progress via <see cref="FirmwareConfig.ProgressCallback"/>,
+    /// and retries transient failures according to the configuration.
+    /// </para>
+    /// </summary>
+    public class FirmwareDownloader
+    {
+        /// <summary>
+        /// Default buffer size for download chunks: 8192 bytes (8 KB).
+        /// </summary>
+        public const int DefaultBufferSize = 8192;
+
+        private readonly FirmwareConfig _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FirmwareDownloader"/> class.
+        /// </summary>
+        /// <param name="config">The firmware update configuration.</param>
+        public FirmwareDownloader(FirmwareConfig config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        /// <summary>
+        /// Downloads the firmware file from the configured URL to the specified local path.
+        /// Supports automatic retry on transient failures and progress reporting.
+        /// </summary>
+        /// <param name="localFilePath">
+        /// The full local path where the downloaded file will be saved.
+        /// Parent directories are created automatically if they do not exist.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>The full path to the downloaded file.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the firmware URL is not configured.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        /// Thrown when the operation is cancelled or times out.
+        /// </exception>
+        /// <exception cref="WebException">
+        /// Thrown when the download fails after all retry attempts.
+        /// </exception>
+        public async Task<string> DownloadAsync(string localFilePath, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(_config.FirmwareUrl))
+            {
+                throw new InvalidOperationException(
+                    "Firmware URL is not configured. Set FirmwareConfig.FirmwareUrl before downloading.");
+            }
+
+            FirmwareTrace.BeginOperation("FirmwareDownload");
+            FirmwareTrace.Info("Download URL: {0}", _config.FirmwareUrl);
+            FirmwareTrace.Info("Target path: {0}", localFilePath);
+
+            // Ensure target directory exists
+            string directory = Path.GetDirectoryName(localFilePath);
+            if (!string.IsNullOrEmpty(directory) && !System.IO.Directory.Exists(directory))
+            {
+                System.IO.Directory.CreateDirectory(directory);
+                FirmwareTrace.Debug("Created download directory: {0}", directory);
+            }
+
+            // Create combined timeout token
+            using (var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_config.TimeoutSeconds)))
+            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token))
+            {
+                int attempt = 0;
+                Exception lastException = null;
+                var combinedToken = linkedCts.Token;
+
+                while (attempt < _config.RetryCount)
+                {
+                    attempt++;
+                    combinedToken.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        FirmwareTrace.Info("Download attempt {0}/{1}", attempt, _config.RetryCount);
+
+                        await DownloadWithProgressAsync(localFilePath, combinedToken)
+                            .ConfigureAwait(false);
+
+                        FirmwareTrace.EndOperation("FirmwareDownload", TimeSpan.Zero, true);
+                        FirmwareTrace.Info("Download completed successfully: {0}", localFilePath);
+                        return localFilePath;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        FirmwareTrace.Warn("Download cancelled on attempt {0}", attempt);
+                        throw;
+                    }
+                    catch (WebException wex)
+                    {
+                        lastException = wex;
+                        FirmwareTrace.Error(
+                            "Download attempt {0}/{1} failed (WebException): {2}",
+                            attempt,
+                            _config.RetryCount,
+                            wex.Message);
+
+                        if (attempt < _config.RetryCount)
+                        {
+                            FirmwareTrace.Warn(
+                                "Retrying in {0} seconds...",
+                                _config.RetryDelaySeconds);
+                            await Task.Delay(_config.RetryDelaySeconds * 1000, combinedToken)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        lastException = ex;
+                        FirmwareTrace.Error(
+                            "Download attempt {0}/{1} failed: {2}",
+                            attempt,
+                            _config.RetryCount,
+                            ex.Message);
+
+                        if (attempt < _config.RetryCount)
+                        {
+                            FirmwareTrace.Warn(
+                                "Retrying in {0} seconds...",
+                                _config.RetryDelaySeconds);
+                            await Task.Delay(_config.RetryDelaySeconds * 1000, combinedToken)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                }
+
+                // All retries exhausted
+                FirmwareTrace.EndOperation("FirmwareDownload", TimeSpan.Zero, false);
+                string errorMessage = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Firmware download failed after {0} attempts. Last error: {1}",
+                    _config.RetryCount,
+                    lastException?.Message ?? "Unknown error");
+                FirmwareTrace.Error(errorMessage);
+                throw new WebException(errorMessage, lastException);
+            }
+        }
+
+        /// <summary>
+        /// Performs a single download attempt with progress reporting.
+        /// Uses <see cref="HttpWebRequest"/> for broad .NET Standard 2.0 compatibility.
+        /// </summary>
+        /// <param name="localFilePath">Where to save the downloaded file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        private async Task DownloadWithProgressAsync(string localFilePath, CancellationToken cancellationToken)
+        {
+            var request = WebRequest.CreateHttp(_config.FirmwareUrl);
+            request.Method = "GET";
+
+            // Configure timeout
+            int timeoutMs = _config.TimeoutSeconds * 1000;
+            request.Timeout = timeoutMs;
+            request.ReadWriteTimeout = timeoutMs;
+
+            using (cancellationToken.Register(() => request.Abort()))
+            {
+                using (var response = await request.GetResponseAsync().ConfigureAwait(false) as HttpWebResponse)
+                {
+                    if (response == null)
+                    {
+                        throw new WebException("Failed to get HTTP response from firmware URL.");
+                    }
+
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        throw new WebException(
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Firmware download returned HTTP {0} ({1}).",
+                                (int)response.StatusCode,
+                                response.StatusDescription));
+                    }
+
+                    long contentLength = response.ContentLength;
+                    long totalBytesRead = 0;
+
+                    FirmwareTrace.Info("Download started. Content length: {0} bytes", contentLength);
+
+                    using (var responseStream = response.GetResponseStream())
+                    using (var fileStream = new FileStream(
+                        localFilePath,
+                        FileMode.Create,
+                        FileAccess.Write,
+                        FileShare.None,
+                        DefaultBufferSize,
+                        useAsync: true))
+                    {
+                        byte[] buffer = new byte[DefaultBufferSize];
+                        int bytesRead;
+                        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                        long lastReportedBytes = 0;
+
+                        while ((bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
+                            .ConfigureAwait(false)) > 0)
+                        {
+                            await fileStream.WriteAsync(buffer, 0, bytesRead, cancellationToken)
+                                .ConfigureAwait(false);
+
+                            totalBytesRead += bytesRead;
+
+                            // Report progress at reasonable intervals (every 100KB or when complete)
+                            if (totalBytesRead - lastReportedBytes >= 102400 ||
+                                totalBytesRead == contentLength ||
+                                contentLength <= 0)
+                            {
+                                FirmwareTrace.Progress("Download", totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead);
+
+                                // Invoke user-provided progress callback
+                                if (_config.ProgressCallback != null)
+                                {
+                                    try
+                                    {
+                                        _config.ProgressCallback(totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
+                                    }
+                                }
+
+                                lastReportedBytes = totalBytesRead;
+                            }
+
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+
+                        stopwatch.Stop();
+
+                        if (contentLength > 0 && totalBytesRead != contentLength)
+                        {
+                            throw new WebException(
+                                string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    "Download incomplete: received {0} of {1} bytes.",
+                                    totalBytesRead,
+                                    contentLength));
+                        }
+
+                        double speedKBps = stopwatch.Elapsed.TotalSeconds > 0
+                            ? (totalBytesRead / 1024.0) / stopwatch.Elapsed.TotalSeconds
+                            : 0;
+
+                        FirmwareTrace.Info(
+                            "Download finished. Total: {0} bytes, Duration: {1:F1}s, Speed: {2:F1} KB/s",
+                            totalBytesRead,
+                            stopwatch.Elapsed.TotalSeconds,
+                            speedKBps);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/FirmwareValidator.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/FirmwareValidator.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.OTA
+{
+    /// <summary>
+    /// Validates firmware file integrity using SHA256 hash comparison.
+    /// Ensures the downloaded firmware binary matches the expected hash
+    /// before it is applied to the target device.
+    /// 
+    /// <para>
+    /// Validation is skipped when <see cref="FirmwareConfig.ExpectedSha256"/>
+    /// is null or empty.
+    /// </para>
+    /// </summary>
+    public class FirmwareValidator
+    {
+        private readonly FirmwareConfig _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FirmwareValidator"/> class.
+        /// </summary>
+        /// <param name="config">The firmware update configuration.</param>
+        public FirmwareValidator(FirmwareConfig config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        /// <summary>
+        /// Validates the firmware file at the given path against the expected hash.
+        /// If no expected hash is configured, validation is skipped and returns true.
+        /// </summary>
+        /// <param name="firmwareFilePath">The full path to the firmware file to validate.</param>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
+        /// <returns>
+        /// True if the firmware is valid (hash matches or validation is skipped);
+        /// false if the hash does not match.
+        /// </returns>
+        /// <exception cref="FileNotFoundException">
+        /// Thrown when the firmware file does not exist.
+        /// </exception>
+        public Task<bool> ValidateAsync(string firmwareFilePath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Validate(firmwareFilePath));
+        }
+
+        /// <summary>
+        /// Synchronously computes the SHA256 hash of the firmware file and compares
+        /// it against the expected value.
+        /// </summary>
+        /// <param name="firmwareFilePath">The full path to the firmware file.</param>
+        /// <returns>True if the hash matches or validation is skipped; false otherwise.</returns>
+        private bool Validate(string firmwareFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(_config.ExpectedSha256))
+            {
+                FirmwareTrace.Warn("No expected SHA256 hash configured — skipping firmware validation.");
+                return true;
+            }
+
+            FirmwareTrace.BeginOperation("FirmwareValidation");
+            FirmwareTrace.Info("Validating firmware file: {0}", firmwareFilePath);
+
+            if (!File.Exists(firmwareFilePath))
+            {
+                FirmwareTrace.Error("Firmware file not found at path: {0}", firmwareFilePath);
+                throw new FileNotFoundException(
+                    string.Format(CultureInfo.InvariantCulture, "Firmware file not found: {0}", firmwareFilePath),
+                    firmwareFilePath);
+            }
+
+            try
+            {
+                string computedHash;
+
+                using (var stream = new FileStream(firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var sha256 = SHA256.Create())
+                {
+                    byte[] hashBytes = sha256.ComputeHash(stream);
+                    computedHash = BitConverter.ToString(hashBytes).Replace("-", string.Empty);
+                }
+
+                bool isValid = string.Equals(
+                    computedHash,
+                    _config.ExpectedSha256,
+                    StringComparison.OrdinalIgnoreCase);
+
+                if (isValid)
+                {
+                    FirmwareTrace.Info("Firmware validation PASSED. Hash: {0}", computedHash);
+                    FirmwareTrace.EndOperation("FirmwareValidation", TimeSpan.Zero, true);
+                }
+                else
+                {
+                    FirmwareTrace.Error(
+                        "Firmware validation FAILED. Expected: {0}, Actual: {1}",
+                        _config.ExpectedSha256,
+                        computedHash);
+                    FirmwareTrace.EndOperation("FirmwareValidation", TimeSpan.Zero, false);
+                }
+
+                return isValid;
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Error("Firmware validation encountered an error", ex);
+                FirmwareTrace.EndOperation("FirmwareValidation", TimeSpan.Zero, false);
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #228.

## Summary
Implements over-the-air firmware download with progress reporting, automatic retry, and integrity validation for GeneralUpdate.Firmware.

## Changes
- **FirmwareDownloader** — Async download via HttpWebRequest with:
  - Chunked reading (8KB buffer) with progress reporting every 100KB
  - Automatic retry using FirmwareConfig.RetryCount and RetryDelaySeconds
  - Timeout via CancellationTokenSource linked to FirmwareConfig.TimeoutSeconds
  - Progress callback invocation (FirmwareConfig.ProgressCallback)
  - Auto-creation of target directories
  - Download speed calculation (KB/s)
- **FirmwareValidator** — SHA256 hash validation:
  - Computes SHA256 of the firmware file using SHA256.Create()
  - Compares against FirmwareConfig.ExpectedSha256 (case-insensitive)
  - Skips validation when ExpectedSha256 is null/empty
- **FirmwareBootstrap** — Updated ExecuteAsync():
  - Auto-generates temp file path when LocalFilePath not specified
  - Wires FirmwareDownloader for URL-based firmware acquisition
  - Wires FirmwareValidator between download and flashing
  - New error codes: FW_DOWNLOAD_FAILED, FW_VALIDATION_FAILED

## Design
- Zero additional NuGet dependencies (HttpWebRequest, SHA256 all in netstandard2.0)
- Full trace logging for all download and validation stages
- Progress callbacks wrapped in try/catch to avoid disrupting the update flow