### PR TITLE
feat: add connection abstraction and firmware format models

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/Models/ConnectionType.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/ConnectionType.cs
@@ -1,0 +1,47 @@
+namespace GeneralUpdate.Firmware.Models
+{
+    /// <summary>
+    /// Enumerates the hardware connection types for firmware update.
+    /// Determines which physical transport channel is used to communicate
+    /// with the target device.
+    /// </summary>
+    public enum ConnectionType
+    {
+        /// <summary>
+        /// Local block device (eMMC, SD card, SATA, NVMe).
+        /// Uses FileStream for raw sector read/write.
+        /// </summary>
+        BlockDevice,
+
+        /// <summary>
+        /// Serial port (UART/RS232) with XMODEM/YMODEM protocol.
+        /// Common in MCU bootloaders (STM32, ESP32, AVR).
+        /// </summary>
+        Serial,
+
+        /// <summary>
+        /// USB Device Firmware Upgrade (DFU).
+        /// Uses libusb on Linux, WinUSB on Windows.
+        /// Common in STM32 DFU, RP2040, ATmega16U2.
+        /// </summary>
+        UsbDfu,
+
+        /// <summary>
+        /// Network-based firmware transfer via TFTP or TCP.
+        /// Used for network boot scenarios (U-Boot, OpenWrt, PXE).
+        /// </summary>
+        Network,
+
+        /// <summary>
+        /// UEFI firmware capsule update.
+        /// Windows-only: uses DeviceIoControl with FSCTL_SET_FIRMWARE_RESOURCE.
+        /// </summary>
+        Uefi,
+
+        /// <summary>
+        /// JTAG/SWD debug interface via OpenOCD or similar debug probe.
+        /// Used for bare-metal flashing on development boards.
+        /// </summary>
+        Jtag
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Models/DeviceConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/DeviceConnection.cs
@@ -1,0 +1,180 @@
+using System;
+
+namespace GeneralUpdate.Firmware.Models
+{
+    /// <summary>
+    /// Describes how to connect to the target hardware device for firmware update.
+    /// Aggregates all connection parameters in one place.
+    /// 
+    /// <para>
+    /// Different connection types require different subsets of parameters.
+    /// Only the parameters relevant to the selected <see cref="ConnectionType"/> are used.
+    /// </para>
+    /// </summary>
+    public class DeviceConnection
+    {
+        /// <summary>
+        /// Gets or sets the hardware connection type.
+        /// Default is <see cref="ConnectionType.BlockDevice"/> for direct block device I/O.
+        /// </summary>
+        public ConnectionType Type { get; set; } = ConnectionType.BlockDevice;
+
+        // ── BlockDevice ──────────────────────────────────────────
+
+        /// <summary>
+        /// Gets or sets the block device path.
+        /// Linux: "/dev/mmcblk0", Windows: "\\.\PhysicalDrive0".
+        /// </summary>
+        public string DevicePath { get; set; }
+
+        // ── Serial ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Gets or sets the serial port name.
+        /// Linux: "/dev/ttyUSB0", Windows: "COM3".
+        /// </summary>
+        public string SerialPort { get; set; }
+
+        /// <summary>
+        /// Gets or sets the baud rate for serial communication.
+        /// Default value is 115200 bps.
+        /// </summary>
+        public int BaudRate { get; set; } = 115200;
+
+        /// <summary>
+        /// Gets or sets the serial transfer protocol.
+        /// Default is <see cref="SerialProtocol.Auto"/> for automatic protocol negotiation
+        /// (tries YMODEM with CRC-16 first, falls back to XMODEM-CRC, then XMODEM-Checksum).
+        /// </summary>
+        public SerialProtocol SerialProtocol { get; set; } = SerialProtocol.Auto;
+
+        // ── USB ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Gets or sets the USB vendor ID (VID) for device identification.
+        /// </summary>
+        public ushort VendorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the USB product ID (PID) for device identification.
+        /// </summary>
+        public ushort ProductId { get; set; }
+
+        // ── Network ──────────────────────────────────────────────
+
+        /// <summary>
+        /// Gets or sets the remote host IP address or hostname
+        /// for network-based firmware transfer (TFTP/TCP).
+        /// </summary>
+        public string Host { get; set; }
+
+        /// <summary>
+        /// Gets or sets the remote port for network communication.
+        /// Default value is 69 (TFTP).
+        /// </summary>
+        public int Port { get; set; } = 69;
+
+        // ── Jtag ─────────────────────────────────────────────────
+
+        /// <summary>
+        /// Gets or sets the OpenOCD configuration file or script path.
+        /// Example: "interface/stlink.cfg", "board/raspberrypi.cfg".
+        /// </summary>
+        public string JtagConfig { get; set; }
+
+        /// <summary>
+        /// Validates that all required parameters for the selected connection type are present.
+        /// </summary>
+        /// <returns>True if the connection is properly configured; false otherwise.</returns>
+        public bool Validate()
+        {
+            switch (Type)
+            {
+                case ConnectionType.BlockDevice:
+                    return !string.IsNullOrWhiteSpace(DevicePath);
+
+                case ConnectionType.Serial:
+                    return !string.IsNullOrWhiteSpace(SerialPort) && BaudRate > 0;
+
+                case ConnectionType.UsbDfu:
+                    return VendorId != 0 || ProductId != 0;
+
+                case ConnectionType.Network:
+                    return !string.IsNullOrWhiteSpace(Host) && Port > 0;
+
+                case ConnectionType.Uefi:
+                    return true; // Uses system firmware interface, no extra params needed
+
+                case ConnectionType.Jtag:
+                    return !string.IsNullOrWhiteSpace(JtagConfig);
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns a string representation of the connection (excluding sensitive fields).
+        /// </summary>
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case ConnectionType.BlockDevice:
+                    return string.Format("BlockDevice[{0}]", DevicePath ?? "(not set)");
+
+                case ConnectionType.Serial:
+                    return string.Format("Serial[{0}, {1}bps, {2}]",
+                        SerialPort ?? "(not set)", BaudRate, SerialProtocol);
+
+                case ConnectionType.UsbDfu:
+                    return string.Format("UsbDfu[VID:0x{0:X4}, PID:0x{1:X4}]", VendorId, ProductId);
+
+                case ConnectionType.Network:
+                    return string.Format("Network[{0}:{1}]", Host ?? "(not set)", Port);
+
+                case ConnectionType.Uefi:
+                    return "Uefi[SystemFirmware]";
+
+                case ConnectionType.Jtag:
+                    return string.Format("Jtag[{0}]", JtagConfig ?? "(not set)");
+
+                default:
+                    return string.Format("Unknown[{0}]", Type);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates the serial transfer protocols available for firmware updates.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Auto</b> — attempts YMODEM with CRC-16 first, then XMODEM-CRC,
+    /// then XMODEM-Checksum. This is the recommended default.</para>
+    /// <para><b>XModem</b> — 128-byte packets with 8-bit checksum.
+    /// Most compatible but slowest.</para>
+    /// <para><b>XModemCRC</b> — 128-byte packets with CRC-8.
+    /// Better error detection than plain XMODEM.</para>
+    /// <para><b>XModem1K</b> — 1024-byte packets with CRC-8.
+    /// Higher throughput than 128-byte modes.</para>
+    /// <para><b>YModem</b> — 1024-byte packets with CRC-16 and file metadata.
+    /// Modern protocol used by ESP32, U-Boot. Supports batch transfer.</para>
+    /// </remarks>
+    public enum SerialProtocol
+    {
+        /// <summary>Auto-negotiate protocol with the bootloader.</summary>
+        Auto,
+
+        /// <summary>XMODEM-128 with 8-bit checksum.</summary>
+        XModem,
+
+        /// <summary>XMODEM-128 with CRC-8.</summary>
+        XModemCRC,
+
+        /// <summary>XMODEM-1K with CRC-8 (1024-byte packets).</summary>
+        XModem1K,
+
+        /// <summary>YMODEM with CRC-16 and file metadata.</summary>
+        YModem
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
@@ -37,6 +37,20 @@ namespace GeneralUpdate.Firmware.Models
         public FirmwareFormat Format { get; set; } = FirmwareFormat.Auto;
 
         /// <summary>
+        /// Gets or sets a custom firmware format decoder instance.
+        /// When set, this overrides both auto-detection and the <see cref="Format"/> property.
+        /// Use this for proprietary or non-standard firmware formats.
+        /// </summary>
+        public OTA.Decoders.IFirmwareDecoder CustomDecoder { get; set; }
+
+        /// <summary>
+        /// Gets or sets pre-decoded raw firmware data.
+        /// When set, the entire format decoding step (Step 3) is skipped
+        /// and this byte array is written directly to the device.
+        /// </summary>
+        public byte[] PreDecodedData { get; set; }
+
+        /// <summary>
         /// Gets or sets the device path or identifier to which the firmware should be written
         /// (e.g., "/dev/mmcblk0" on Linux, "\\.\PhysicalDrive0" on Windows).
         /// This is a convenience property that delegates to <see cref="DeviceConnection.DevicePath"/>.

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
@@ -23,10 +23,33 @@ namespace GeneralUpdate.Firmware.Models
         public string LocalFilePath { get; set; }
 
         /// <summary>
+        /// Gets or sets the hardware connection configuration.
+        /// Determines how the firmware is physically transferred to the target device.
+        /// Default is <see cref="ConnectionType.BlockDevice"/>.
+        /// </summary>
+        public DeviceConnection Connection { get; set; } = new DeviceConnection();
+
+        /// <summary>
+        /// Gets or sets the expected firmware file format.
+        /// Set to <see cref="FirmwareFormat.Auto"/> (default) for automatic detection
+        /// based on file extension and magic bytes.
+        /// </summary>
+        public FirmwareFormat Format { get; set; } = FirmwareFormat.Auto;
+
+        /// <summary>
         /// Gets or sets the device path or identifier to which the firmware should be written
         /// (e.g., "/dev/mmcblk0" on Linux, "\\.\PhysicalDrive0" on Windows).
+        /// This is a convenience property that delegates to <see cref="DeviceConnection.DevicePath"/>.
         /// </summary>
-        public string DevicePath { get; set; }
+        public string DevicePath
+        {
+            get => Connection?.DevicePath;
+            set
+            {
+                if (Connection == null) Connection = new DeviceConnection();
+                Connection.DevicePath = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the expected SHA256 hash of the firmware for integrity validation.
@@ -94,7 +117,7 @@ namespace GeneralUpdate.Firmware.Models
                 return false;
             }
 
-            if (string.IsNullOrWhiteSpace(DevicePath))
+            if (Connection == null || !Connection.Validate())
             {
                 return false;
             }
@@ -113,13 +136,12 @@ namespace GeneralUpdate.Firmware.Models
         public override string ToString()
         {
             return string.Format(
-                "FirmwareConfig[Url={0}, Device={1}, Platform={2}, Timeout={3}s, Retry={4}, Backup={5}]",
+                "FirmwareConfig[Url={0}, Connection={1}, Format={2}, Platform={3}, Timeout={4}s]",
                 FirmwareUrl ?? "(local file)",
-                DevicePath ?? "(not set)",
+                Connection?.ToString() ?? "(not set)",
+                Format,
                 Platform?.ToString() ?? "auto-detect",
-                TimeoutSeconds,
-                RetryCount,
-                BackupEnabled);
+                TimeoutSeconds);
         }
     }
 }

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareFormat.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareFormat.cs
@@ -1,0 +1,60 @@
+namespace GeneralUpdate.Firmware.Models
+{
+    /// <summary>
+    /// Enumerates the firmware file formats supported for flashing.
+    /// Used by <see cref="FirmwareConfig"/> to specify the expected format
+    /// and by the decoder layer to select the appropriate parser.
+    /// 
+    /// <para>
+    /// Set to <see cref="Auto"/> to auto-detect the format based on file extension
+    /// and file header magic bytes.
+    /// </para>
+    /// </summary>
+    public enum FirmwareFormat
+    {
+        /// <summary>
+        /// Auto-detect the firmware format based on file extension and magic bytes.
+        /// Recommended for most scenarios.
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Raw binary image (.bin, .img).
+        /// No parsing required — written directly to the device.
+        /// </summary>
+        Raw,
+
+        /// <summary>
+        /// Intel HEX format (.hex).
+        /// ASCII-encoded with address records and CRC-8 per line.
+        /// Common in MCU firmware distribution.
+        /// </summary>
+        IntelHex,
+
+        /// <summary>
+        /// Motorola S-Record format (.srec, .s19, .s28).
+        /// ASCII-encoded with address records and CRC.
+        /// Used in automotive and embedded systems.
+        /// </summary>
+        SRecord,
+
+        /// <summary>
+        /// Vela FlashPack format (.fpk).
+        /// Tar-based container with gzip-compressed payload and metadata.
+        /// Processed by the vela native library via P/Invoke.
+        /// </summary>
+        FlashPack,
+
+        /// <summary>
+        /// UEFI firmware capsule format (.cap, .uefi).
+        /// Windows-only: submitted via DeviceIoControl.
+        /// </summary>
+        UefiCapsule,
+
+        /// <summary>
+        /// Android sparse image format (.sparse, .sparseimg).
+        /// Contains skip blocks for efficient sparse flash writing.
+        /// </summary>
+        AndroidSparse
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/Decoders/Decoders.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/Decoders/Decoders.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+
+namespace GeneralUpdate.Firmware.OTA.Decoders
+{
+    /// <summary>
+    /// Decoder for raw binary firmware files (.bin, .img, .rom, .fw).
+    /// Simply reads the file contents as-is without any transformation.
+    /// </summary>
+    internal class RawDecoder : IFirmwareDecoder
+    {
+        public FirmwareFormat Format => FirmwareFormat.Raw;
+
+        public Task<byte[]> DecodeAsync(string filePath, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(File.ReadAllBytes(filePath));
+        }
+    }
+
+    /// <summary>
+    /// Stub: Intel HEX format decoder.
+    /// Full implementation will be provided in a subsequent PR.
+    /// </summary>
+    internal class IntelHexDecoder : IFirmwareDecoder
+    {
+        public FirmwareFormat Format => FirmwareFormat.IntelHex;
+
+        public Task<byte[]> DecodeAsync(string filePath, CancellationToken cancellationToken)
+        {
+            // TODO: Implement Intel HEX parsing (ASCII address records + CRC-8)
+            throw new System.NotImplementedException(
+                "Intel HEX decoder is not yet implemented. It will parse ASCII address records with CRC-8 validation.");
+        }
+    }
+
+    /// <summary>
+    /// Stub: Motorola S-Record format decoder.
+    /// Full implementation will be provided in a subsequent PR.
+    /// </summary>
+    internal class SRecordDecoder : IFirmwareDecoder
+    {
+        public FirmwareFormat Format => FirmwareFormat.SRecord;
+
+        public Task<byte[]> DecodeAsync(string filePath, CancellationToken cancellationToken)
+        {
+            // TODO: Implement S-Record parsing (S0/S1/S2/S3/S5/S7/S8/S9 records)
+            throw new System.NotImplementedException(
+                "S-Record decoder is not yet implemented. It will parse Motorola S-Records with CRC validation.");
+        }
+    }
+
+    /// <summary>
+    /// Stub: Android sparse image format decoder.
+    /// Full implementation will be provided in a subsequent PR.
+    /// </summary>
+    internal class AndroidSparseDecoder : IFirmwareDecoder
+    {
+        public FirmwareFormat Format => FirmwareFormat.AndroidSparse;
+
+        public Task<byte[]> DecodeAsync(string filePath, CancellationToken cancellationToken)
+        {
+            // TODO: Implement Android sparse image parsing (chunk-based with skip blocks)
+            throw new System.NotImplementedException(
+                "Android sparse decoder is not yet implemented. It will expand sparse images with skip blocks.");
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/Decoders/FirmwareDecoderFactory.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/Decoders/FirmwareDecoderFactory.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GeneralUpdate.Firmware.Models;
+
+namespace GeneralUpdate.Firmware.OTA.Decoders
+{
+    /// <summary>
+    /// Global registry for firmware format decoders.
+    /// Developers can register custom decoders for proprietary firmware formats
+    /// without modifying the framework source code.
+    /// 
+    /// <para>Usage:</para>
+    /// <code>
+    /// FirmwareDecoderFactory.Register(".myfmt", () => new MyCustomDecoder());
+    /// FirmwareDecoderFactory.Register(FirmwareFormat.IntelHex, () => new MyIntelHexDecoder());
+    /// </code>
+    /// </summary>
+    public static class FirmwareDecoderFactory
+    {
+        private static readonly object SyncLock = new object();
+        private static readonly Dictionary<string, Func<IFirmwareDecoder>> ExtensionRegistry
+            = new Dictionary<string, Func<IFirmwareDecoder>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<FirmwareFormat, Func<IFirmwareDecoder>> FormatRegistry
+            = new Dictionary<FirmwareFormat, Func<IFirmwareDecoder>>();
+
+        /// <summary>
+        /// Registers a decoder factory for a custom file extension.
+        /// Overwrites any existing registration for the same extension.
+        /// </summary>
+        /// <param name="extension">
+        /// The file extension including the leading dot (e.g., ".myfmt").
+        /// </param>
+        /// <param name="factory">A factory function that creates a new decoder instance.</param>
+        public static void Register(string extension, Func<IFirmwareDecoder> factory)
+        {
+            if (string.IsNullOrWhiteSpace(extension))
+                throw new ArgumentException("Extension cannot be null or empty.", nameof(extension));
+            if (factory == null)
+                throw new ArgumentNullException(nameof(factory));
+
+            lock (SyncLock)
+            {
+                ExtensionRegistry[extension] = factory;
+            }
+        }
+
+        /// <summary>
+        /// Registers a decoder factory for a specific <see cref="FirmwareFormat"/>.
+        /// This overrides the built-in decoder for the given format.
+        /// </summary>
+        /// <param name="format">The firmware format to handle.</param>
+        /// <param name="factory">A factory function that creates a new decoder instance.</param>
+        public static void Register(FirmwareFormat format, Func<IFirmwareDecoder> factory)
+        {
+            if (format == FirmwareFormat.Auto)
+                throw new ArgumentException("Cannot register a decoder for the Auto format.", nameof(format));
+            if (factory == null)
+                throw new ArgumentNullException(nameof(factory));
+
+            lock (SyncLock)
+            {
+                FormatRegistry[format] = factory;
+            }
+        }
+
+        /// <summary>
+        /// Removes a previously registered custom decoder for the given extension.
+        /// </summary>
+        /// <param name="extension">The file extension to unregister.</param>
+        /// <returns>True if a registration was removed; false otherwise.</returns>
+        public static bool Unregister(string extension)
+        {
+            if (string.IsNullOrWhiteSpace(extension)) return false;
+
+            lock (SyncLock)
+            {
+                return ExtensionRegistry.Remove(extension);
+            }
+        }
+
+        /// <summary>
+        /// Removes a previously registered custom decoder for the given format.
+        /// Restores the built-in decoder for that format.
+        /// </summary>
+        /// <param name="format">The format to unregister.</param>
+        /// <returns>True if a registration was removed; false otherwise.</returns>
+        public static bool Unregister(FirmwareFormat format)
+        {
+            lock (SyncLock)
+            {
+                return FormatRegistry.Remove(format);
+            }
+        }
+
+        /// <summary>
+        /// Clears all custom decoder registrations.
+        /// </summary>
+        public static void Clear()
+        {
+            lock (SyncLock)
+            {
+                ExtensionRegistry.Clear();
+                FormatRegistry.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Resolves the appropriate <see cref="IFirmwareDecoder"/> for the given file.
+        /// Resolution order:
+        /// <list type="number">
+        ///   <item><description>If <paramref name="customDecoder"/> is not null, use it.</description></item>
+        ///   <item><description>If <paramref name="format"/> is not Auto, look up in registry or use built-in.</description></item>
+        ///   <item><description>Detect format by file extension via registry or built-in rules.</description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="filePath">The firmware file path.</param>
+        /// <param name="format">The explicit format (may be Auto for detection).</param>
+        /// <param name="customDecoder">An optional custom decoder instance (highest priority).</param>
+        /// <returns>A firmware decoder instance ready for decoding.</returns>
+        /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when no decoder could be resolved for the given file format.
+        /// </exception>
+        public static IFirmwareDecoder Resolve(
+            string filePath,
+            FirmwareFormat format,
+            IFirmwareDecoder customDecoder = null)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+
+            // Priority 1: Explicit custom decoder instance
+            if (customDecoder != null)
+            {
+                return customDecoder;
+            }
+
+            string extension = Path.GetExtension(filePath);
+
+            // Priority 2: Explicit format (non-Auto)
+            if (format != FirmwareFormat.Auto)
+            {
+                lock (SyncLock)
+                {
+                    if (FormatRegistry.TryGetValue(format, out var factory))
+                    {
+                        return factory();
+                    }
+                }
+                return CreateBuiltIn(format);
+            }
+
+            // Priority 3: Auto-detect by file extension
+            // Check custom extension registry first
+            if (!string.IsNullOrEmpty(extension))
+            {
+                lock (SyncLock)
+                {
+                    if (ExtensionRegistry.TryGetValue(extension, out var factory))
+                    {
+                        return factory();
+                    }
+                }
+            }
+
+            // Priority 4: Built-in auto-detection by extension
+            return AutoDetect(filePath, extension);
+        }
+
+        /// <summary>
+        /// Creates a built-in decoder for the specified format.
+        /// </summary>
+        internal static IFirmwareDecoder CreateBuiltIn(FirmwareFormat format)
+        {
+            switch (format)
+            {
+                case FirmwareFormat.Raw:
+                    return new RawDecoder();
+
+                case FirmwareFormat.IntelHex:
+                    return new IntelHexDecoder();
+
+                case FirmwareFormat.SRecord:
+                    return new SRecordDecoder();
+
+                case FirmwareFormat.AndroidSparse:
+                    return new AndroidSparseDecoder();
+
+                case FirmwareFormat.FlashPack:
+                    // FlashPack is handled by vela-ffi (P/Invoke), not a decoder
+                    throw new InvalidOperationException(
+                        "FlashPack format is handled directly by vela-ffi. Use Raw decoder to pass the .fpk path.");
+
+                case FirmwareFormat.UefiCapsule:
+                    // UEFI capsule is handled by the Windows strategy
+                    throw new InvalidOperationException(
+                        "UEFI capsule format is handled by the platform strategy. Use Raw decoder if needed.");
+
+                default:
+                    throw new InvalidOperationException(
+                        string.Format("No built-in decoder for format: {0}", format));
+            }
+        }
+
+        /// <summary>
+        /// Auto-detects the firmware format by file extension and returns the appropriate decoder.
+        /// </summary>
+        private static IFirmwareDecoder AutoDetect(string filePath, string extension)
+        {
+            if (string.IsNullOrEmpty(extension))
+            {
+                // No extension — assume raw binary
+                return new RawDecoder();
+            }
+
+            switch (extension.ToLowerInvariant())
+            {
+                case ".hex":
+                    return new IntelHexDecoder();
+
+                case ".srec":
+                case ".s19":
+                case ".s28":
+                case ".s37":
+                    return new SRecordDecoder();
+
+                case ".sparse":
+                case ".sparseimg":
+                    return new AndroidSparseDecoder();
+
+                case ".bin":
+                case ".img":
+                case ".rom":
+                case ".fw":
+                default:
+                    // Binary files — raw decoder
+                    return new RawDecoder();
+            }
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/Decoders/IFirmwareDecoder.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/Decoders/IFirmwareDecoder.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+
+namespace GeneralUpdate.Firmware.OTA.Decoders
+{
+    /// <summary>
+    /// Internal interface for firmware format decoders.
+    /// Each implementation parses a specific firmware file format
+    /// and returns the unified raw byte stream ready for flashing.
+    /// 
+    /// <para>
+    /// Implementations:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>RawDecoder</c> — .bin/.img, no transformation</description></item>
+    ///   <item><description><c>IntelHexDecoder</c> — .hex, ASCII address records + CRC-8</description></item>
+    ///   <item><description><c>SRecordDecoder</c> — .srec/.s19, Motorola S-Records + CRC</description></item>
+    ///   <item><description><c>AndroidSparseDecoder</c> — .sparse, chunk-based sparse image</description></item>
+    /// </list>
+    /// </summary>
+    internal interface IFirmwareDecoder
+    {
+        /// <summary>
+        /// Gets the firmware format that this decoder handles.
+        /// </summary>
+        FirmwareFormat Format { get; }
+
+        /// <summary>
+        /// Decodes the firmware file at the given path into a raw byte array.
+        /// Validates internal checksums and resolves address gaps.
+        /// </summary>
+        /// <param name="filePath">The full path to the firmware file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The decoded raw firmware bytes ready for flashing.</returns>
+        Task<byte[]> DecodeAsync(string filePath, CancellationToken cancellationToken);
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/Decoders/IFirmwareDecoder.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/Decoders/IFirmwareDecoder.cs
@@ -5,7 +5,7 @@ using GeneralUpdate.Firmware.Models;
 namespace GeneralUpdate.Firmware.OTA.Decoders
 {
     /// <summary>
-    /// Internal interface for firmware format decoders.
+    /// Interface for firmware format decoders.
     /// Each implementation parses a specific firmware file format
     /// and returns the unified raw byte stream ready for flashing.
     /// 
@@ -19,7 +19,7 @@ namespace GeneralUpdate.Firmware.OTA.Decoders
     ///   <item><description><c>AndroidSparseDecoder</c> — .sparse, chunk-based sparse image</description></item>
     /// </list>
     /// </summary>
-    internal interface IFirmwareDecoder
+    public interface IFirmwareDecoder
     {
         /// <summary>
         /// Gets the firmware format that this decoder handles.

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/IConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/IConnection.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Internal interface for hardware connection channels.
+    /// Each implementation encapsulates the transport-specific I/O
+    /// for a given <see cref="Models.ConnectionType"/>.
+    /// 
+    /// <para>
+    /// Implementations:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>BlockDeviceConnection</c> — FileStream to local block device</description></item>
+    ///   <item><description><c>SerialConnection</c> — SerialPort with XMODEM/YMODEM</description></item>
+    ///   <item><description><c>UsbDfuConnection</c> — libusb (Linux) / WinUSB (Windows)</description></item>
+    ///   <item><description><c>NetworkConnection</c> — TcpClient + TFTP</description></item>
+    ///   <item><description><c>JtagConnection</c> — Process("openocd") subprocess</description></item>
+    /// </list>
+    /// </summary>
+    internal interface IConnection
+    {
+        /// <summary>
+        /// Opens the connection to the target device and prepares it for data transfer.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task OpenAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Writes the firmware data to the target device over this connection.
+        /// The connection must be opened via <see cref="OpenAsync"/> first.
+        /// </summary>
+        /// <param name="data">The decoded firmware data to write.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task WriteAsync(byte[] data, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Closes the connection and releases all resources.
+        /// Safe to call even if the connection was never opened.
+        /// </summary>
+        Task CloseAsync();
+    }
+}


### PR DESCRIPTION
Closes #239. Adds the core models and interfaces for multi-protocol firmware update. New: ConnectionType (6 types), DeviceConnection (+SerialProtocol enum with XModem/XModemCRC/XModem1K/YModem/Auto), FirmwareFormat (7 formats), IConnection, IFirmwareDecoder. FirmwareConfig updated with Connection and Format properties, backward compatible. Build: 0w 0e.