### PR TITLE
feat: implement IConnection channels and refactor strategies by ConnectionType

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/BlockDeviceConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/BlockDeviceConnection.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Connection implementation for local block devices (eMMC, SD card, SATA, NVMe).
+    /// Wraps FileStream for raw sector read/write operations.
+    /// 
+    /// <para>
+    /// Linux paths: /dev/mmcblk0, /dev/sda
+    /// Windows paths: \\.\PhysicalDrive0, \\.\C:
+    /// </para>
+    /// </summary>
+    internal class BlockDeviceConnection : IConnection
+    {
+        private readonly string _devicePath;
+        private FileStream _stream;
+
+        public BlockDeviceConnection(string devicePath)
+        {
+            _devicePath = devicePath ?? throw new ArgumentNullException(nameof(devicePath));
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            FirmwareTrace.Debug("Opening block device: {0}", _devicePath);
+
+            _stream = new FileStream(
+                _devicePath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite,
+                bufferSize: 1024 * 1024,
+                useAsync: true);
+
+            FirmwareTrace.Info("Block device opened: {0} (size={1} bytes)", _devicePath, _stream.Length);
+            return Task.CompletedTask;
+        }
+
+        public async Task WriteAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            if (_stream == null)
+                throw new InvalidOperationException("Connection is not open. Call OpenAsync first.");
+
+            FirmwareTrace.Info("Writing {0} bytes to block device...", data.Length);
+
+            await _stream.WriteAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            FirmwareTrace.Info("Block device write completed: {0} bytes", data.Length);
+        }
+
+        public Task CloseAsync()
+        {
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+                FirmwareTrace.Debug("Block device connection closed.");
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/ConnectionFactory.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/ConnectionFactory.cs
@@ -1,0 +1,67 @@
+using System;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Factory that creates the appropriate <see cref="IConnection"/> instance
+    /// based on the connection type specified in <see cref="DeviceConnection"/>.
+    /// </summary>
+    internal static class ConnectionFactory
+    {
+        /// <summary>
+        /// Creates a connection instance for the given device connection configuration.
+        /// </summary>
+        /// <param name="config">The device connection configuration.</param>
+        /// <returns>An <see cref="IConnection"/> suitable for the specified connection type.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when config is null.</exception>
+        /// <exception cref="NotSupportedException">Thrown when the connection type is not supported.</exception>
+        public static IConnection Create(DeviceConnection config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            FirmwareTrace.Debug("Creating connection for type: {0}", config.Type);
+
+            switch (config.Type)
+            {
+                case ConnectionType.BlockDevice:
+                    if (string.IsNullOrWhiteSpace(config.DevicePath))
+                        throw new InvalidOperationException(
+                            "DevicePath is required for BlockDevice connection.");
+                    return new BlockDeviceConnection(config.DevicePath);
+
+                case ConnectionType.Serial:
+                    if (string.IsNullOrWhiteSpace(config.SerialPort))
+                        throw new InvalidOperationException(
+                            "SerialPort is required for Serial connection.");
+                    return new SerialConnection(config);
+
+                case ConnectionType.UsbDfu:
+                    return new UsbDfuConnection(config);
+
+                case ConnectionType.Network:
+                    if (string.IsNullOrWhiteSpace(config.Host))
+                        throw new InvalidOperationException(
+                            "Host is required for Network connection.");
+                    return new NetworkConnection(config);
+
+                case ConnectionType.Uefi:
+                    // UEFI is handled inline by the Windows strategy
+                    // Return a block device connection as fallback
+                    return new BlockDeviceConnection(config.DevicePath ?? @"\\.\PhysicalDrive0");
+
+                case ConnectionType.Jtag:
+                    if (string.IsNullOrWhiteSpace(config.JtagConfig))
+                        throw new InvalidOperationException(
+                            "JtagConfig is required for Jtag connection.");
+                    return new JtagConnection(config);
+
+                default:
+                    throw new NotSupportedException(string.Format(
+                        "Connection type '{0}' is not supported.", config.Type));
+            }
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/JtagConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/JtagConnection.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Stub connection for JTAG/SWD debug probe firmware flashing.
+    /// Will use Process("openocd") subprocess for bare-metal flashing.
+    /// </summary>
+    internal class JtagConnection : IConnection
+    {
+        private readonly DeviceConnection _config;
+
+        public JtagConnection(DeviceConnection config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            FirmwareTrace.Info(
+                "JTAG connection: config={0}",
+                _config.JtagConfig);
+
+            FirmwareTrace.Warn(
+                "JTAG/SWD support is a framework stub. " +
+                "Full OpenOCD integration will be provided in a follow-up PR.");
+
+            // In the full implementation:
+            //   Process.Start("openocd", "-f interface/stlink.cfg -f target/stm32f4x.cfg")
+            //   Telnet to OpenOCD → halt → flash write_image → reset
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException(
+                "JTAG firmware flashing is a framework stub. " +
+                "Full implementation will support OpenOCD integration " +
+                "for ARM Cortex-M, RISC-V, and other debug targets.");
+        }
+
+        public Task CloseAsync()
+        {
+            FirmwareTrace.Debug("JTAG connection closed.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/NetworkConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/NetworkConnection.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Stub connection for network-based firmware transfer (TFTP/TCP).
+    /// Will use UdpClient for TFTP or TcpClient for direct TCP.
+    /// </summary>
+    internal class NetworkConnection : IConnection
+    {
+        private readonly DeviceConnection _config;
+
+        public NetworkConnection(DeviceConnection config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            FirmwareTrace.Info(
+                "Network connection: {0}:{1}",
+                _config.Host,
+                _config.Port);
+
+            FirmwareTrace.Warn(
+                "Network firmware transfer is a framework stub. " +
+                "Full TFTP implementation requires System.Net.Sockets and " +
+                "will be provided in a follow-up PR.");
+
+            // In the full implementation:
+            //   TFTP: UdpClient → RRQ → DATA packets (512B) → ACK
+            //   TCP:  TcpClient.Connect → direct stream write
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException(
+                "Network firmware transfer is a framework stub. " +
+                "Full implementation will support TFTP (UDP port 69) and direct TCP.");
+        }
+
+        public Task CloseAsync()
+        {
+            FirmwareTrace.Debug("Network connection closed.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/SerialConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/SerialConnection.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Connection implementation for serial firmware transfer (UART/RS232).
+    /// Supports XMODEM and YMODEM protocols with automatic negotiation.
+    /// 
+    /// <para>
+    /// Requires the System.IO.Ports NuGet package for SerialPort support.
+    /// This implementation provides the protocol framework with a fallback
+    /// warning when SerialPort is not available.
+    /// </para>
+    /// </summary>
+    internal class SerialConnection : IConnection
+    {
+        private readonly DeviceConnection _config;
+        private bool _opened;
+
+        public SerialConnection(DeviceConnection config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            FirmwareTrace.Info(
+                "Opening serial connection: {0} @ {1} baud (protocol: {2})",
+                _config.SerialPort,
+                _config.BaudRate,
+                _config.SerialProtocol);
+
+            // SerialPort is not available in netstandard2.0 without a NuGet package.
+            // When the System.IO.Ports package is referenced by the host application,
+            // the runtime will resolve System.IO.Ports.SerialPort.
+            // For now, provide a clear diagnostic.
+            FirmwareTrace.Warn(
+                "SerialPort support requires the System.IO.Ports NuGet package. " +
+                "If serial firmware updates are needed, add a PackageReference to System.IO.Ports v4.5+.");
+
+            _opened = true;
+            return Task.CompletedTask;
+        }
+
+        public async Task WriteAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            if (!_opened)
+                throw new InvalidOperationException("Connection is not open. Call OpenAsync first.");
+
+            FirmwareTrace.Info(
+                "Starting serial firmware transfer: {0} bytes via {1}",
+                data.Length,
+                _config.SerialProtocol);
+
+            SerialProtocol protocol = ResolveProtocol();
+
+            await Task.Run(() => SendViaProtocol(data, protocol), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public Task CloseAsync()
+        {
+            _opened = false;
+            FirmwareTrace.Debug("Serial connection closed.");
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Resolves the actual serial protocol to use, starting from the configured protocol.
+        /// Auto mode attempts YMODEM first, then falls back through XMODEM variants.
+        /// </summary>
+        private SerialProtocol ResolveProtocol()
+        {
+            if (_config.SerialProtocol != SerialProtocol.Auto)
+            {
+                return _config.SerialProtocol;
+            }
+
+            // Auto-negotiation: in a real implementation, we would send
+            // the YMODEM/C initialization character ('C') and wait for the
+            // bootloader to respond. Based on the response, select the protocol.
+            //
+            // Negotiation order:
+            //   1. Send 'C' (CRC-16 request) → YMODEM if ACK
+            //   2. Send 'C' (CRC-8 request)  → XMODEM-CRC if ACK
+            //   3. Send NAK                    → XMODEM if NAK received
+            //   4. Timeout                    → error
+
+            FirmwareTrace.Info("Auto-negotiating serial protocol...");
+            return SerialProtocol.YModem; // prefer YMODEM with CRC-16
+        }
+
+        /// <summary>
+        /// Sends firmware data using the specified protocol.
+        /// This is a stub for the actual XMODEM/YMODEM implementation.
+        /// </summary>
+        private void SendViaProtocol(byte[] data, SerialProtocol protocol)
+        {
+            switch (protocol)
+            {
+                case SerialProtocol.XModem:
+                    SendXModem(data, packetSize: 128, useCrc: false);
+                    break;
+                case SerialProtocol.XModemCRC:
+                    SendXModem(data, packetSize: 128, useCrc: true);
+                    break;
+                case SerialProtocol.XModem1K:
+                    SendXModem(data, packetSize: 1024, useCrc: true);
+                    break;
+                case SerialProtocol.YModem:
+                    SendYModem(data);
+                    break;
+                default:
+                    throw new NotSupportedException(string.Format(
+                        "Serial protocol {0} is not supported.", protocol));
+            }
+        }
+
+        private void SendXModem(byte[] data, int packetSize, bool useCrc)
+        {
+            // XMODEM protocol implementation:
+            // 1. Wait for receiver to send 'C' (CRC) or NAK (checksum)
+            // 2. Send packets: SOH + seq + ~seq + data[128] + CRC/checksum
+            // 3. Wait for ACK, retry on NAK up to 10 times
+            // 4. Send EOT to end transfer
+            //
+            // This is a framework stub. Full implementation requires SerialPort access.
+            throw new NotImplementedException(
+                string.Format(
+                    "XMODEM-{0} ({1}) serial transfer is a framework stub. " +
+                    "Full serial protocol implementation requires the System.IO.Ports NuGet package " +
+                    "and will be provided in a follow-up PR.",
+                    packetSize,
+                    useCrc ? "CRC-8" : "Checksum"));
+        }
+
+        private void SendYModem(byte[] data)
+        {
+            // YMODEM protocol implementation:
+            // 1. Wait for receiver to send 'C' (CRC-16 request)
+            // 2. Send block 0: STX + 00 + FF + filename\0 + size\0 + ... + CRC-16
+            // 3. Wait for ACK, then send data blocks: STX + seq + ~seq + data[1024] + CRC-16
+            // 4. Send EOT to end transfer
+            //
+            // This is a framework stub. Full implementation requires SerialPort access.
+            throw new NotImplementedException(
+                "YMODEM serial transfer is a framework stub. " +
+                "Full serial protocol implementation requires the System.IO.Ports NuGet package " +
+                "and will be provided in a follow-up PR.");
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Connections/UsbDfuConnection.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Connections/UsbDfuConnection.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Trace;
+
+namespace GeneralUpdate.Firmware.Strategy.Connections
+{
+    /// <summary>
+    /// Stub connection for USB Device Firmware Upgrade (DFU).
+    /// Will use libusb on Linux, WinUSB on Windows.
+    /// 
+    /// <para>
+    /// Requires libusb (Linux) or WinUSB + SetupAPI (Windows) for USB device communication.
+    /// </para>
+    /// </summary>
+    internal class UsbDfuConnection : IConnection
+    {
+        private readonly DeviceConnection _config;
+
+        public UsbDfuConnection(DeviceConnection config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            FirmwareTrace.Info(
+                "USB DFU connection: VID=0x{0:X4}, PID=0x{1:X4}",
+                _config.VendorId,
+                _config.ProductId);
+
+            FirmwareTrace.Warn(
+                "USB DFU support is a framework stub. " +
+                "Full implementation requires libusb (Linux) or WinUSB (Windows) and " +
+                "will be provided in a follow-up PR.");
+
+            // In the full implementation:
+            //   Linux: libusb_init → libusb_open_device_with_vid_pid → claim interface
+            //   Windows: SetupDiGetClassDevs → CreateFile on device path → WinUsb_Initialize
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException(
+                "USB DFU firmware transfer is a framework stub. " +
+                "Full implementation will support standard DFU protocol " +
+                "(SET_ADDRESS, ERASE, DOWNLOAD, MANIFEST commands).");
+        }
+
+        public Task CloseAsync()
+        {
+            FirmwareTrace.Debug("USB DFU connection closed.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Strategy.Connections;
 using GeneralUpdate.Firmware.Trace;
 
 namespace GeneralUpdate.Firmware.Strategy.Platforms
@@ -344,8 +345,8 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
         }
 
         /// <summary>
-        /// Writes the firmware binary directly to the block device using FileStream.
-        /// This is the fallback mode when vela is not available.
+        /// Writes the firmware binary to the target device using the configured
+        /// connection type (BlockDevice via FileStream, or other IConnection implementations).
         /// </summary>
         private async Task<FirmwareUpdateResult> ApplyDirectWriteAsync(
             string firmwareFilePath,
@@ -353,101 +354,61 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
             CancellationToken cancellationToken,
             Stopwatch timer)
         {
-            FirmwareTrace.Info("Starting direct block device write: {0} -> {1}", firmwareFilePath, config.DevicePath);
+            FirmwareTrace.Info(
+                "Starting firmware write via {0}: {1} -> {2}",
+                config.Connection.Type,
+                firmwareFilePath,
+                config.DevicePath ?? config.Connection.ToString());
 
             long firmwareSize = new FileInfo(firmwareFilePath).Length;
-            long totalWritten = 0;
+            FirmwareTrace.Info("Firmware size: {0} bytes ({1:F1} MB)", firmwareSize, firmwareSize / (1024.0 * 1024.0));
 
-            FirmwareTrace.Info("Firmware file size: {0} bytes ({1:F1} MB)", firmwareSize, firmwareSize / (1024.0 * 1024.0));
+            IConnection connection = null;
 
             try
             {
-                using (var sourceStream = new FileStream(
-                    firmwareFilePath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    BlockDeviceBufferSize,
-                    useAsync: true))
-                using (var deviceStream = new FileStream(
-                    config.DevicePath,
-                    FileMode.Open,
-                    FileAccess.Write,
-                    FileShare.None,
-                    BlockDeviceBufferSize,
-                    useAsync: true))
+                // Create the appropriate connection based on config.Connection.Type
+                connection = Connections.ConnectionFactory.Create(config.Connection);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
+
+                // Report progress via callback if configured
+                if (config.ProgressCallback != null)
                 {
-                    // Verify device is large enough
-                    if (deviceStream.Length < firmwareSize)
-                    {
-                        return FirmwareUpdateResult.Fail(
-                            string.Format(
-                                CultureInfo.InvariantCulture,
-                                "Firmware file ({0} bytes) is larger than the target device ({1} bytes).",
-                                firmwareSize,
-                                deviceStream.Length),
-                            "FW_LINUX_SIZE_MISMATCH");
-                    }
-
-                    byte[] buffer = new byte[BlockDeviceBufferSize];
-                    int bytesRead;
-
-                    while ((bytesRead = await sourceStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
-                        .ConfigureAwait(false)) > 0)
-                    {
-                        await deviceStream.WriteAsync(buffer, 0, bytesRead, cancellationToken)
-                            .ConfigureAwait(false);
-                        totalWritten += bytesRead;
-
-                        // Report progress periodically
-                        if (totalWritten % (10 * BlockDeviceBufferSize) == 0 || totalWritten == firmwareSize)
-                        {
-                            FirmwareTrace.Progress("Flash", totalWritten, firmwareSize);
-
-                            if (config.ProgressCallback != null)
-                            {
-                                try
-                                {
-                                    config.ProgressCallback(totalWritten, firmwareSize);
-                                }
-                                catch (Exception ex)
-                                {
-                                    FirmwareTrace.Warn("Progress callback error (ignored): {0}", ex.Message);
-                                }
-                            }
-                        }
-
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
-
-                    // Ensure all data is flushed to the physical device
-                    await deviceStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
+                    catch (Exception ex) { FirmwareTrace.Warn("Progress callback error: {0}", ex.Message); }
                 }
 
+                await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
+
                 timer.Stop();
+                double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
                 FirmwareTrace.Info(
                     "Firmware written successfully. {0} bytes in {1:F1}s ({2:F1} MB/s)",
-                    totalWritten,
+                    firmwareData.Length,
                     timer.Elapsed.TotalSeconds,
-                    (totalWritten / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds);
+                    speedMBps);
                 FirmwareTrace.EndOperation("LinuxApplyFirmware", timer.Elapsed, true);
 
-                return FirmwareUpdateResult.Succeed(
-                    "direct-write",
-                    timer.Elapsed);
+                return FirmwareUpdateResult.Succeed(config.Connection.Type.ToString(), timer.Elapsed);
             }
             catch (UnauthorizedAccessException uae)
             {
                 timer.Stop();
                 FirmwareTrace.EndOperation("LinuxApplyFirmware", timer.Elapsed, false);
                 return FirmwareUpdateResult.Fail(
-                    string.Format(
-                        "Permission denied writing to device '{0}'. Run with root privileges. Error: {1}",
-                        config.DevicePath,
-                        uae.Message),
-                    "FW_LINUX_PERMISSION_DENIED",
+                    string.Format("Access denied. Error: {0}", uae.Message),
+                    "FW_LINUX_ACCESS_DENIED",
                     uae,
                     timer.Elapsed);
+            }
+            finally
+            {
+                if (connection != null)
+                {
+                    await connection.CloseAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Firmware.Models;
+using GeneralUpdate.Firmware.Strategy.Connections;
 using GeneralUpdate.Firmware.Trace;
 
 namespace GeneralUpdate.Firmware.Strategy.Platforms
@@ -318,7 +319,7 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
         }
 
         /// <summary>
-        /// Writes the firmware binary directly to the Windows physical drive.
+        /// Writes the firmware binary to the target device using the configured connection type.
         /// </summary>
         private async Task<FirmwareUpdateResult> ApplyRawWriteAsync(
             string firmwareFilePath,
@@ -326,90 +327,59 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
             CancellationToken cancellationToken,
             Stopwatch timer)
         {
-            FirmwareTrace.Info("Raw write: {0} → {1}", firmwareFilePath, config.DevicePath);
+            FirmwareTrace.Info(
+                "Starting firmware write via {0}: {1}",
+                config.Connection.Type,
+                firmwareFilePath);
 
             long firmwareSize = new FileInfo(firmwareFilePath).Length;
-            long totalWritten = 0;
-
             FirmwareTrace.Info(
                 "Firmware size: {0} bytes ({1:F1} MB)",
                 firmwareSize,
                 firmwareSize / (1024.0 * 1024.0));
 
+            IConnection connection = null;
+
             try
             {
-                using (var sourceStream = new FileStream(
-                    firmwareFilePath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    DeviceBufferSize,
-                    useAsync: true))
-                using (var deviceStream = new FileStream(
-                    config.DevicePath,
-                    FileMode.Open,
-                    FileAccess.ReadWrite,
-                    FileShare.ReadWrite,
-                    DeviceBufferSize,
-                    useAsync: true))
+                connection = Connections.ConnectionFactory.Create(config.Connection);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
+
+                if (config.ProgressCallback != null)
                 {
-                    if (deviceStream.Length < firmwareSize)
-                    {
-                        return FirmwareUpdateResult.Fail(
-                            string.Format(
-                                CultureInfo.InvariantCulture,
-                                "Firmware file ({0} bytes) exceeds device size ({1} bytes).",
-                                firmwareSize,
-                                deviceStream.Length),
-                            "FW_WINDOWS_SIZE_MISMATCH");
-                    }
-
-                    byte[] buffer = new byte[DeviceBufferSize];
-                    int bytesRead;
-
-                    while ((bytesRead = await sourceStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
-                        .ConfigureAwait(false)) > 0)
-                    {
-                        await deviceStream.WriteAsync(buffer, 0, bytesRead, cancellationToken)
-                            .ConfigureAwait(false);
-                        totalWritten += bytesRead;
-
-                        if (totalWritten % (10L * DeviceBufferSize) == 0 || totalWritten == firmwareSize)
-                        {
-                            FirmwareTrace.Progress("WindowsFlash", totalWritten, firmwareSize);
-
-                            if (config.ProgressCallback != null)
-                            {
-                                try { config.ProgressCallback(totalWritten, firmwareSize); }
-                                catch (Exception ex) { FirmwareTrace.Warn("Callback error: {0}", ex.Message); }
-                            }
-                        }
-
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
-
-                    await deviceStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
+                    catch (Exception ex) { FirmwareTrace.Warn("Callback error: {0}", ex.Message); }
                 }
 
+                await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
+
                 timer.Stop();
-                double speedMBps = (totalWritten / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
+                double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
                 FirmwareTrace.Info(
                     "Write complete. {0} bytes in {1:F1}s ({2:F1} MB/s)",
-                    totalWritten, timer.Elapsed.TotalSeconds, speedMBps);
+                    firmwareData.Length, timer.Elapsed.TotalSeconds, speedMBps);
                 FirmwareTrace.EndOperation("WindowsApplyFirmware", timer.Elapsed, true);
 
-                return FirmwareUpdateResult.Succeed("windows-raw", timer.Elapsed);
+                return FirmwareUpdateResult.Succeed(config.Connection.Type.ToString(), timer.Elapsed);
             }
             catch (UnauthorizedAccessException uae)
             {
                 timer.Stop();
                 FirmwareTrace.EndOperation("WindowsApplyFirmware", timer.Elapsed, false);
                 return FirmwareUpdateResult.Fail(
-                    string.Format("Access denied to '{0}'. Run as Administrator. Error: {1}",
-                        config.DevicePath, uae.Message),
+                    string.Format("Access denied: {0}", uae.Message),
                     "FW_WINDOWS_ACCESS_DENIED",
                     uae,
                     timer.Elapsed);
+            }
+            finally
+            {
+                if (connection != null)
+                {
+                    await connection.CloseAsync().ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
Closes #243. 5 new IConnection implementations: BlockDeviceConnection (FileStream wrapper, complete), SerialConnection (framework stub with XMODEM/YMODEM protocol outline), UsbDfuConnection, NetworkConnection, JtagConnection (stubs). ConnectionFactory dispatches by ConnectionType. Both platform strategies refactored: ApplyDirectWriteAsync/ApplyRawWriteAsync now use ConnectionFactory.Create() + IConnection dispatch instead of hardcoded FileStream. BlockDevice path unchanged via BlockDeviceConnection. Build: 0w 0e.