### PR TITLE
feat: add developer-friendly firmware update callbacks to GeneralFirmwareBootstrap

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -25,6 +25,10 @@ namespace GeneralUpdate.Firmware
     ///     config.DevicePath = "/dev/mmcblk0";
     /// })
     /// .UseDefaultStrategy()
+    /// .OnStageChanged((stage, desc) => Console.WriteLine($"[{stage}] {desc}"))
+    /// .OnDownloadProgress((recv, total, speed, eta) => Console.Write($"\r{recv}/{total}"))
+    /// .OnCompleted(result => Console.WriteLine("Firmware update succeeded!"))
+    /// .OnFailed(result => Console.WriteLine($"Update failed: {result.Message}"))
     /// .ExecuteAsync();
     /// </code>
     /// </summary>
@@ -32,6 +36,14 @@ namespace GeneralUpdate.Firmware
     {
         private FirmwareConfig _config;
         private IFirmwareStrategy _strategy;
+
+        // ===== Fluent-registered callbacks =====
+        private Action<FirmwareUpdateStage, string>  _onStageChanged;
+        private Action<FirmwareProgressInfo>         _onProgress;
+        private Action<long, long, double, TimeSpan> _onDownloadProgress;
+        private Action<FirmwareUpdateResult>         _onCompleted;
+        private Action<FirmwareUpdateResult>         _onFailed;
+        private Action<string, string>               _onWarning;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeneralFirmwareBootstrap"/> class.
@@ -73,6 +85,63 @@ namespace GeneralUpdate.Firmware
             FirmwareTrace.Info("FirmwareConfig validated successfully");
             return new GeneralFirmwareBootstrap(config);
         }
+
+        // ============================================================
+        // Fluent callback registration methods
+        // ============================================================
+
+        /// <summary>
+        /// Registers a callback that is invoked each time the update enters a new stage.
+        /// </summary>
+        /// <param name="handler">(FirmwareUpdateStage stage, string description)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnStageChanged(Action<FirmwareUpdateStage, string> handler)
+        { _onStageChanged += handler; return this; }
+
+        /// <summary>
+        /// Registers a callback that is invoked periodically with rich progress information.
+        /// Suitable for driving a progress bar or status display.
+        /// </summary>
+        /// <param name="handler">(FirmwareProgressInfo info)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnProgress(Action<FirmwareProgressInfo> handler)
+        { _onProgress += handler; return this; }
+
+        /// <summary>
+        /// Registers a callback that is invoked during the download stage with speed and ETA.
+        /// </summary>
+        /// <param name="handler">(long bytesReceived, long totalBytes, double speedBytesPerSecond, TimeSpan estimatedRemaining)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnDownloadProgress(Action<long, long, double, TimeSpan> handler)
+        { _onDownloadProgress += handler; return this; }
+
+        /// <summary>
+        /// Registers a callback that is invoked when the firmware update completes successfully.
+        /// </summary>
+        /// <param name="handler">(FirmwareUpdateResult result)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnCompleted(Action<FirmwareUpdateResult> handler)
+        { _onCompleted += handler; return this; }
+
+        /// <summary>
+        /// Registers a callback that is invoked when the firmware update fails.
+        /// </summary>
+        /// <param name="handler">(FirmwareUpdateResult result)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnFailed(Action<FirmwareUpdateResult> handler)
+        { _onFailed += handler; return this; }
+
+        /// <summary>
+        /// Registers a callback that is invoked for non-fatal warnings during the update.
+        /// </summary>
+        /// <param name="handler">(string message, string warningCode)</param>
+        /// <returns>This instance for fluent chaining.</returns>
+        public GeneralFirmwareBootstrap OnWarning(Action<string, string> handler)
+        { _onWarning += handler; return this; }
+
+        // ============================================================
+        // Strategy configuration methods
+        // ============================================================
 
         /// <summary>
         /// Uses the default platform strategy based on auto-detection of the current OS.
@@ -135,9 +204,15 @@ namespace GeneralUpdate.Firmware
             return this;
         }
 
+        // ============================================================
+        // Execute
+        // ============================================================
+
         /// <summary>
         /// Executes the firmware update operation asynchronously.
         /// This performs validation, backup (if enabled), download, and flashing in sequence.
+        /// Fires stage-change, progress, download-progress, completion, failure, and warning
+        /// callbacks throughout the pipeline.
         /// </summary>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         /// <returns>A result indicating success or failure of the entire operation.</returns>
@@ -162,6 +237,9 @@ namespace GeneralUpdate.Firmware
                 // ========================================================
                 // Step 1: Validate device readiness
                 // ========================================================
+                RaiseStageChanged(FirmwareUpdateStage.ValidatingDevice, "Checking device readiness...");
+                RaiseProgress(ValidatingDeviceProgress(0));
+
                 FirmwareTrace.BeginOperation("DeviceValidation");
                 var validationSw = Stopwatch.StartNew();
 
@@ -173,16 +251,23 @@ namespace GeneralUpdate.Firmware
 
                 if (!isReady)
                 {
-                    return FirmwareUpdateResult.Fail(
+                    var failResult = FirmwareUpdateResult.Fail(
                         "Device validation failed. The target device is not ready for firmware update.",
                         "FW_DEVICE_NOT_READY");
+                    RaiseResultCallbacks(failResult);
+                    return failResult;
                 }
+
+                RaiseProgress(ValidatingDeviceProgress(100));
 
                 // ========================================================
                 // Step 2: Create backup (if enabled)
                 // ========================================================
                 if (_config.BackupEnabled)
                 {
+                    RaiseStageChanged(FirmwareUpdateStage.BackingUp, "Backing up current firmware...");
+                    RaiseProgress(BackingUpProgress(0));
+
                     FirmwareTrace.BeginOperation("FirmwareBackup");
                     var backupSw = Stopwatch.StartNew();
 
@@ -194,13 +279,18 @@ namespace GeneralUpdate.Firmware
 
                     if (!backupOk)
                     {
-                        return FirmwareUpdateResult.Fail(
+                        var failResult = FirmwareUpdateResult.Fail(
                             "Firmware backup failed. Update aborted for safety.",
                             "FW_BACKUP_FAILED");
+                        RaiseResultCallbacks(failResult);
+                        return failResult;
                     }
+
+                    RaiseProgress(BackingUpProgress(100));
                 }
                 else
                 {
+                    RaiseWarning("Firmware backup is disabled. Proceeding without safety net.", "FW_BACKUP_SKIPPED");
                     FirmwareTrace.Warn("Firmware backup is disabled. Proceeding without safety net.");
                 }
 
@@ -210,6 +300,8 @@ namespace GeneralUpdate.Firmware
                 string localPath = _config.LocalFilePath;
                 if (!string.IsNullOrWhiteSpace(_config.FirmwareUrl))
                 {
+                    RaiseStageChanged(FirmwareUpdateStage.Downloading, "Downloading firmware...");
+
                     FirmwareTrace.Info("Firmware URL provided: {0}", _config.FirmwareUrl);
 
                     // If no local path specified, generate one in temp directory
@@ -223,8 +315,21 @@ namespace GeneralUpdate.Firmware
                         FirmwareTrace.Info("No LocalFilePath specified; using temp path: {0}", localPath);
                     }
 
-                    // Download the firmware
-                    var downloader = new OTA.FirmwareDownloader(_config);
+                    // Download the firmware (passing callbacks for speed/ETA reporting)
+                    var downloader = new OTA.FirmwareDownloader(
+                        _config,
+                        onDownloadProgress: (bytes, total, speed, eta) =>
+                        {
+                            // Merge fluent + config callbacks
+                            _onDownloadProgress?.Invoke(bytes, total, speed, eta);
+                            _config.OnDownloadProgress?.Invoke(bytes, total, speed, eta);
+                        },
+                        onProgress: (info) =>
+                        {
+                            _onProgress?.Invoke(info);
+                            _config.OnProgress?.Invoke(info);
+                        });
+
                     try
                     {
                         localPath = await downloader.DownloadAsync(localPath, cancellationToken)
@@ -233,10 +338,12 @@ namespace GeneralUpdate.Firmware
                     catch (Exception downloadEx)
                     {
                         FirmwareTrace.Error("Firmware download failed", downloadEx);
-                        return FirmwareUpdateResult.Fail(
+                        var failResult = FirmwareUpdateResult.Fail(
                             string.Format("Firmware download failed: {0}", downloadEx.Message),
                             "FW_DOWNLOAD_FAILED",
                             downloadEx);
+                        RaiseResultCallbacks(failResult);
+                        return failResult;
                     }
 
                     // Set the resolved local path back to config for downstream use
@@ -250,20 +357,30 @@ namespace GeneralUpdate.Firmware
                 // ========================================================
                 // Step 3.5: Validate firmware integrity
                 // ========================================================
+                RaiseStageChanged(FirmwareUpdateStage.ValidatingFirmware, "Validating firmware integrity...");
+                RaiseProgress(ValidatingFirmwareProgress(0));
+
                 var validator = new OTA.FirmwareValidator(_config);
                 bool isValid = await validator.ValidateAsync(localPath, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (!isValid)
                 {
-                    return FirmwareUpdateResult.Fail(
+                    var failResult = FirmwareUpdateResult.Fail(
                         "Firmware validation failed. The downloaded file does not match the expected SHA256 hash.",
                         "FW_VALIDATION_FAILED");
+                    RaiseResultCallbacks(failResult);
+                    return failResult;
                 }
+
+                RaiseProgress(ValidatingFirmwareProgress(100));
 
                 // ========================================================
                 // Step 4: Apply firmware to device
                 // ========================================================
+                RaiseStageChanged(FirmwareUpdateStage.Flashing, "Writing firmware to device...");
+                RaiseProgress(FlashingProgress(0));
+
                 FirmwareTrace.BeginOperation("ApplyFirmware");
                 var applySw = Stopwatch.StartNew();
 
@@ -280,12 +397,19 @@ namespace GeneralUpdate.Firmware
                 applySw.Stop();
                 FirmwareTrace.EndOperation("ApplyFirmware", applySw.Elapsed, result.Success);
 
+                // Flashing complete
+                RaiseProgress(FlashingProgress(result.Success ? 100 : 0));
+
                 overallSw.Stop();
                 result.Duration = overallSw.Elapsed;
 
                 FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, result.Success);
                 FirmwareTrace.Info("Total firmware update time: {0:F3}s", overallSw.Elapsed.TotalSeconds);
 
+                // ========================================================
+                // Notify result
+                // ========================================================
+                RaiseResultCallbacks(result);
                 return result;
             }
             catch (OperationCanceledException)
@@ -294,10 +418,12 @@ namespace GeneralUpdate.Firmware
                 FirmwareTrace.Warn("Firmware update was cancelled after {0:F3}s", overallSw.Elapsed.TotalSeconds);
                 FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
 
-                return FirmwareUpdateResult.Fail(
+                var cancelResult = FirmwareUpdateResult.Fail(
                     "Firmware update was cancelled.",
                     "FW_CANCELLED",
                     duration: overallSw.Elapsed);
+                RaiseResultCallbacks(cancelResult);
+                return cancelResult;
             }
             catch (Exception ex)
             {
@@ -305,13 +431,137 @@ namespace GeneralUpdate.Firmware
                 FirmwareTrace.Error("Firmware update failed with unexpected error", ex);
                 FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
 
-                return FirmwareUpdateResult.Fail(
+                var errorResult = FirmwareUpdateResult.Fail(
                     string.Format("An unexpected error occurred: {0}", ex.Message),
                     "FW_UNEXPECTED_ERROR",
                     ex,
                     overallSw.Elapsed);
+                RaiseResultCallbacks(errorResult);
+                return errorResult;
             }
         }
+
+        // ============================================================
+        // Internal helpers — callback invocation
+        // ============================================================
+
+        /// <summary>
+        /// Fires OnStageChanged on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseStageChanged(FirmwareUpdateStage stage, string description)
+        {
+            FirmwareTrace.Info("Stage: {0} — {1}", stage, description);
+
+            SafeInvoke(_onStageChanged, stage, description);
+            SafeInvoke(_config.OnStageChanged, stage, description);
+        }
+
+        /// <summary>
+        /// Fires OnProgress on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseProgress(FirmwareProgressInfo info)
+        {
+            SafeInvoke(_onProgress, info);
+            SafeInvoke(_config.OnProgress, info);
+        }
+
+        /// <summary>
+        /// Fires OnWarning on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseWarning(string message, string code)
+        {
+            SafeInvoke(_onWarning, message, code);
+            SafeInvoke(_config.OnWarning, message, code);
+        }
+
+        /// <summary>
+        /// Fires the appropriate result callback (OnCompleted or OnFailed) and the final stage.
+        /// </summary>
+        private void RaiseResultCallbacks(FirmwareUpdateResult result)
+        {
+            if (result.Success)
+            {
+                RaiseStageChanged(FirmwareUpdateStage.Completed, string.Format(
+                    "Firmware update completed. Version: {0}, Duration: {1:F1}s",
+                    result.AppliedVersion ?? "(unknown)",
+                    result.Duration.TotalSeconds));
+
+                SafeInvoke(_onCompleted, result);
+                SafeInvoke(_config.OnCompleted, result);
+            }
+            else
+            {
+                RaiseStageChanged(FirmwareUpdateStage.Failed, string.Format(
+                    "[{0}] {1}",
+                    result.ErrorCode ?? "FW_FAILED",
+                    result.Message));
+
+                SafeInvoke(_onFailed, result);
+                SafeInvoke(_config.OnFailed, result);
+            }
+        }
+
+        // ============================================================
+        // Progress helpers — weighted progress across stages
+        // ============================================================
+
+        /// <summary>
+        /// Stage weights for overall progress calculation.
+        /// ValidatingDevice=5%, BackingUp=15%, Downloading=50%, ValidatingFirmware=10%, Flashing=20%.
+        /// </summary>
+        private static FirmwareProgressInfo ValidatingDeviceProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.ValidatingDevice,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = stagePct * 0.05f,
+            StatusText = string.Format("Validating device... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo BackingUpProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.BackingUp,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 5f + stagePct * 0.15f,
+            StatusText = string.Format("Backing up firmware... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo ValidatingFirmwareProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.ValidatingFirmware,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 70f + stagePct * 0.10f,
+            StatusText = string.Format("Validating firmware... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo FlashingProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.Flashing,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 80f + stagePct * 0.20f,
+            StatusText = string.Format("Flashing firmware... {0:F0}%", stagePct)
+        };
+
+        // ============================================================
+        // Safe invoke helpers
+        // ============================================================
+
+        private static void SafeInvoke<T1, T2>(Action<T1, T2> callback, T1 arg1, T2 arg2)
+        {
+            if (callback == null) return;
+            try { callback(arg1, arg2); }
+            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
+        }
+
+        private static void SafeInvoke<T>(Action<T> callback, T arg)
+        {
+            if (callback == null) return;
+            try { callback(arg); }
+            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
+        }
+
+        // ============================================================
+        // Platform detection and strategy resolution
+        // ============================================================
 
         /// <summary>
         /// Auto-detects the current runtime platform.

--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -228,6 +228,10 @@ namespace GeneralUpdate.Firmware
                 throw new InvalidOperationException(error);
             }
 
+            // Merge fluent-registered callbacks into config so strategies and
+            // validators can access them internally.
+            MergeCallbacksIntoConfig();
+
             FirmwareTrace.BeginOperation("FirmwareUpdate");
 
             var overallSw = Stopwatch.StartNew();
@@ -439,6 +443,21 @@ namespace GeneralUpdate.Firmware
                 RaiseResultCallbacks(errorResult);
                 return errorResult;
             }
+        }
+
+        /// <summary>
+        /// Merges fluent-registered callbacks into <see cref="FirmwareConfig"/> so that
+        /// strategies and validators can fire them internally without needing separate
+        /// callback parameters.
+        /// </summary>
+        private void MergeCallbacksIntoConfig()
+        {
+            _config.OnStageChanged     += _onStageChanged;
+            _config.OnProgress          += _onProgress;
+            _config.OnDownloadProgress  += _onDownloadProgress;
+            _config.OnCompleted         += _onCompleted;
+            _config.OnFailed            += _onFailed;
+            _config.OnWarning           += _onWarning;
         }
 
         // ============================================================

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
@@ -118,7 +118,50 @@ namespace GeneralUpdate.Firmware.Models
         /// The first argument is bytes received, second is total bytes.
         /// Set to null to disable progress callbacks.
         /// </summary>
+        [Obsolete("Use OnDownloadProgress to also get download speed and estimated time remaining. Both callbacks fire together.")]
         public Action<long, long> ProgressCallback { get; set; }
+
+        // ===== New notification callbacks =====
+
+        /// <summary>
+        /// Gets or sets a callback invoked when the firmware update enters a new stage.
+        /// Parameters: (<see cref="FirmwareUpdateStage"/> stage, string description).
+        /// Example stages: ValidatingDevice, BackingUp, Downloading, Flashing, Completed, Failed.
+        /// </summary>
+        public Action<FirmwareUpdateStage, string> OnStageChanged { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback invoked periodically (approx. every 500 ms) with rich progress information.
+        /// Parameter: <see cref="FirmwareProgressInfo"/> containing stage, percentages, speed, ETA, etc.
+        /// Suitable for driving a progress bar or status display.
+        /// </summary>
+        public Action<FirmwareProgressInfo> OnProgress { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback invoked during the download stage with speed and ETA.
+        /// Parameters: (long bytesReceived, long totalBytes, double speedBytesPerSecond, TimeSpan estimatedRemaining).
+        /// Fires roughly every 500 ms during the download.
+        /// </summary>
+        public Action<long, long, double, TimeSpan> OnDownloadProgress { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback invoked when the firmware update completes successfully.
+        /// Parameter: <see cref="FirmwareUpdateResult"/> with the applied version, duration, etc.
+        /// </summary>
+        public Action<FirmwareUpdateResult> OnCompleted { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback invoked when the firmware update fails.
+        /// Parameter: <see cref="FirmwareUpdateResult"/> with the error code, message, and exception details.
+        /// </summary>
+        public Action<FirmwareUpdateResult> OnFailed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback invoked for non-fatal warnings during the update.
+        /// Parameters: (string message, string warningCode).
+        /// Examples: backup skipped by configuration, retry attempts, etc.
+        /// </summary>
+        public Action<string, string> OnWarning { get; set; }
 
         /// <summary>
         /// Validates that the configuration contains all required fields for an update operation.

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareProgressInfo.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareProgressInfo.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace GeneralUpdate.Firmware.Models
+{
+    /// <summary>
+    /// A snapshot of the current progress in a firmware update operation.
+    /// Passed to <see cref="Action{FirmwareProgressInfo}"/> callbacks
+    /// to give callers rich information about the ongoing operation.
+    /// </summary>
+    public class FirmwareProgressInfo
+    {
+        /// <summary>Which stage the update is currently in.</summary>
+        public FirmwareUpdateStage Stage { get; set; }
+
+        /// <summary>
+        /// Progress within the current stage, from 0.0 to 100.0.
+        /// For example, during <see cref="FirmwareUpdateStage.Downloading"/> this
+        /// reflects the percentage of bytes downloaded.
+        /// </summary>
+        public float StageProgressPercent { get; set; }
+
+        /// <summary>
+        /// Overall progress across all stages, from 0.0 to 100.0,
+        /// weighted by the relative duration of each stage.
+        /// Suitable for driving a single progress bar.
+        /// </summary>
+        public float OverallProgressPercent { get; set; }
+
+        /// <summary>Bytes downloaded so far (only meaningful during <see cref="FirmwareUpdateStage.Downloading"/>).</summary>
+        public long BytesDownloaded { get; set; }
+
+        /// <summary>Total bytes to download. -1 if the server did not provide Content-Length.</summary>
+        public long TotalBytes { get; set; }
+
+        /// <summary>Current download speed in bytes per second.</summary>
+        public double SpeedBytesPerSecond { get; set; }
+
+        /// <summary>Estimated time remaining for the current stage.</summary>
+        public TimeSpan EstimatedRemaining { get; set; }
+
+        /// <summary>Time elapsed since the current stage started.</summary>
+        public TimeSpan Elapsed { get; set; }
+
+        /// <summary>A human-readable status string (e.g., "下载中... 5120/10240 KB").</summary>
+        public string StatusText { get; set; }
+
+        /// <summary>Returns a compact string representation suitable for logging.</summary>
+        public override string ToString()
+        {
+            return string.Format(
+                "Stage={0}, Overall={1:F1}%, StagePct={2:F1}%, Bytes={3}/{4}, Speed={5:F1}KB/s, ETA={6}",
+                Stage,
+                OverallProgressPercent,
+                StageProgressPercent,
+                BytesDownloaded,
+                TotalBytes,
+                SpeedBytesPerSecond / 1024.0,
+                EstimatedRemaining);
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareUpdateStage.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareUpdateStage.cs
@@ -1,0 +1,34 @@
+namespace GeneralUpdate.Firmware.Models
+{
+    /// <summary>
+    /// Represents the current stage of a firmware update operation.
+    /// Used by <see cref="FirmwareProgressInfo"/> and stage-change callbacks
+    /// to inform the caller which phase is in progress.
+    /// </summary>
+    public enum FirmwareUpdateStage
+    {
+        /// <summary>The update has not started yet.</summary>
+        Idle,
+
+        /// <summary>Validating whether the target device is ready and compatible.</summary>
+        ValidatingDevice,
+
+        /// <summary>Backing up the current firmware before applying the update.</summary>
+        BackingUp,
+
+        /// <summary>Downloading the firmware binary from the remote URL.</summary>
+        Downloading,
+
+        /// <summary>Validating firmware integrity (e.g., SHA256 hash check).</summary>
+        ValidatingFirmware,
+
+        /// <summary>Writing (flashing) the firmware to the target device.</summary>
+        Flashing,
+
+        /// <summary>The firmware update completed successfully.</summary>
+        Completed,
+
+        /// <summary>The firmware update failed.</summary>
+        Failed
+    }
+}

--- a/src/c#/GeneralUpdate.Firmware/OTA/FirmwareDownloader.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/FirmwareDownloader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -15,8 +16,9 @@ namespace GeneralUpdate.Firmware.OTA
     /// 
     /// <para>
     /// The downloader reads the firmware binary in configurable chunks,
-    /// reports progress via <see cref="FirmwareConfig.ProgressCallback"/>,
-    /// and retries transient failures according to the configuration.
+    /// reports progress via <see cref="FirmwareConfig.OnDownloadProgress"/>
+    /// with speed and ETA, and retries transient failures according to
+    /// the configuration.
     /// </para>
     /// </summary>
     public class FirmwareDownloader
@@ -27,14 +29,28 @@ namespace GeneralUpdate.Firmware.OTA
         public const int DefaultBufferSize = 8192;
 
         private readonly FirmwareConfig _config;
+        private readonly Action<long, long, double, TimeSpan> _onDownloadProgress;
+        private readonly Action<FirmwareProgressInfo> _onProgress;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirmwareDownloader"/> class.
         /// </summary>
         /// <param name="config">The firmware update configuration.</param>
-        public FirmwareDownloader(FirmwareConfig config)
+        /// <param name="onDownloadProgress">
+        /// Optional callback for download progress with speed and ETA.
+        /// Parameters: (bytesReceived, totalBytes, speedBytesPerSecond, estimatedRemaining).
+        /// </param>
+        /// <param name="onProgress">
+        /// Optional callback for rich progress information.
+        /// </param>
+        public FirmwareDownloader(
+            FirmwareConfig config,
+            Action<long, long, double, TimeSpan> onDownloadProgress = null,
+            Action<FirmwareProgressInfo> onProgress = null)
         {
             _config = config ?? throw new ArgumentNullException(nameof(config));
+            _onDownloadProgress = onDownloadProgress;
+            _onProgress = onProgress;
         }
 
         /// <summary>
@@ -158,6 +174,8 @@ namespace GeneralUpdate.Firmware.OTA
         /// <summary>
         /// Performs a single download attempt with progress reporting.
         /// Uses <see cref="HttpWebRequest"/> for broad .NET Standard 2.0 compatibility.
+        /// Reports speed and ETA via <see cref="FirmwareConfig.OnDownloadProgress"/> and
+        /// rich progress via <see cref="FirmwareConfig.OnProgress"/> at ~500 ms intervals.
         /// </summary>
         /// <param name="localFilePath">Where to save the downloaded file.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
@@ -206,8 +224,10 @@ namespace GeneralUpdate.Firmware.OTA
                     {
                         byte[] buffer = new byte[DefaultBufferSize];
                         int bytesRead;
-                        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-                        long lastReportedBytes = 0;
+                        var stageStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                        long lastReportBytes = 0;
+                        long lastReportTimeMs = 0;
+                        var speedSamples = new Queue<double>(4);
 
                         while ((bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
                             .ConfigureAwait(false)) > 0)
@@ -217,33 +237,77 @@ namespace GeneralUpdate.Firmware.OTA
 
                             totalBytesRead += bytesRead;
 
-                            // Report progress at reasonable intervals (every 100KB or when complete)
-                            if (totalBytesRead - lastReportedBytes >= 102400 ||
-                                totalBytesRead == contentLength ||
-                                contentLength <= 0)
+                            // Report at ~500 ms intervals for smooth speed/ETA updates
+                            long elapsedMs = stageStopwatch.ElapsedMilliseconds;
+                            if (elapsedMs - lastReportTimeMs >= 500 ||
+                                totalBytesRead == contentLength)
                             {
+                                // --- Calculate instant speed and sliding-window average ---
+                                double deltaBytes = totalBytesRead - lastReportBytes;
+                                double deltaSeconds = (elapsedMs - lastReportTimeMs) / 1000.0;
+                                double instantSpeed = deltaSeconds > 0 ? deltaBytes / deltaSeconds : 0;
+
+                                speedSamples.Enqueue(instantSpeed);
+                                if (speedSamples.Count > 3) speedSamples.Dequeue();
+
+                                double avgSpeed = 0;
+                                foreach (var s in speedSamples) avgSpeed += s;
+                                avgSpeed = speedSamples.Count > 0 ? avgSpeed / speedSamples.Count : instantSpeed;
+
+                                TimeSpan eta = contentLength > 0 && avgSpeed > 0
+                                    ? TimeSpan.FromSeconds((contentLength - totalBytesRead) / avgSpeed)
+                                    : TimeSpan.Zero;
+
+                                // --- Stage progress ---
+                                float stagePct = contentLength > 0
+                                    ? (float)totalBytesRead / contentLength * 100f
+                                    : 0f;
+
+                                // --- Overall progress (download stage = 20%→70% band) ---
+                                float overallPct = contentLength > 0
+                                    ? 20f + (stagePct * 0.5f)
+                                    : 20f;
+
+                                // --- Trace ---
                                 FirmwareTrace.Progress("Download", totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead);
 
-                                // Invoke user-provided progress callback
-                                if (_config.ProgressCallback != null)
-                                {
-                                    try
-                                    {
-                                        _config.ProgressCallback(totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
-                                    }
-                                }
+                                // --- New: rich download callback (bytes, total, speed, eta) ---
+                                FireCallback(_onDownloadProgress, totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead, avgSpeed, eta);
+                                FireCallback(_config.OnDownloadProgress, totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead, avgSpeed, eta);
 
-                                lastReportedBytes = totalBytesRead;
+                                // --- New: general progress callback ---
+                                var info = new FirmwareProgressInfo
+                                {
+                                    Stage = FirmwareUpdateStage.Downloading,
+                                    StageProgressPercent = stagePct,
+                                    OverallProgressPercent = overallPct,
+                                    BytesDownloaded = totalBytesRead,
+                                    TotalBytes = contentLength,
+                                    SpeedBytesPerSecond = avgSpeed,
+                                    EstimatedRemaining = eta,
+                                    Elapsed = stageStopwatch.Elapsed,
+                                    StatusText = string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        "下载中... {0}/{1} KB",
+                                        totalBytesRead / 1024,
+                                        contentLength > 0 ? contentLength / 1024 : -1)
+                                };
+                                FireCallback(_onProgress, info);
+                                FireCallback(_config.OnProgress, info);
+
+                                // --- Legacy: backward-compatible callback ---
+#pragma warning disable 618
+                                FireCallback(_config.ProgressCallback, totalBytesRead, contentLength > 0 ? contentLength : totalBytesRead);
+#pragma warning restore 618
+
+                                lastReportBytes = totalBytesRead;
+                                lastReportTimeMs = elapsedMs;
                             }
 
                             cancellationToken.ThrowIfCancellationRequested();
                         }
 
-                        stopwatch.Stop();
+                        stageStopwatch.Stop();
 
                         if (contentLength > 0 && totalBytesRead != contentLength)
                         {
@@ -255,18 +319,49 @@ namespace GeneralUpdate.Firmware.OTA
                                     contentLength));
                         }
 
-                        double speedKBps = stopwatch.Elapsed.TotalSeconds > 0
-                            ? (totalBytesRead / 1024.0) / stopwatch.Elapsed.TotalSeconds
+                        double speedKBps = stageStopwatch.Elapsed.TotalSeconds > 0
+                            ? (totalBytesRead / 1024.0) / stageStopwatch.Elapsed.TotalSeconds
                             : 0;
 
                         FirmwareTrace.Info(
                             "Download finished. Total: {0} bytes, Duration: {1:F1}s, Speed: {2:F1} KB/s",
                             totalBytesRead,
-                            stopwatch.Elapsed.TotalSeconds,
+                            stageStopwatch.Elapsed.TotalSeconds,
                             speedKBps);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Safely invokes a 4-parameter callback, catching and logging any exceptions.
+        /// Prevents a misbehaving callback from crashing the download pipeline.
+        /// </summary>
+        private static void FireCallback<T1, T2, T3, T4>(Action<T1, T2, T3, T4> callback, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            if (callback == null) return;
+            try { callback(arg1, arg2, arg3, arg4); }
+            catch (Exception ex) { FirmwareTrace.Warn("Download progress callback threw an exception (ignored): {0}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Safely invokes a 1-parameter callback, catching and logging any exceptions.
+        /// </summary>
+        private static void FireCallback<T>(Action<T> callback, T arg)
+        {
+            if (callback == null) return;
+            try { callback(arg); }
+            catch (Exception ex) { FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Safely invokes a 2-parameter callback, catching and logging any exceptions.
+        /// </summary>
+        private static void FireCallback<T1, T2>(Action<T1, T2> callback, T1 arg1, T2 arg2)
+        {
+            if (callback == null) return;
+            try { callback(arg1, arg2); }
+            catch (Exception ex) { FirmwareTrace.Warn("Progress legacy callback threw an exception (ignored): {0}", ex.Message); }
         }
     }
 }

--- a/src/c#/GeneralUpdate.Firmware/OTA/FirmwareValidator.cs
+++ b/src/c#/GeneralUpdate.Firmware/OTA/FirmwareValidator.cs
@@ -16,7 +16,8 @@ namespace GeneralUpdate.Firmware.OTA
     /// 
     /// <para>
     /// Validation is skipped when <see cref="FirmwareConfig.ExpectedSha256"/>
-    /// is null or empty.
+    /// is null or empty. Progress is reported via <see cref="FirmwareConfig.OnProgress"/>
+    /// if configured.
     /// </para>
     /// </summary>
     public class FirmwareValidator
@@ -35,6 +36,7 @@ namespace GeneralUpdate.Firmware.OTA
         /// <summary>
         /// Validates the firmware file at the given path against the expected hash.
         /// If no expected hash is configured, validation is skipped and returns true.
+        /// Fires <see cref="FirmwareConfig.OnProgress"/> during hash computation.
         /// </summary>
         /// <param name="firmwareFilePath">The full path to the firmware file to validate.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
@@ -45,14 +47,16 @@ namespace GeneralUpdate.Firmware.OTA
         /// <exception cref="FileNotFoundException">
         /// Thrown when the firmware file does not exist.
         /// </exception>
-        public Task<bool> ValidateAsync(string firmwareFilePath, CancellationToken cancellationToken = default)
+        public async Task<bool> ValidateAsync(string firmwareFilePath, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(Validate(firmwareFilePath));
+            return await Task.Run(() => Validate(firmwareFilePath), cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Synchronously computes the SHA256 hash of the firmware file and compares
-        /// it against the expected value.
+        /// it against the expected value. Reports progress via
+        /// <see cref="FirmwareConfig.OnProgress"/>.
         /// </summary>
         /// <param name="firmwareFilePath">The full path to the firmware file.</param>
         /// <returns>True if the hash matches or validation is skipped; false otherwise.</returns>
@@ -77,13 +81,41 @@ namespace GeneralUpdate.Firmware.OTA
 
             try
             {
-                string computedHash;
+                // --- Fire progress: start ---
+                FireValidationProgress(0, firmwareFilePath);
 
-                using (var stream = new FileStream(firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                string computedHash;
+                long fileSize = new FileInfo(firmwareFilePath).Length;
+
+                using (var stream = new FileStream(firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1024 * 1024))
                 using (var sha256 = SHA256.Create())
                 {
-                    byte[] hashBytes = sha256.ComputeHash(stream);
-                    computedHash = BitConverter.ToString(hashBytes).Replace("-", string.Empty);
+                    // Compute hash with progress reporting for large files
+                    byte[] buffer = new byte[1024 * 1024]; // 1 MB chunks
+                    long totalRead = 0;
+                    int bytesRead;
+                    var chunkSw = System.Diagnostics.Stopwatch.StartNew();
+                    long lastReportBytes = 0;
+                    long lastReportMs = 0;
+
+                    // Use TransformBlock to incrementally compute hash with progress
+                    sha256.Initialize();
+                    while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        sha256.TransformBlock(buffer, 0, bytesRead, null, 0);
+                        totalRead += bytesRead;
+
+                        long elapsedMs = chunkSw.ElapsedMilliseconds;
+                        if (elapsedMs - lastReportMs >= 500 || totalRead == fileSize)
+                        {
+                            float stagePct = fileSize > 0 ? (float)totalRead / fileSize * 100f : 0f;
+                            FireValidationProgress(stagePct, firmwareFilePath);
+                            lastReportBytes = totalRead;
+                            lastReportMs = elapsedMs;
+                        }
+                    }
+                    sha256.TransformFinalBlock(buffer, 0, 0);
+                    computedHash = BitConverter.ToString(sha256.Hash).Replace("-", string.Empty);
                 }
 
                 bool isValid = string.Equals(
@@ -105,6 +137,9 @@ namespace GeneralUpdate.Firmware.OTA
                     FirmwareTrace.EndOperation("FirmwareValidation", TimeSpan.Zero, false);
                 }
 
+                // --- Fire progress: complete ---
+                FireValidationProgress(isValid ? 100 : 0, firmwareFilePath);
+
                 return isValid;
             }
             catch (Exception ex)
@@ -112,6 +147,33 @@ namespace GeneralUpdate.Firmware.OTA
                 FirmwareTrace.Error("Firmware validation encountered an error", ex);
                 FirmwareTrace.EndOperation("FirmwareValidation", TimeSpan.Zero, false);
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Fires <see cref="FirmwareConfig.OnProgress"/> with the current validation progress.
+        /// </summary>
+        private void FireValidationProgress(float stagePct, string firmwareFilePath)
+        {
+            var callback = _config.OnProgress;
+            if (callback == null) return;
+
+            try
+            {
+                callback(new FirmwareProgressInfo
+                {
+                    Stage = FirmwareUpdateStage.ValidatingFirmware,
+                    StageProgressPercent = stagePct,
+                    OverallProgressPercent = 70f + (stagePct * 0.10f),
+                    StatusText = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Validating firmware integrity... {0:F0}%",
+                        stagePct)
+                });
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Warn("Validation progress callback threw an exception (ignored): {0}", ex.Message);
             }
         }
     }

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
@@ -233,6 +233,13 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                         if (totalBytesRead % (10 * BlockDeviceBufferSize) == 0)
                         {
                             FirmwareTrace.Progress("Backup", totalBytesRead, sourceStream.Length);
+
+                            // Fire progress callback for the backup stage
+                            FireProgress(config, FirmwareUpdateStage.BackingUp,
+                                sourceStream.Length > 0 ? (float)totalBytesRead / sourceStream.Length * 100f : 0f,
+                                5f + (sourceStream.Length > 0 ? (float)totalBytesRead / sourceStream.Length * 15f : 0f),
+                                string.Format(CultureInfo.InvariantCulture, "Backing up... {0}/{1} MB",
+                                    totalBytesRead / (1024 * 1024), sourceStream.Length / (1024 * 1024)));
                         }
                     }
 
@@ -373,14 +380,26 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
 
                 byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
 
-                // Report progress via callback if configured
+                // Fire progress: flashing starts
+                FireProgress(config, FirmwareUpdateStage.Flashing, 0, 80f,
+                    string.Format(CultureInfo.InvariantCulture, "Writing firmware... {0} MB", firmwareData.Length / (1024 * 1024)));
+
+                // Legacy callback (deprecated but still supported)
+#pragma warning disable 618
                 if (config.ProgressCallback != null)
                 {
                     try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
                     catch (Exception ex) { FirmwareTrace.Warn("Progress callback error: {0}", ex.Message); }
                 }
+#pragma warning restore 618
+
+                // Fire progress: writing
+                FireProgress(config, FirmwareUpdateStage.Flashing, 50f, 90f, "Writing firmware to device...");
 
                 await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
+
+                // Fire progress: write complete
+                FireProgress(config, FirmwareUpdateStage.Flashing, 100f, 100f, "Firmware written successfully.");
 
                 timer.Stop();
                 double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
@@ -528,6 +547,34 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                 FirmwareTrace.Warn("Falling back to direct block device write.");
                 return await ApplyDirectWriteAsync(firmwareFilePath, config, cancellationToken, timer)
                     .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Safely fires <see cref="FirmwareConfig.OnProgress"/> during backup or flashing.
+        /// </summary>
+        private static void FireProgress(
+            FirmwareConfig config,
+            FirmwareUpdateStage stage,
+            float stagePct,
+            float overallPct,
+            string statusText)
+        {
+            var callback = config?.OnProgress;
+            if (callback == null) return;
+            try
+            {
+                callback(new FirmwareProgressInfo
+                {
+                    Stage = stage,
+                    StageProgressPercent = stagePct,
+                    OverallProgressPercent = overallPct,
+                    StatusText = statusText
+                });
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
             }
         }
     }

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
@@ -219,6 +219,13 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                         if (totalBytesRead % (10L * DeviceBufferSize) == 0)
                         {
                             FirmwareTrace.Progress("WindowsBackup", totalBytesRead, deviceStream.Length);
+
+                            // Fire progress callback for the backup stage
+                            FireProgress(config, FirmwareUpdateStage.BackingUp,
+                                deviceStream.Length > 0 ? (float)totalBytesRead / deviceStream.Length * 100f : 0f,
+                                5f + (deviceStream.Length > 0 ? (float)totalBytesRead / deviceStream.Length * 15f : 0f),
+                                string.Format(CultureInfo.InvariantCulture, "Backing up... {0}/{1} MB",
+                                    totalBytesRead / (1024 * 1024), deviceStream.Length / (1024 * 1024)));
                         }
                     }
 
@@ -347,13 +354,26 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
 
                 byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
 
+                // Fire progress: flashing starts
+                FireProgress(config, FirmwareUpdateStage.Flashing, 0, 80f,
+                    string.Format(CultureInfo.InvariantCulture, "Writing firmware... {0} MB", firmwareData.Length / (1024 * 1024)));
+
+                // Legacy callback (deprecated but still supported)
+#pragma warning disable 618
                 if (config.ProgressCallback != null)
                 {
                     try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
                     catch (Exception ex) { FirmwareTrace.Warn("Callback error: {0}", ex.Message); }
                 }
+#pragma warning restore 618
+
+                // Fire progress: writing
+                FireProgress(config, FirmwareUpdateStage.Flashing, 50f, 90f, "Writing firmware to device...");
 
                 await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
+
+                // Fire progress: write complete
+                FireProgress(config, FirmwareUpdateStage.Flashing, 100f, 100f, "Firmware written successfully.");
 
                 timer.Stop();
                 double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
@@ -573,6 +593,34 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
         {
             if (string.IsNullOrWhiteSpace(path)) return "device";
             return path.Replace(@"\\.\", string.Empty).Replace("\\", "_").Replace(":", string.Empty);
+        }
+
+        /// <summary>
+        /// Safely fires <see cref="FirmwareConfig.OnProgress"/> during backup or flashing.
+        /// </summary>
+        private static void FireProgress(
+            FirmwareConfig config,
+            FirmwareUpdateStage stage,
+            float stagePct,
+            float overallPct,
+            string statusText)
+        {
+            var callback = config?.OnProgress;
+            if (callback == null) return;
+            try
+            {
+                callback(new FirmwareProgressInfo
+                {
+                    Stage = stage,
+                    StageProgressPercent = stagePct,
+                    OverallProgressPercent = overallPct,
+                    StatusText = statusText
+                });
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #249

## Summary

Add a comprehensive, developer-friendly callback/notification system to `GeneralFirmwareBootstrap` so callers can observe every phase of the firmware update pipeline in real time.

## What Changed

### New files
- **`FirmwareUpdateStage.cs`** ��?Enum defining the 8 stages of a firmware update lifecycle
- **`FirmwareProgressInfo.cs`** ��?Rich progress-info POCO with stage %, overall %, speed, ETA, elapsed, and status text

### Modified files
- **`FirmwareConfig.cs`** ��?6 new `Action<>` callback properties; old `ProgressCallback` marked `[Obsolete]` but still fully supported
- **`FirmwareDownloader.cs`** ��?Sliding-window speed calculation, ETA estimation, fires new callbacks at ~500 ms intervals
- **`GeneralFirmwareBootstrap.cs`** ��?Fluent API (`OnStageChanged`/`OnProgress`/`OnDownloadProgress`/`OnCompleted`/`OnFailed`/`OnWarning`) + weighted overall-progress calculation (5%��?0%��?0%��?0%��?00%)

## API Surface

### Fluent chaining (recommended)
```csharp
var result = await GeneralFirmwareBootstrap.Create(config => { ... })
    .UseDefaultStrategy()
    .OnStageChanged((stage, desc) => Console.WriteLine($"[{stage}] {desc}"))
    .OnDownloadProgress((received, total, speed, eta) => { /* speed in B/s */ })
    .OnProgress(info => progressBar.Value = info.OverallProgressPercent)
    .OnCompleted(r => Console.WriteLine($"OK: {r.AppliedVersion}"))
    .OnFailed(r => Console.WriteLine($"FAIL [{r.ErrorCode}]: {r.Message}"))
    .OnWarning((msg, code) => Console.WriteLine($"WARN [{code}]: {msg}"))
    .ExecuteAsync();
```

### Config-property registration
```csharp
config.OnStageChanged = myHandler;
config.OnDownloadProgress = myDownloadHandler;
config.OnCompleted = myCompletionHandler;
// ...
```

### Download-specific callback signature
```csharp
Action<long, long, double, TimeSpan>
//     bytesReceived, totalBytes, speedBytesPerSecond, estimatedRemaining
```

## Design Decisions

| Choice | Reason |
|---|---|
| `Action<>` instead of custom delegates | Lighter, no new types to learn, works with lambdas/MethodGroup |
| Double registration (fluent + config) | Both chains fire; no surprise ��?fluent for convenience, config for DI |
| `[Obsolete]` on old callback | Not breaking; both old & new callbacks fire together |
| Callbacks wrapped in try-catch | Misbehaving callbacks never crash the pipeline |
| ~500 ms reporting interval (was 100 KB) | Smoother speed/ETA display, especially on fast connections |
| Sliding-window speed (3 samples) | Dampens jitter vs. raw instant speed |

## Backward Compatibility

- ��?Old `config.ProgressCallback` works as before (with deprecation hint)
- ��?`FirmwareDownloader` constructor is backward-compatible (new params have defaults)
- ��?No breaking API changes
- ��?Builds clean (0 errors)

