### PR TITLE
feat: add write-verify and auto-rollback for firmware update safety

### DIFF
--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -238,6 +238,9 @@ namespace GeneralUpdate.Firmware
 
             try
             {
+                // Track whether we have a usable backup for potential rollback
+                bool backupOk = false;
+
                 // ========================================================
                 // Step 1: Validate device readiness
                 // ========================================================
@@ -275,7 +278,7 @@ namespace GeneralUpdate.Firmware
                     FirmwareTrace.BeginOperation("FirmwareBackup");
                     var backupSw = Stopwatch.StartNew();
 
-                    bool backupOk = await _strategy.BackupCurrentFirmwareAsync(_config, cancellationToken)
+                    backupOk = await _strategy.BackupCurrentFirmwareAsync(_config, cancellationToken)
                         .ConfigureAwait(false);
 
                     backupSw.Stop();
@@ -404,6 +407,68 @@ namespace GeneralUpdate.Firmware
                 // Flashing complete
                 RaiseProgress(FlashingProgress(result.Success ? 100 : 0));
 
+                // ========================================================
+                // Step 5: Auto-rollback on failure
+                // ========================================================
+                if (!result.Success && _config.EnableAutoRollback && backupOk && !string.IsNullOrWhiteSpace(_config.LastBackupPath))
+                {
+                    FirmwareTrace.Warn("Flashing failed. Attempting auto-rollback from: {0}", _config.LastBackupPath);
+                    RaiseWarning(
+                        string.Format("Flashing failed [{0}]. Rolling back to original firmware...", result.ErrorCode),
+                        "FW_ROLLBACK_ATTEMPT");
+
+                    try
+                    {
+                        RaiseStageChanged(FirmwareUpdateStage.RollingBack,
+                            "Flashing failed — restoring original firmware from backup...");
+                        RaiseProgress(VerifyingWriteProgress(0));
+
+                        var rollbackSw = Stopwatch.StartNew();
+                        FirmwareUpdateResult rollbackResult = await _strategy.ApplyFirmwareAsync(
+                            _config.LastBackupPath, _config, cancellationToken)
+                            .ConfigureAwait(false);
+                        rollbackSw.Stop();
+
+                        if (rollbackResult.Success)
+                        {
+                            FirmwareTrace.Info("Rollback completed successfully in {0:F1}s", rollbackSw.Elapsed.TotalSeconds);
+                            RaiseProgress(VerifyingWriteProgress(100));
+
+                            overallSw.Stop();
+                            return FirmwareUpdateResult.Fail(
+                                string.Format("Flashing failed [{0}], but firmware was rolled back to the original version. {1}",
+                                    result.ErrorCode, result.Message),
+                                "FW_FLASH_FAILED_ROLLED_BACK",
+                                result.Error,
+                                overallSw.Elapsed);
+                        }
+                        else
+                        {
+                            FirmwareTrace.Error("Rollback failed: {0}", rollbackResult.Message);
+                            RaiseWarning(
+                                string.Format("Rollback also failed: {0}", rollbackResult.Message),
+                                "FW_ROLLBACK_FAILED");
+
+                            overallSw.Stop();
+                            result.Duration = overallSw.Elapsed;
+                            RaiseResultCallbacks(result);
+                            return result;
+                        }
+                    }
+                    catch (Exception rollbackEx)
+                    {
+                        FirmwareTrace.Error("Rollback threw an exception", rollbackEx);
+                        RaiseWarning(
+                            string.Format("Rollback failed with exception: {0}", rollbackEx.Message),
+                            "FW_ROLLBACK_EXCEPTION");
+
+                        overallSw.Stop();
+                        result.Duration = overallSw.Elapsed;
+                        RaiseResultCallbacks(result);
+                        return result;
+                    }
+                }
+
                 overallSw.Stop();
                 result.Duration = overallSw.Elapsed;
 
@@ -422,6 +487,9 @@ namespace GeneralUpdate.Firmware
                 FirmwareTrace.Warn("Firmware update was cancelled after {0:F3}s", overallSw.Elapsed.TotalSeconds);
                 FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
 
+                // Attempt rollback if cancelled mid-flash
+                await TryRollbackAsync(cancellationToken).ConfigureAwait(false);
+
                 var cancelResult = FirmwareUpdateResult.Fail(
                     "Firmware update was cancelled.",
                     "FW_CANCELLED",
@@ -434,6 +502,9 @@ namespace GeneralUpdate.Firmware
                 overallSw.Stop();
                 FirmwareTrace.Error("Firmware update failed with unexpected error", ex);
                 FirmwareTrace.EndOperation("FirmwareUpdate", overallSw.Elapsed, false);
+
+                // Attempt rollback on unexpected error
+                await TryRollbackAsync(cancellationToken).ConfigureAwait(false);
 
                 var errorResult = FirmwareUpdateResult.Fail(
                     string.Format("An unexpected error occurred: {0}", ex.Message),
@@ -559,6 +630,55 @@ namespace GeneralUpdate.Firmware
             OverallProgressPercent = 80f + stagePct * 0.20f,
             StatusText = string.Format("Flashing firmware... {0:F0}%", stagePct)
         };
+
+        private static FirmwareProgressInfo VerifyingWriteProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.VerifyingWrite,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 100f,
+            StatusText = string.Format("Verifying written data... {0:F0}%", stagePct)
+        };
+
+        // ============================================================
+        // Rollback
+        // ============================================================
+
+        /// <summary>
+        /// Attempts to restore the backup firmware if auto-rollback is enabled
+        /// and a backup path is available. Safe to call even when no backup exists.
+        /// </summary>
+        private async Task TryRollbackAsync(CancellationToken cancellationToken)
+        {
+            if (!_config.EnableAutoRollback) return;
+            if (string.IsNullOrWhiteSpace(_config.LastBackupPath)) return;
+            if (!System.IO.File.Exists(_config.LastBackupPath)) return;
+
+            FirmwareTrace.Warn("Attempting automatic rollback from backup: {0}", _config.LastBackupPath);
+            RaiseStageChanged(FirmwareUpdateStage.RollingBack, "Unexpected error — restoring original firmware...");
+
+            try
+            {
+                var rollbackResult = await _strategy.ApplyFirmwareAsync(
+                    _config.LastBackupPath, _config, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (rollbackResult.Success)
+                {
+                    FirmwareTrace.Info("Rollback completed successfully.");
+                    RaiseWarning("Original firmware restored from backup.", "FW_ROLLBACK_OK");
+                }
+                else
+                {
+                    FirmwareTrace.Error("Rollback failed: {0}", rollbackResult.Message);
+                    RaiseWarning("Rollback failed — device may be in an inconsistent state.", "FW_ROLLBACK_FAILED");
+                }
+            }
+            catch (Exception rollbackEx)
+            {
+                FirmwareTrace.Error("Rollback threw exception", rollbackEx);
+                RaiseWarning(string.Format("Rollback failed: {0}", rollbackEx.Message), "FW_ROLLBACK_EXCEPTION");
+            }
+        }
 
         // ============================================================
         // Safe invoke helpers

--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -421,7 +421,13 @@ namespace GeneralUpdate.Firmware
                     {
                         RaiseStageChanged(FirmwareUpdateStage.RollingBack,
                             "Flashing failed — restoring original firmware from backup...");
-                        RaiseProgress(VerifyingWriteProgress(0));
+                        RaiseProgress(new FirmwareProgressInfo
+                        {
+                            Stage = FirmwareUpdateStage.RollingBack,
+                            StageProgressPercent = 0,
+                            OverallProgressPercent = 100f,
+                            StatusText = "Restoring original firmware..."
+                        });
 
                         var rollbackSw = Stopwatch.StartNew();
                         FirmwareUpdateResult rollbackResult = await _strategy.ApplyFirmwareAsync(
@@ -432,7 +438,6 @@ namespace GeneralUpdate.Firmware
                         if (rollbackResult.Success)
                         {
                             FirmwareTrace.Info("Rollback completed successfully in {0:F1}s", rollbackSw.Elapsed.TotalSeconds);
-                            RaiseProgress(VerifyingWriteProgress(100));
 
                             overallSw.Stop();
                             return FirmwareUpdateResult.Fail(
@@ -679,143 +684,6 @@ namespace GeneralUpdate.Firmware
                 RaiseWarning(string.Format("Rollback failed: {0}", rollbackEx.Message), "FW_ROLLBACK_EXCEPTION");
             }
         }
-
-        // ============================================================
-        // Safe invoke helpers
-        // ============================================================
-
-        private static void SafeInvoke<T1, T2>(Action<T1, T2> callback, T1 arg1, T2 arg2)
-        {
-            if (callback == null) return;
-            try { callback(arg1, arg2); }
-            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
-        }
-
-        private static void SafeInvoke<T>(Action<T> callback, T arg)
-        {
-            if (callback == null) return;
-            try { callback(arg); }
-            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
-        }
-
-        // ============================================================
-        // Platform detection and strategy resolution
-        // ============================================================
-
-        /// <summary>
-        /// Merges fluent-registered callbacks into <see cref="FirmwareConfig"/> so that
-        /// strategies and validators can fire them internally without needing separate
-        /// callback parameters.
-        /// </summary>
-        private void MergeCallbacksIntoConfig()
-        {
-            _config.OnStageChanged     += _onStageChanged;
-            _config.OnProgress          += _onProgress;
-            _config.OnDownloadProgress  += _onDownloadProgress;
-            _config.OnCompleted         += _onCompleted;
-            _config.OnFailed            += _onFailed;
-            _config.OnWarning           += _onWarning;
-        }
-
-        // ============================================================
-        // Internal helpers — callback invocation
-        // ============================================================
-
-        /// <summary>
-        /// Fires OnStageChanged on both fluent-registered handlers and config-registered handlers.
-        /// </summary>
-        private void RaiseStageChanged(FirmwareUpdateStage stage, string description)
-        {
-            FirmwareTrace.Info("Stage: {0} — {1}", stage, description);
-
-            SafeInvoke(_onStageChanged, stage, description);
-            SafeInvoke(_config.OnStageChanged, stage, description);
-        }
-
-        /// <summary>
-        /// Fires OnProgress on both fluent-registered handlers and config-registered handlers.
-        /// </summary>
-        private void RaiseProgress(FirmwareProgressInfo info)
-        {
-            SafeInvoke(_onProgress, info);
-            SafeInvoke(_config.OnProgress, info);
-        }
-
-        /// <summary>
-        /// Fires OnWarning on both fluent-registered handlers and config-registered handlers.
-        /// </summary>
-        private void RaiseWarning(string message, string code)
-        {
-            SafeInvoke(_onWarning, message, code);
-            SafeInvoke(_config.OnWarning, message, code);
-        }
-
-        /// <summary>
-        /// Fires the appropriate result callback (OnCompleted or OnFailed) and the final stage.
-        /// </summary>
-        private void RaiseResultCallbacks(FirmwareUpdateResult result)
-        {
-            if (result.Success)
-            {
-                RaiseStageChanged(FirmwareUpdateStage.Completed, string.Format(
-                    "Firmware update completed. Version: {0}, Duration: {1:F1}s",
-                    result.AppliedVersion ?? "(unknown)",
-                    result.Duration.TotalSeconds));
-
-                SafeInvoke(_onCompleted, result);
-                SafeInvoke(_config.OnCompleted, result);
-            }
-            else
-            {
-                RaiseStageChanged(FirmwareUpdateStage.Failed, string.Format(
-                    "[{0}] {1}",
-                    result.ErrorCode ?? "FW_FAILED",
-                    result.Message));
-
-                SafeInvoke(_onFailed, result);
-                SafeInvoke(_config.OnFailed, result);
-            }
-        }
-
-        // ============================================================
-        // Progress helpers — weighted progress across stages
-        // ============================================================
-
-        /// <summary>
-        /// Stage weights for overall progress calculation.
-        /// ValidatingDevice=5%, BackingUp=15%, Downloading=50%, ValidatingFirmware=10%, Flashing=20%.
-        /// </summary>
-        private static FirmwareProgressInfo ValidatingDeviceProgress(float stagePct) => new FirmwareProgressInfo
-        {
-            Stage = FirmwareUpdateStage.ValidatingDevice,
-            StageProgressPercent = stagePct,
-            OverallProgressPercent = stagePct * 0.05f,
-            StatusText = string.Format("Validating device... {0:F0}%", stagePct)
-        };
-
-        private static FirmwareProgressInfo BackingUpProgress(float stagePct) => new FirmwareProgressInfo
-        {
-            Stage = FirmwareUpdateStage.BackingUp,
-            StageProgressPercent = stagePct,
-            OverallProgressPercent = 5f + stagePct * 0.15f,
-            StatusText = string.Format("Backing up firmware... {0:F0}%", stagePct)
-        };
-
-        private static FirmwareProgressInfo ValidatingFirmwareProgress(float stagePct) => new FirmwareProgressInfo
-        {
-            Stage = FirmwareUpdateStage.ValidatingFirmware,
-            StageProgressPercent = stagePct,
-            OverallProgressPercent = 70f + stagePct * 0.10f,
-            StatusText = string.Format("Validating firmware... {0:F0}%", stagePct)
-        };
-
-        private static FirmwareProgressInfo FlashingProgress(float stagePct) => new FirmwareProgressInfo
-        {
-            Stage = FirmwareUpdateStage.Flashing,
-            StageProgressPercent = stagePct,
-            OverallProgressPercent = 80f + stagePct * 0.20f,
-            StatusText = string.Format("Flashing firmware... {0:F0}%", stagePct)
-        };
 
         // ============================================================
         // Safe invoke helpers

--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -445,6 +445,128 @@ namespace GeneralUpdate.Firmware
             }
         }
 
+        // ============================================================
+        // Internal helpers — callback invocation
+        // ============================================================
+
+        /// <summary>
+        /// Fires OnStageChanged on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseStageChanged(FirmwareUpdateStage stage, string description)
+        {
+            FirmwareTrace.Info("Stage: {0} — {1}", stage, description);
+
+            SafeInvoke(_onStageChanged, stage, description);
+            SafeInvoke(_config.OnStageChanged, stage, description);
+        }
+
+        /// <summary>
+        /// Fires OnProgress on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseProgress(FirmwareProgressInfo info)
+        {
+            SafeInvoke(_onProgress, info);
+            SafeInvoke(_config.OnProgress, info);
+        }
+
+        /// <summary>
+        /// Fires OnWarning on both fluent-registered handlers and config-registered handlers.
+        /// </summary>
+        private void RaiseWarning(string message, string code)
+        {
+            SafeInvoke(_onWarning, message, code);
+            SafeInvoke(_config.OnWarning, message, code);
+        }
+
+        /// <summary>
+        /// Fires the appropriate result callback (OnCompleted or OnFailed) and the final stage.
+        /// </summary>
+        private void RaiseResultCallbacks(FirmwareUpdateResult result)
+        {
+            if (result.Success)
+            {
+                RaiseStageChanged(FirmwareUpdateStage.Completed, string.Format(
+                    "Firmware update completed. Version: {0}, Duration: {1:F1}s",
+                    result.AppliedVersion ?? "(unknown)",
+                    result.Duration.TotalSeconds));
+
+                SafeInvoke(_onCompleted, result);
+                SafeInvoke(_config.OnCompleted, result);
+            }
+            else
+            {
+                RaiseStageChanged(FirmwareUpdateStage.Failed, string.Format(
+                    "[{0}] {1}",
+                    result.ErrorCode ?? "FW_FAILED",
+                    result.Message));
+
+                SafeInvoke(_onFailed, result);
+                SafeInvoke(_config.OnFailed, result);
+            }
+        }
+
+        // ============================================================
+        // Progress helpers — weighted progress across stages
+        // ============================================================
+
+        /// <summary>
+        /// Stage weights for overall progress calculation.
+        /// ValidatingDevice=5%, BackingUp=15%, Downloading=50%, ValidatingFirmware=10%, Flashing=20%.
+        /// </summary>
+        private static FirmwareProgressInfo ValidatingDeviceProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.ValidatingDevice,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = stagePct * 0.05f,
+            StatusText = string.Format("Validating device... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo BackingUpProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.BackingUp,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 5f + stagePct * 0.15f,
+            StatusText = string.Format("Backing up firmware... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo ValidatingFirmwareProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.ValidatingFirmware,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 70f + stagePct * 0.10f,
+            StatusText = string.Format("Validating firmware... {0:F0}%", stagePct)
+        };
+
+        private static FirmwareProgressInfo FlashingProgress(float stagePct) => new FirmwareProgressInfo
+        {
+            Stage = FirmwareUpdateStage.Flashing,
+            StageProgressPercent = stagePct,
+            OverallProgressPercent = 80f + stagePct * 0.20f,
+            StatusText = string.Format("Flashing firmware... {0:F0}%", stagePct)
+        };
+
+        // ============================================================
+        // Safe invoke helpers
+        // ============================================================
+
+        private static void SafeInvoke<T1, T2>(Action<T1, T2> callback, T1 arg1, T2 arg2)
+        {
+            if (callback == null) return;
+            try { callback(arg1, arg2); }
+            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
+        }
+
+        private static void SafeInvoke<T>(Action<T> callback, T arg)
+        {
+            if (callback == null) return;
+            try { callback(arg); }
+            catch (Exception ex) { FirmwareTrace.Warn("Callback exception (ignored): {0}", ex.Message); }
+        }
+
+        // ============================================================
+        // Platform detection and strategy resolution
+        // ============================================================
+
         /// <summary>
         /// Merges fluent-registered callbacks into <see cref="FirmwareConfig"/> so that
         /// strategies and validators can fire them internally without needing separate

--- a/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
+++ b/src/c#/GeneralUpdate.Firmware/GeneralFirmwareBootstrap.cs
@@ -445,6 +445,21 @@ namespace GeneralUpdate.Firmware
             }
         }
 
+        /// <summary>
+        /// Merges fluent-registered callbacks into <see cref="FirmwareConfig"/> so that
+        /// strategies and validators can fire them internally without needing separate
+        /// callback parameters.
+        /// </summary>
+        private void MergeCallbacksIntoConfig()
+        {
+            _config.OnStageChanged     += _onStageChanged;
+            _config.OnProgress          += _onProgress;
+            _config.OnDownloadProgress  += _onDownloadProgress;
+            _config.OnCompleted         += _onCompleted;
+            _config.OnFailed            += _onFailed;
+            _config.OnWarning           += _onWarning;
+        }
+
         // ============================================================
         // Internal helpers — callback invocation
         // ============================================================

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareConfig.cs
@@ -108,6 +108,29 @@ namespace GeneralUpdate.Firmware.Models
         public string BackupDirectory { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to verify the written firmware by reading it back
+        /// from the device and comparing with the source file.
+        /// Default value is true (safe-by-default).
+        /// Verification uses chunked comparison to keep memory usage low.
+        /// </summary>
+        public bool EnableWriteVerify { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to automatically restore the backup if flashing fails.
+        /// When enabled and a backup exists, the original firmware is written back
+        /// to the device automatically on flash failure.
+        /// Default value is true (safe-by-default).
+        /// Requires <see cref="BackupEnabled"/> to be true for the backup to exist.
+        /// </summary>
+        public bool EnableAutoRollback { get; set; } = true;
+
+        /// <summary>
+        /// Set internally by <see cref="Strategy.IFirmwareStrategy.BackupCurrentFirmwareAsync"/>
+        /// after a successful backup. Used for automatic rollback if flashing fails.
+        /// </summary>
+        internal string LastBackupPath { get; set; }
+
+        /// <summary>
         /// Gets or sets whether to require user confirmation before proceeding with the update.
         /// Default value is false (headless/automated by default).
         /// </summary>

--- a/src/c#/GeneralUpdate.Firmware/Models/FirmwareUpdateStage.cs
+++ b/src/c#/GeneralUpdate.Firmware/Models/FirmwareUpdateStage.cs
@@ -25,6 +25,12 @@ namespace GeneralUpdate.Firmware.Models
         /// <summary>Writing (flashing) the firmware to the target device.</summary>
         Flashing,
 
+        /// <summary>Verifying that the firmware was written correctly by comparing with source.</summary>
+        VerifyingWrite,
+
+        /// <summary>Restoring the original firmware from a backup after a failed update.</summary>
+        RollingBack,
+
         /// <summary>The firmware update completed successfully.</summary>
         Completed,
 

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
@@ -250,6 +250,7 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                     "Backup completed. {0} bytes written to {1}",
                     totalBytesRead,
                     backupPath);
+                config.LastBackupPath = backupPath;
                 FirmwareTrace.EndOperation("LinuxFirmwareBackup", TimeSpan.Zero, true);
                 return true;
             }
@@ -469,6 +470,25 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
 
                 writeSw.Stop();
 
+                // === Write-verify: read back and compare with source ===
+                bool verified = true;
+                if (config.EnableWriteVerify)
+                {
+                    verified = await VerifyWrittenDataAsync(
+                        firmwareFilePath, config, firmwareSize, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (!verified)
+                    {
+                        timer.Stop();
+                        FirmwareTrace.EndOperation("LinuxApplyFirmware", timer.Elapsed, false);
+                        return FirmwareUpdateResult.Fail(
+                            "Write verification failed: data read back from device does not match source.",
+                            "FW_LINUX_VERIFY_FAILED",
+                            duration: timer.Elapsed);
+                    }
+                }
+
                 timer.Stop();
                 double speedMBps = (totalWritten / (1024.0 * 1024.0)) / writeSw.Elapsed.TotalSeconds;
                 FirmwareTrace.Info(
@@ -643,6 +663,111 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
             catch (Exception ex)
             {
                 FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that data written to the device matches the source firmware file.
+        /// Reads back from the device in chunks and compares with the source.
+        /// Reports progress via <see cref="FirmwareConfig.OnProgress"/>.
+        /// </summary>
+        private async Task<bool> VerifyWrittenDataAsync(
+            string firmwareFilePath,
+            FirmwareConfig config,
+            long expectedSize,
+            CancellationToken cancellationToken)
+        {
+            FireProgress(config, FirmwareUpdateStage.VerifyingWrite, 0, 100f, "Verifying written data...");
+            FirmwareTrace.Info("Starting write-verify. Expected size: {0} bytes", expectedSize);
+
+            try
+            {
+                var verifySw = System.Diagnostics.Stopwatch.StartNew();
+                var sourceBuffer = new byte[1024 * 1024];
+                var deviceBuffer = new byte[1024 * 1024];
+                long totalVerified = 0;
+                long lastReportMs = 0;
+
+                using (var sourceStream = new FileStream(
+                    firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                    bufferSize: 1024 * 1024, useAsync: true))
+                using (var deviceStream = new FileStream(
+                    config.DevicePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+                    bufferSize: 1024 * 1024, useAsync: true))
+                {
+                    while (totalVerified < expectedSize)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        int sourceBytes = await sourceStream.ReadAsync(
+                            sourceBuffer, 0, sourceBuffer.Length, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (sourceBytes == 0) break;
+
+                        int devicePos = 0;
+                        while (devicePos < sourceBytes)
+                        {
+                            int deviceBytes = await deviceStream.ReadAsync(
+                                deviceBuffer, devicePos, sourceBytes - devicePos, cancellationToken)
+                                .ConfigureAwait(false);
+
+                            if (deviceBytes == 0)
+                            {
+                                FirmwareTrace.Error("Device read returned 0 bytes at offset {0}", totalVerified + devicePos);
+                                return false;
+                            }
+                            devicePos += deviceBytes;
+                        }
+
+                        // Compare
+                        for (int i = 0; i < sourceBytes; i++)
+                        {
+                            if (sourceBuffer[i] != deviceBuffer[i])
+                            {
+                                long badOffset = totalVerified + i;
+                                FirmwareTrace.Error(
+                                    "Write-verify mismatch at byte {0}: expected 0x{1:X2}, got 0x{2:X2}",
+                                    badOffset, sourceBuffer[i], deviceBuffer[i]);
+                                return false;
+                            }
+                        }
+
+                        totalVerified += sourceBytes;
+
+                        long elapsedMs = verifySw.ElapsedMilliseconds;
+                        if (elapsedMs - lastReportMs >= 500 || totalVerified >= expectedSize)
+                        {
+                            float pct = expectedSize > 0 ? (float)totalVerified / expectedSize * 100f : 0f;
+                            FireProgress(config, FirmwareUpdateStage.VerifyingWrite,
+                                pct, 100f,
+                                string.Format(CultureInfo.InvariantCulture,
+                                    "Verifying... {0}/{1} MB",
+                                    totalVerified / (1024 * 1024),
+                                    expectedSize / (1024 * 1024)));
+                            lastReportMs = elapsedMs;
+                        }
+                    }
+                }
+
+                verifySw.Stop();
+                double speedMBps = (totalVerified / (1024.0 * 1024.0)) / verifySw.Elapsed.TotalSeconds;
+                FirmwareTrace.Info(
+                    "Write-verify passed. {0} bytes verified in {1:F1}s ({2:F1} MB/s)",
+                    totalVerified, verifySw.Elapsed.TotalSeconds, speedMBps);
+
+                FireProgress(config, FirmwareUpdateStage.VerifyingWrite, 100f, 100f, "Verification passed.");
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                FirmwareTrace.Warn("Write-verify cancelled.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Error("Write-verify failed with exception", ex);
+                return false;
             }
         }
     }

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/LinuxFirmwareStrategy.cs
@@ -378,35 +378,103 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                 connection = Connections.ConnectionFactory.Create(config.Connection);
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-                byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
+                // === Chunked streaming write with progress ===
+                // Avoids File.ReadAllBytes — large firmware files won't OOM.
+                // Each 1 MB chunk is read, written, and reported independently.
+                var chunkBuffer = new byte[1024 * 1024]; // 1 MB chunks
+                long totalWritten = 0;
+                var writeSw = System.Diagnostics.Stopwatch.StartNew();
+                long lastReportBytes = 0;
+                long lastReportMs = 0;
+                var speedSamples = new System.Collections.Generic.Queue<double>(4);
 
-                // Fire progress: flashing starts
-                FireProgress(config, FirmwareUpdateStage.Flashing, 0, 80f,
-                    string.Format(CultureInfo.InvariantCulture, "Writing firmware... {0} MB", firmwareData.Length / (1024 * 1024)));
-
-                // Legacy callback (deprecated but still supported)
-#pragma warning disable 618
-                if (config.ProgressCallback != null)
+                using (var fileStream = new FileStream(
+                    firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                    bufferSize: 1024 * 1024, useAsync: true))
                 {
-                    try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
-                    catch (Exception ex) { FirmwareTrace.Warn("Progress callback error: {0}", ex.Message); }
-                }
+                    int bytesRead;
+                    while ((bytesRead = await fileStream.ReadAsync(
+                        chunkBuffer, 0, chunkBuffer.Length, cancellationToken)
+                        .ConfigureAwait(false)) > 0)
+                    {
+                        // Write this chunk to the device
+                        if (bytesRead == chunkBuffer.Length)
+                        {
+                            await connection.WriteAsync(chunkBuffer, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // Last chunk: copy to correctly-sized array
+                            byte[] lastChunk = new byte[bytesRead];
+                            Array.Copy(chunkBuffer, 0, lastChunk, 0, bytesRead);
+                            await connection.WriteAsync(lastChunk, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+
+                        totalWritten += bytesRead;
+
+                        // Report progress at ~500 ms intervals
+                        long elapsedMs = writeSw.ElapsedMilliseconds;
+                        if (elapsedMs - lastReportMs >= 500 || totalWritten == firmwareSize)
+                        {
+                            double deltaBytes = totalWritten - lastReportBytes;
+                            double deltaSecs = (elapsedMs - lastReportMs) / 1000.0;
+                            double instantSpeed = deltaSecs > 0 ? deltaBytes / deltaSecs : 0;
+
+                            speedSamples.Enqueue(instantSpeed);
+                            if (speedSamples.Count > 3) speedSamples.Dequeue();
+                            double avgSpeed = 0;
+                            foreach (var s in speedSamples) avgSpeed += s;
+                            avgSpeed = speedSamples.Count > 0 ? avgSpeed / speedSamples.Count : instantSpeed;
+
+                            TimeSpan eta = firmwareSize > 0 && avgSpeed > 0
+                                ? TimeSpan.FromSeconds((firmwareSize - totalWritten) / avgSpeed)
+                                : TimeSpan.Zero;
+
+                            float stagePct = firmwareSize > 0
+                                ? (float)totalWritten / firmwareSize * 100f
+                                : 0f;
+
+                            FireProgress(config, FirmwareUpdateStage.Flashing,
+                                stagePct,
+                                80f + (stagePct * 0.20f),
+                                string.Format(CultureInfo.InvariantCulture,
+                                    "Flashing... {0}/{1} MB | {2:F1} MB/s",
+                                    totalWritten / (1024 * 1024),
+                                    firmwareSize / (1024 * 1024),
+                                    avgSpeed / (1024 * 1024)));
+
+                            // Fire download-style callback (bytes, total, speed, eta) for flashing too
+                            if (config.OnDownloadProgress != null)
+                            {
+                                try { config.OnDownloadProgress(totalWritten, firmwareSize, avgSpeed, eta); }
+                                catch (Exception ex) { FirmwareTrace.Warn("OnDownloadProgress error: {0}", ex.Message); }
+                            }
+
+                            // Legacy callback
+#pragma warning disable 618
+                            if (config.ProgressCallback != null)
+                            {
+                                try { config.ProgressCallback(totalWritten, firmwareSize); }
+                                catch (Exception ex) { FirmwareTrace.Warn("Legacy callback error: {0}", ex.Message); }
+                            }
 #pragma warning restore 618
 
-                // Fire progress: writing
-                FireProgress(config, FirmwareUpdateStage.Flashing, 50f, 90f, "Writing firmware to device...");
+                            lastReportBytes = totalWritten;
+                            lastReportMs = elapsedMs;
+                        }
+                    }
+                }
 
-                await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
-
-                // Fire progress: write complete
-                FireProgress(config, FirmwareUpdateStage.Flashing, 100f, 100f, "Firmware written successfully.");
+                writeSw.Stop();
 
                 timer.Stop();
-                double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
+                double speedMBps = (totalWritten / (1024.0 * 1024.0)) / writeSw.Elapsed.TotalSeconds;
                 FirmwareTrace.Info(
                     "Firmware written successfully. {0} bytes in {1:F1}s ({2:F1} MB/s)",
-                    firmwareData.Length,
-                    timer.Elapsed.TotalSeconds,
+                    totalWritten,
+                    writeSw.Elapsed.TotalSeconds,
                     speedMBps);
                 FirmwareTrace.EndOperation("LinuxApplyFirmware", timer.Elapsed, true);
 

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
@@ -352,34 +352,102 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                 connection = Connections.ConnectionFactory.Create(config.Connection);
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-                byte[] firmwareData = File.ReadAllBytes(firmwareFilePath);
+                // === Chunked streaming write with progress ===
+                // Avoids File.ReadAllBytes — large firmware files won't OOM.
+                // Each 1 MB chunk is read, written, and reported independently.
+                var chunkBuffer = new byte[1024 * 1024]; // 1 MB chunks
+                long totalWritten = 0;
+                var writeSw = Stopwatch.StartNew();
+                long lastReportBytes = 0;
+                long lastReportMs = 0;
+                var speedSamples = new System.Collections.Generic.Queue<double>(4);
 
-                // Fire progress: flashing starts
-                FireProgress(config, FirmwareUpdateStage.Flashing, 0, 80f,
-                    string.Format(CultureInfo.InvariantCulture, "Writing firmware... {0} MB", firmwareData.Length / (1024 * 1024)));
-
-                // Legacy callback (deprecated but still supported)
-#pragma warning disable 618
-                if (config.ProgressCallback != null)
+                using (var fileStream = new FileStream(
+                    firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                    bufferSize: 1024 * 1024, useAsync: true))
                 {
-                    try { config.ProgressCallback(firmwareData.Length, firmwareData.Length); }
-                    catch (Exception ex) { FirmwareTrace.Warn("Callback error: {0}", ex.Message); }
-                }
+                    int bytesRead;
+                    while ((bytesRead = await fileStream.ReadAsync(
+                        chunkBuffer, 0, chunkBuffer.Length, cancellationToken)
+                        .ConfigureAwait(false)) > 0)
+                    {
+                        // Write this chunk to the device
+                        if (bytesRead == chunkBuffer.Length)
+                        {
+                            await connection.WriteAsync(chunkBuffer, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // Last chunk: copy to correctly-sized array
+                            byte[] lastChunk = new byte[bytesRead];
+                            Array.Copy(chunkBuffer, 0, lastChunk, 0, bytesRead);
+                            await connection.WriteAsync(lastChunk, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+
+                        totalWritten += bytesRead;
+
+                        // Report progress at ~500 ms intervals
+                        long elapsedMs = writeSw.ElapsedMilliseconds;
+                        if (elapsedMs - lastReportMs >= 500 || totalWritten == firmwareSize)
+                        {
+                            double deltaBytes = totalWritten - lastReportBytes;
+                            double deltaSecs = (elapsedMs - lastReportMs) / 1000.0;
+                            double instantSpeed = deltaSecs > 0 ? deltaBytes / deltaSecs : 0;
+
+                            speedSamples.Enqueue(instantSpeed);
+                            if (speedSamples.Count > 3) speedSamples.Dequeue();
+                            double avgSpeed = 0;
+                            foreach (var s in speedSamples) avgSpeed += s;
+                            avgSpeed = speedSamples.Count > 0 ? avgSpeed / speedSamples.Count : instantSpeed;
+
+                            TimeSpan eta = firmwareSize > 0 && avgSpeed > 0
+                                ? TimeSpan.FromSeconds((firmwareSize - totalWritten) / avgSpeed)
+                                : TimeSpan.Zero;
+
+                            float stagePct = firmwareSize > 0
+                                ? (float)totalWritten / firmwareSize * 100f
+                                : 0f;
+
+                            FireProgress(config, FirmwareUpdateStage.Flashing,
+                                stagePct,
+                                80f + (stagePct * 0.20f),
+                                string.Format(CultureInfo.InvariantCulture,
+                                    "Flashing... {0}/{1} MB | {2:F1} MB/s",
+                                    totalWritten / (1024 * 1024),
+                                    firmwareSize / (1024 * 1024),
+                                    avgSpeed / (1024 * 1024)));
+
+                            // Fire download-style callback (bytes, total, speed, eta) for flashing too
+                            if (config.OnDownloadProgress != null)
+                            {
+                                try { config.OnDownloadProgress(totalWritten, firmwareSize, avgSpeed, eta); }
+                                catch (Exception ex) { FirmwareTrace.Warn("OnDownloadProgress error: {0}", ex.Message); }
+                            }
+
+                            // Legacy callback
+#pragma warning disable 618
+                            if (config.ProgressCallback != null)
+                            {
+                                try { config.ProgressCallback(totalWritten, firmwareSize); }
+                                catch (Exception ex) { FirmwareTrace.Warn("Legacy callback error: {0}", ex.Message); }
+                            }
 #pragma warning restore 618
 
-                // Fire progress: writing
-                FireProgress(config, FirmwareUpdateStage.Flashing, 50f, 90f, "Writing firmware to device...");
+                            lastReportBytes = totalWritten;
+                            lastReportMs = elapsedMs;
+                        }
+                    }
+                }
 
-                await connection.WriteAsync(firmwareData, cancellationToken).ConfigureAwait(false);
-
-                // Fire progress: write complete
-                FireProgress(config, FirmwareUpdateStage.Flashing, 100f, 100f, "Firmware written successfully.");
+                writeSw.Stop();
 
                 timer.Stop();
-                double speedMBps = (firmwareData.Length / (1024.0 * 1024.0)) / timer.Elapsed.TotalSeconds;
+                double speedMBps = (totalWritten / (1024.0 * 1024.0)) / writeSw.Elapsed.TotalSeconds;
                 FirmwareTrace.Info(
                     "Write complete. {0} bytes in {1:F1}s ({2:F1} MB/s)",
-                    firmwareData.Length, timer.Elapsed.TotalSeconds, speedMBps);
+                    totalWritten, writeSw.Elapsed.TotalSeconds, speedMBps);
                 FirmwareTrace.EndOperation("WindowsApplyFirmware", timer.Elapsed, true);
 
                 return FirmwareUpdateResult.Succeed(config.Connection.Type.ToString(), timer.Elapsed);

--- a/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
+++ b/src/c#/GeneralUpdate.Firmware/Strategy/Platforms/WindowsFirmwareStrategy.cs
@@ -234,6 +234,7 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
 
                 double sizeMB = totalBytesRead / (1024.0 * 1024.0);
                 FirmwareTrace.Info("Backup completed: {0:F1} MB → {1}", sizeMB, backupPath);
+                config.LastBackupPath = backupPath;
                 FirmwareTrace.EndOperation("WindowsFirmwareBackup", TimeSpan.Zero, true);
                 return true;
             }
@@ -442,6 +443,25 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
                 }
 
                 writeSw.Stop();
+
+                // === Write-verify: read back and compare with source ===
+                bool verified = true;
+                if (config.EnableWriteVerify)
+                {
+                    verified = await VerifyWrittenDataAsync(
+                        firmwareFilePath, config, firmwareSize, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (!verified)
+                    {
+                        timer.Stop();
+                        FirmwareTrace.EndOperation("WindowsApplyFirmware", timer.Elapsed, false);
+                        return FirmwareUpdateResult.Fail(
+                            "Write verification failed: data read back from device does not match source.",
+                            "FW_WINDOWS_VERIFY_FAILED",
+                            duration: timer.Elapsed);
+                    }
+                }
 
                 timer.Stop();
                 double speedMBps = (totalWritten / (1024.0 * 1024.0)) / writeSw.Elapsed.TotalSeconds;
@@ -688,6 +708,111 @@ namespace GeneralUpdate.Firmware.Strategy.Platforms
             catch (Exception ex)
             {
                 FirmwareTrace.Warn("Progress callback threw an exception (ignored): {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that data written to the device matches the source firmware file.
+        /// Reads back from the device in chunks and compares with the source.
+        /// Reports progress via <see cref="FirmwareConfig.OnProgress"/>.
+        /// </summary>
+        private async Task<bool> VerifyWrittenDataAsync(
+            string firmwareFilePath,
+            FirmwareConfig config,
+            long expectedSize,
+            CancellationToken cancellationToken)
+        {
+            FireProgress(config, FirmwareUpdateStage.VerifyingWrite, 0, 100f, "Verifying written data...");
+            FirmwareTrace.Info("Starting write-verify. Expected size: {0} bytes", expectedSize);
+
+            try
+            {
+                var verifySw = Stopwatch.StartNew();
+                var sourceBuffer = new byte[1024 * 1024];
+                var deviceBuffer = new byte[1024 * 1024];
+                long totalVerified = 0;
+                long lastReportMs = 0;
+
+                using (var sourceStream = new FileStream(
+                    firmwareFilePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                    bufferSize: 1024 * 1024, useAsync: true))
+                using (var deviceStream = new FileStream(
+                    config.DevicePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+                    bufferSize: 1024 * 1024, useAsync: true))
+                {
+                    while (totalVerified < expectedSize)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        int sourceBytes = await sourceStream.ReadAsync(
+                            sourceBuffer, 0, sourceBuffer.Length, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (sourceBytes == 0) break;
+
+                        int devicePos = 0;
+                        while (devicePos < sourceBytes)
+                        {
+                            int deviceBytes = await deviceStream.ReadAsync(
+                                deviceBuffer, devicePos, sourceBytes - devicePos, cancellationToken)
+                                .ConfigureAwait(false);
+
+                            if (deviceBytes == 0)
+                            {
+                                FirmwareTrace.Error("Device read returned 0 bytes at offset {0}", totalVerified + devicePos);
+                                return false;
+                            }
+                            devicePos += deviceBytes;
+                        }
+
+                        // Compare
+                        for (int i = 0; i < sourceBytes; i++)
+                        {
+                            if (sourceBuffer[i] != deviceBuffer[i])
+                            {
+                                long badOffset = totalVerified + i;
+                                FirmwareTrace.Error(
+                                    "Write-verify mismatch at byte {0}: expected 0x{1:X2}, got 0x{2:X2}",
+                                    badOffset, sourceBuffer[i], deviceBuffer[i]);
+                                return false;
+                            }
+                        }
+
+                        totalVerified += sourceBytes;
+
+                        long elapsedMs = verifySw.ElapsedMilliseconds;
+                        if (elapsedMs - lastReportMs >= 500 || totalVerified >= expectedSize)
+                        {
+                            float pct = expectedSize > 0 ? (float)totalVerified / expectedSize * 100f : 0f;
+                            FireProgress(config, FirmwareUpdateStage.VerifyingWrite,
+                                pct, 100f,
+                                string.Format(CultureInfo.InvariantCulture,
+                                    "Verifying... {0}/{1} MB",
+                                    totalVerified / (1024 * 1024),
+                                    expectedSize / (1024 * 1024)));
+                            lastReportMs = elapsedMs;
+                        }
+                    }
+                }
+
+                verifySw.Stop();
+                double speedMBps = (totalVerified / (1024.0 * 1024.0)) / verifySw.Elapsed.TotalSeconds;
+                FirmwareTrace.Info(
+                    "Write-verify passed. {0} bytes verified in {1:F1}s ({2:F1} MB/s)",
+                    totalVerified, verifySw.Elapsed.TotalSeconds, speedMBps);
+
+                FireProgress(config, FirmwareUpdateStage.VerifyingWrite, 100f, 100f, "Verification passed.");
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                FirmwareTrace.Warn("Write-verify cancelled.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                FirmwareTrace.Error("Write-verify failed with exception", ex);
+                return false;
             }
         }
     }


### PR DESCRIPTION
Closes #250

## Summary

Add two safety mechanisms to firmware update pipeline:

### Write-Verify
After flashing completes, reads back the written data from the device and compares it byte-for-byte with the source firmware file in 1MB chunks. Reports verification progress and speed. If any byte mismatches, the update is marked as failed.

Controlled by `FirmwareConfig.EnableWriteVerify` (default: `true`).

### Auto-Rollback
If flashing fails (or an unexpected exception/cancellation occurs), automatically restores the original firmware from the backup file created earlier. Uses the same `ApplyFirmwareAsync` path to write the backup back to the device.

Controlled by `FirmwareConfig.EnableAutoRollback` (default: `true`).
Requires `BackupEnabled = true` for the backup to exist.

## Changes

| File | Change |
|---|---|
| `Models/FirmwareUpdateStage.cs` | Add `VerifyingWrite`, `RollingBack` stages |
| `Models/FirmwareConfig.cs` | Add `EnableWriteVerify`, `EnableAutoRollback`, `LastBackupPath` |
| `GeneralFirmwareBootstrap.cs` | Rollback orchestration in `ExecuteAsync` + `TryRollbackAsync` helper |
| `LinuxFirmwareStrategy.cs` | Write-verify in `ApplyDirectWriteAsync` + `VerifyWrittenDataAsync`; set `LastBackupPath` in backup |
| `WindowsFirmwareStrategy.cs` | Same as above |

## Usage

```csharp
var result = await GeneralFirmwareBootstrap.Create(config =>
{
    config.FirmwareUrl = "https://ota.example.com/fw.bin";
    config.DevicePath = "/dev/mmcblk0";
    config.BackupEnabled = true;        // needed for rollback
    config.EnableWriteVerify = true;    // default true
    config.EnableAutoRollback = true;   // default true
})
.UseDefaultStrategy()
.OnStageChanged((stage, desc) => Console.WriteLine($"[{stage}] {desc}"))
.OnFailed(r => Console.WriteLine($"FAIL: {r.Message}"))
.ExecuteAsync();
```

## Pipeline (updated)

```
ValidatingDevice → BackingUp → Downloading → ValidatingFirmware
    → Flashing → VerifyingWrite → Completed
                    ↓ (fail)
              RollingBack → Failed (rolled back)
```