### PR TITLE
fix: SkipDirectorys should match directory name, not full path

### DIFF
--- a/src/c#/GeneralUpdate.Common/FileBasic/BlackListManager.cs
+++ b/src/c#/GeneralUpdate.Common/FileBasic/BlackListManager.cs
@@ -133,7 +133,7 @@ public class BlackListManager
 
     public bool IsSkipDirectory(string directory)
     {
-        var dirName = Path.GetFileName(directory);
+        var dirName = new DirectoryInfo(directory).Name;
         return _skipDirectorys.Any(dirName.Contains);
     }
 }

--- a/src/c#/GeneralUpdate.Common/FileBasic/BlackListManager.cs
+++ b/src/c#/GeneralUpdate.Common/FileBasic/BlackListManager.cs
@@ -133,6 +133,7 @@ public class BlackListManager
 
     public bool IsSkipDirectory(string directory)
     {
-        return _skipDirectorys.Any(directory.Contains);
+        var dirName = Path.GetFileName(directory);
+        return _skipDirectorys.Any(dirName.Contains);
     }
 }

--- a/src/c#/GeneralUpdate.Common/FileBasic/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Common/FileBasic/StorageManager.cs
@@ -118,7 +118,7 @@ namespace GeneralUpdate.Common.FileBasic
                     bool shouldSkip = false;
                     foreach (var notBackup in skipDirectorys)
                     {
-                        if (dic.FullName.Contains(notBackup))
+                        if (dic.Name.Contains(notBackup))
                         {
                             shouldSkip = true;
                             break;


### PR DESCRIPTION
## Description
When `SkipDirectorys` is configured (e.g., `{"Logs", "Data", "Backups"}`), the skip check uses substring matching against the **full path** of directories, not just the directory name. This causes directories like `Modules` to be skipped if the installation path happens to contain a skip string (e.g., `C:\Users\xxx\AppData\Local\MyApp\Modules` matches `"Data"` because `AppData` contains `Data`).

## Root Cause
Two locations use `fullPath.Contains(skipDir)` instead of `directoryName.Contains(skipDir)`:

1. `BlackListManager.IsSkipDirectory()` - uses `_skipDirectorys.Any(directory.Contains)` where `directory` is the full path
2. `StorageManager.GetAllFiles()` - uses `dic.FullName.Contains(notBackup)` where `dic.FullName` is the full path

Note: `StorageManager.CopyDirectory()` (used for backup) already correctly uses `Path.GetFileName(dirPath).Contains(name)`.

## Fix
- `BlackListManager.IsSkipDirectory`: use `Path.GetFileName()` to extract only the directory name before checking against skip strings
- `StorageManager.GetAllFiles`: use `dic.Name` instead of `dic.FullName`

Closes #200, Closes #254