### PR TITLE
fix: make GetAllFiles skip-directory check recursive at all levels

### DIFF
--- a/src/c#/GeneralUpdate.Common/FileBasic/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Common/FileBasic/StorageManager.cs
@@ -126,7 +126,7 @@ namespace GeneralUpdate.Common.FileBasic
                     }
 
                     if (!shouldSkip)
-                        files.AddRange(GetAllfiles(dic.FullName));
+                        files.AddRange(GetAllFiles(dic.FullName, skipDirectorys));
                 }
 
                 return files;
@@ -134,26 +134,6 @@ namespace GeneralUpdate.Common.FileBasic
             catch
             {
                 return new List<FileInfo>();
-            }
-        }
-
-        private static List<FileInfo> GetAllfiles(string path)
-        {
-            try
-            {
-                var files = new List<FileInfo>();
-                files.AddRange(new DirectoryInfo(path).GetFiles());
-                var tmpDir = new DirectoryInfo(path).GetDirectories();
-                foreach (var dic in tmpDir)
-                {
-                    files.AddRange(GetAllfiles(dic.FullName));
-                }
-
-                return files;
-            }
-            catch (Exception)
-            {
-                return null;
             }
         }
 


### PR DESCRIPTION
## Description
`GetAllFiles` only checks skip directories at the **top level** of the given path, then delegates to the private `GetAllfiles` method which recursively collects **all** files without any skip filtering.

This causes an inconsistency with `ReadFileNode` (used by `Compare` → `CopyUnknownFiles`), which calls `IsSkipDirectory` at **every** directory level.

## Consequence
In `DefaultDirtyStrategy.ExecuteAsync`, `GetAllFiles` may include files from deeply nested skip directories (e.g., `Modules/Logs/file.txt` when `Logs` is in `SkipDirectorys`), while `ReadFileNode` during `CopyUnknownFiles` would skip those same directories. This mismatch can lead to incorrect patch matching or unexpected behavior.

## Fix
- Changed the recursive call from `GetAllfiles` to `GetAllFiles` so the skip-directory filter applies at every directory level
- Removed the now-unused private `GetAllfiles` method

See also: #254

Closes #256