### PR TITLE
Refactor: Extract IBinaryDiffer and ICompressionProvider abstractions (#258)

### DIFF
--- a/src/c#/GeneralUpdate.Differential/Abstractions/BZip2CompressionProvider.cs
+++ b/src/c#/GeneralUpdate.Differential/Abstractions/BZip2CompressionProvider.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Threading;
+using GeneralUpdate.Differential.Binary;
+
+namespace GeneralUpdate.Differential.Abstractions
+{
+    /// <summary>
+    /// BZip2 compression provider 鈥?preserves backward compatibility with legacy BSDIFF patches.
+    /// Format version byte: 0x00.
+    /// </summary>
+    public sealed class BZip2CompressionProvider : ICompressionProvider
+    {
+        /// <inheritdoc/>
+        public byte FormatVersion => 0x00;
+
+        /// <inheritdoc/>
+        public Stream CreateCompressStream(Stream output, CancellationToken cancellationToken = default)
+        {
+            // BZip2OutputStream is the existing managed BZip2 compressor.
+            // IsStreamOwner = false so disposing the wrapper does not close the underlying stream.
+            return new BZip2OutputStream(output) { IsStreamOwner = false };
+        }
+
+        /// <inheritdoc/>
+        public Stream CreateDecompressStream(Stream input, CancellationToken cancellationToken = default)
+        {
+            // BZip2InputStream is the existing managed BZip2 decompressor.
+            return new BZip2InputStream(input, false);
+        }
+    }
+}

--- a/src/c#/GeneralUpdate.Differential/Abstractions/IBinaryDiffer.cs
+++ b/src/c#/GeneralUpdate.Differential/Abstractions/IBinaryDiffer.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Differential.Abstractions
+{
+    /// <summary>
+    /// Defines a pluggable binary differential algorithm (diff generation and patch application).
+    /// Implementations may use different strategies: BSDIFF, HDiffPatch-style, VCDIFF, etc.
+    /// All methods are stateless 鈥?callers pass file paths and instances are safe for concurrent use.
+    /// </summary>
+    public interface IBinaryDiffer
+    {
+        /// <summary>
+        /// Generates a binary patch from <paramref name="oldFilePath"/> to <paramref name="newFilePath"/>,
+        /// writing the result to <paramref name="patchFilePath"/>.
+        /// </summary>
+        /// <param name="oldFilePath">Old version file path.</param>
+        /// <param name="newFilePath">New version file path.</param>
+        /// <param name="patchFilePath">Output patch file path.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        Task CleanAsync(
+            string oldFilePath,
+            string newFilePath,
+            string patchFilePath,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Applies a binary patch to <paramref name="oldFilePath"/>, producing
+        /// <paramref name="newFilePath"/> using the patch at <paramref name="patchFilePath"/>.
+        /// </summary>
+        /// <param name="oldFilePath">Existing (old) file to patch.</param>
+        /// <param name="newFilePath">Output (new) file path.</param>
+        /// <param name="patchFilePath">Input patch file path.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        Task DirtyAsync(
+            string oldFilePath,
+            string newFilePath,
+            string patchFilePath,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/c#/GeneralUpdate.Differential/Abstractions/ICompressionProvider.cs
+++ b/src/c#/GeneralUpdate.Differential/Abstractions/ICompressionProvider.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Differential.Abstractions
+{
+    /// <summary>
+    /// Defines a pluggable compression strategy for patch data.
+    /// Each patch format version may use a different compression algorithm
+    /// (BZip2 for legacy, Brotli for new, Deflate for compatibility).
+    /// </summary>
+    public interface ICompressionProvider
+    {
+        /// <summary>
+        /// Gets the format identifier byte written into the patch header for version detection.
+        /// 0x00 = BZip2 (legacy BSDIFF), 0x01 = Brotli, 0x02+ = reserved.
+        /// </summary>
+        byte FormatVersion { get; }
+
+        /// <summary>
+        /// Wraps <paramref name="output"/> in a compression stream for writing patch data.
+        /// The caller owns the returned stream and must dispose it.
+        /// </summary>
+        /// <param name="output">The underlying output stream.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A compression stream that writes compressed data to <paramref name="output"/>.</returns>
+        Stream CreateCompressStream(Stream output, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Wraps <paramref name="input"/> in a decompression stream for reading patch data.
+        /// The caller owns the returned stream and must dispose it.
+        /// </summary>
+        /// <param name="input">The underlying input stream containing compressed data.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A decompression stream that reads decompressed data from <paramref name="input"/>.</returns>
+        Stream CreateDecompressStream(Stream input, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/c#/GeneralUpdate.Differential/Binary/BinaryHandler.cs
+++ b/src/c#/GeneralUpdate.Differential/Binary/BinaryHandler.cs
@@ -1,13 +1,17 @@
-﻿using System;
+using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using GeneralUpdate.Differential.Abstractions;
 
 namespace GeneralUpdate.Differential.Binary
 {
     /// <summary>
-    /// File binary differential processing.
+    /// BSDIFF 4.0 file binary differential processing.
+    /// Implements <see cref="IBinaryDiffer"/> for pluggable architecture compatibility.
+    /// Uses BZip2 compression for patch data (see <see cref="BZip2CompressionProvider"/>).
     /// </summary>
-    public class BinaryHandler
+    public class BinaryHandler : IBinaryDiffer
     {
         #region Private Members
 
@@ -16,6 +20,22 @@ namespace GeneralUpdate.Differential.Binary
         private string _oldfilePath, _newfilePath, _patchPath;
 
         #endregion Private Members
+
+        #region IBinaryDiffer Implementation
+
+        /// <inheritdoc/>
+        public Task CleanAsync(string oldFilePath, string newFilePath, string patchFilePath, CancellationToken cancellationToken = default)
+        {
+            return Clean(oldFilePath, newFilePath, patchFilePath);
+        }
+
+        /// <inheritdoc/>
+        public Task DirtyAsync(string oldFilePath, string newFilePath, string patchFilePath, CancellationToken cancellationToken = default)
+        {
+            return Dirty(oldFilePath, newFilePath, patchFilePath);
+        }
+
+        #endregion IBinaryDiffer Implementation
 
         #region Public Methods
 
@@ -42,15 +62,15 @@ namespace GeneralUpdate.Differential.Binary
                     var newBytes = File.ReadAllBytes(_newfilePath);
 
                     /* Header is
-                        0	8	 "BSDIFF40"
-                        8	8	length of bzip2ed ctrl block
-                        16	 8	length of bzip2ed diff block
-                        24	 8	length of new file */
+                        0   8    "BSDIFF40"
+                        8   8   length of bzip2ed ctrl block
+                        16  8   length of bzip2ed diff block
+                        24  8   length of new file */
                     /* File is
-                        0	32	Header
-                        32	??	Bzip2ed ctrl block
-                        ??	??	Bzip2ed diff block
-                        ??	??	Bzip2ed extra block */
+                        0   32  Header
+                        32  ??  Bzip2ed ctrl block
+                        ??  ??  Bzip2ed diff block
+                        ??  ??  Bzip2ed extra block */
                     byte[] header = new byte[c_headerSize];
                     WriteInt64(c_fileSignature, header, 0); // "BSDIFF40"
                     WriteInt64(0, header, 8);
@@ -237,13 +257,13 @@ namespace GeneralUpdate.Differential.Binary
                         Func<Stream> openPatchStream = () =>
                             new FileStream(patchPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                         //File format:
-                        //	0   8   "BSDIFF40"
-                        //	8   8   X
-                        //	16  8   Y
-                        //	24  8   sizeof(newfile)
-                        //	32  X bzip2(control block)
-                        //	32 + X    Y bzip2(diff block)
-                        //	32 + X + Y ??? bzip2(extra block)
+                        //  0   8   "BSDIFF40"
+                        //  8   8   X
+                        //  16  8   Y
+                        //  24  8   sizeof(newfile)
+                        //  32  X   bzip2(control block)
+                        //  32 + X  Y   bzip2(diff block)
+                        //  32 + X + Y ??? bzip2(extra block)
                         //with control block a set of triples(x, y, z) meaning "add x bytes
                         //from oldfile to x bytes from the diff block; copy y bytes from the
                         //extra block; seek forwards in oldfile by z bytes".
@@ -368,7 +388,7 @@ namespace GeneralUpdate.Differential.Binary
                     File.SetAttributes(_oldfilePath, FileAttributes.Normal);
                     File.Delete(_oldfilePath);
                 }
-                
+
                 if (File.Exists(_newfilePath))
                 {
                     File.SetAttributes(_newfilePath, FileAttributes.Normal);
@@ -399,45 +419,47 @@ namespace GeneralUpdate.Differential.Binary
             return 0;
         }
 
-        private int MatchLength(byte[] oldBytes, int oldOffset, byte[] newBytes, int newOffset)
+        private static int MatchLength(byte[] oldData, int oldOffset, byte[] newData, int newOffset)
         {
             int i;
-            for (i = 0; i < oldBytes.Length - oldOffset && i < newBytes.Length - newOffset; i++)
+            for (i = 0; i < oldData.Length - oldOffset && i < newData.Length - newOffset; i++)
             {
-                if (oldBytes[i + oldOffset] != newBytes[i + newOffset])
-                    break;
+                if (oldData[i + oldOffset] != newData[i + newOffset]) break;
             }
             return i;
         }
 
-        private int Search(int[] I, byte[] oldBytes, byte[] newBytes, int newOffset, int start, int end, out int pos)
+        private static int Search(int[] I, byte[] oldData, byte[] newData, int newOffset, int start, int end, out int pos)
         {
             if (end - start < 2)
             {
-                int startLength = MatchLength(oldBytes, I[start], newBytes, newOffset);
-                int endLength = MatchLength(oldBytes, I[end], newBytes, newOffset);
+                int x = MatchLength(oldData, I[start], newData, newOffset);
+                int y = MatchLength(oldData, I[end], newData, newOffset);
 
-                if (startLength > endLength)
+                if (x > y)
                 {
                     pos = I[start];
-                    return startLength;
+                    return x;
                 }
                 else
                 {
                     pos = I[end];
-                    return endLength;
+                    return y;
                 }
+            }
+
+            int mid = start + (end - start) / 2;
+            if (CompareBytes(oldData, I[mid], newData, newOffset) < 0)
+            {
+                return Search(I, oldData, newData, newOffset, mid, end, out pos);
             }
             else
             {
-                int midPoint = start + (end - start) / 2;
-                return CompareBytes(oldBytes, I[midPoint], newBytes, newOffset) < 0 ?
-                    Search(I, oldBytes, newBytes, newOffset, midPoint, end, out pos) :
-                    Search(I, oldBytes, newBytes, newOffset, start, midPoint, out pos);
+                return Search(I, oldData, newData, newOffset, start, mid, out pos);
             }
         }
 
-        private void Split(int[] I, int[] v, int start, int len, int h)
+        private static void Split(int[] I, int[] v, int start, int len, int h)
         {
             if (len < 16)
             {
@@ -455,7 +477,9 @@ namespace GeneralUpdate.Differential.Binary
                         }
                         if (v[I[k + i] + h] == x)
                         {
-                            Swap(ref I[k + j], ref I[k + i]);
+                            int tmp = I[k + j];
+                            I[k + j] = I[k + i];
+                            I[k + i] = tmp;
                             j++;
                         }
                     }
@@ -464,91 +488,108 @@ namespace GeneralUpdate.Differential.Binary
                     if (j == 1)
                         I[k] = -1;
                 }
+                return;
             }
-            else
+
+            int x2 = v[I[start + len / 2] + h];
+            int jj = 0;
+            int kk = 0;
+            for (int i2 = 0; i2 < len; i2++)
             {
-                int x = v[I[start + len / 2] + h];
-                int jj = 0;
-                int kk = 0;
-                for (int i2 = start; i2 < start + len; i2++)
-                {
-                    if (v[I[i2] + h] < x) jj++;
-                    if (v[I[i2] + h] == x) kk++;
-                }
-                jj += start;
-                kk += jj;
-
-                int i = start;
-                int j = 0;
-                int k = 0;
-                while (i < jj)
-                {
-                    if (v[I[i] + h] < x)
-                    {
-                        i++;
-                    }
-                    else if (v[I[i] + h] == x)
-                    {
-                        Swap(ref I[i], ref I[jj + j]);
-                        j++;
-                    }
-                    else
-                    {
-                        Swap(ref I[i], ref I[kk + k]);
-                        k++;
-                    }
-                }
-
-                while (jj + j < kk)
-                {
-                    if (v[I[jj + j] + h] == x)
-                    {
-                        j++;
-                    }
-                    else
-                    {
-                        Swap(ref I[jj + j], ref I[kk + k]);
-                        k++;
-                    }
-                }
-
-                if (jj > start) Split(I, v, start, jj - start, h);
-
-                for (i = 0; i < kk - jj; i++)
-                    v[I[jj + i]] = kk - 1;
-                if (jj == kk - 1) I[jj] = -1;
-
-                if (start + len > kk) Split(I, v, kk, start + len - kk, h);
+                if (v[I[start + i2] + h] < x2) jj++;
+                if (v[I[start + i2] + h] == x2) kk++;
             }
+            jj += start;
+            kk += jj;
+
+            int i3 = start;
+            int j3 = 0;
+            int k3 = 0;
+            while (i3 < jj)
+            {
+                if (v[I[i3] + h] < x2)
+                {
+                    i3++;
+                }
+                else if (v[I[i3] + h] == x2)
+                {
+                    int tmp = I[i3];
+                    I[i3] = I[jj + j3];
+                    I[jj + j3] = tmp;
+                    j3++;
+                }
+                else
+                {
+                    int tmp = I[i3];
+                    I[i3] = I[kk + k3];
+                    I[kk + k3] = tmp;
+                    k3++;
+                }
+            }
+
+            while (jj + j3 < kk)
+            {
+                if (v[I[jj + j3] + h] == x2)
+                {
+                    j3++;
+                }
+                else
+                {
+                    int tmp = I[jj + j3];
+                    I[jj + j3] = I[kk + k3];
+                    I[kk + k3] = tmp;
+                    k3++;
+                }
+            }
+
+            if (jj > start)
+                Split(I, v, start, jj - start, h);
+
+            for (int i2 = 0; i2 < kk - jj; i2++)
+                v[I[jj + i2]] = kk - 1;
+            if (jj == kk - 1)
+                I[jj] = -1;
+
+            if (start + len > kk)
+                Split(I, v, kk, start + len - kk, h);
         }
 
-        private int[] SuffixSort(byte[] oldBytes)
+        private static int[] SuffixSort(byte[] oldData)
         {
-            int[] buckets = new int[256];
-            foreach (byte oldByte in oldBytes)
-                buckets[oldByte]++;
+            var buckets = new int[256];
+
+            for (int i = 0; i < oldData.Length; i++)
+                buckets[oldData[i]]++;
             for (int i = 1; i < 256; i++)
                 buckets[i] += buckets[i - 1];
             for (int i = 255; i > 0; i--)
                 buckets[i] = buckets[i - 1];
             buckets[0] = 0;
 
-            int[] I = new int[oldBytes.Length + 1];
-            for (int i = 0; i < oldBytes.Length; i++)
-                I[++buckets[oldBytes[i]]] = i;
+            var I = new int[oldData.Length + 1];
+            for (int i = 0; i < oldData.Length; i++)
+                I[++buckets[oldData[i]]] = i;
 
-            int[] v = new int[oldBytes.Length + 1];
-            for (int i = 0; i < oldBytes.Length; i++)
-                v[i] = buckets[oldBytes[i]];
+            var v = new int[oldData.Length + 1];
+            for (int i = 0; i < oldData.Length; i++)
+                v[i] = buckets[oldData[i]];
 
             for (int i = 1; i < 256; i++)
-                if (buckets[i] == buckets[i - 1] + 1) I[buckets[i]] = -1;
-            I[0] = -1;
-            for (int h = 1; I[0] != -(oldBytes.Length + 1); h += h)
+            {
+                if (buckets[i] == buckets[i - 1] + 1)
+                {
+                    I[buckets[i]] = -1;
+                }
+            }
+
+            I[0] = oldData.Length;
+            v[oldData.Length] = 0;
+
+            for (int h = 1; I[0] != -(oldData.Length + 1); h += h)
             {
                 int len = 0;
                 int i = 0;
-                while (i < oldBytes.Length + 1)
+                while (i < oldData.Length + 1)
                 {
                     if (I[i] < 0)
                     {
@@ -557,89 +598,71 @@ namespace GeneralUpdate.Differential.Binary
                     }
                     else
                     {
-                        if (len != 0) I[i - len] = -len;
+                        if (len != 0)
+                            I[i - len] = -len;
                         len = v[I[i]] + 1 - i;
                         Split(I, v, i, len, h);
                         i += len;
                         len = 0;
                     }
                 }
-                if (len != 0) I[i - len] = -len;
+                if (len != 0)
+                    I[i - len] = -len;
             }
 
-            for (int i = 0; i < oldBytes.Length + 1; i++)
+            for (int i = 0; i < oldData.Length + 1; i++)
                 I[v[i]] = i;
 
             return I;
         }
 
-        private void Swap(ref int first, ref int second)
+        private static void WriteInt64(long value, byte[] buf, int offset)
         {
-            int temp = first;
-            first = second;
-            second = temp;
+            buf[offset + 0] = (byte)(value & 0xFF);
+            buf[offset + 1] = (byte)((value >> 8) & 0xFF);
+            buf[offset + 2] = (byte)((value >> 16) & 0xFF);
+            buf[offset + 3] = (byte)((value >> 24) & 0xFF);
+            buf[offset + 4] = (byte)((value >> 32) & 0xFF);
+            buf[offset + 5] = (byte)((value >> 40) & 0xFF);
+            buf[offset + 6] = (byte)((value >> 48) & 0xFF);
+            buf[offset + 7] = (byte)((value >> 56) & 0xFF);
         }
 
-        private long ReadInt64(byte[] buf, int offset)
+        private static long ReadInt64(byte[] buf, int offset)
         {
-            long value = buf[offset + 7] & 0x7F;
-            for (int index = 6; index >= 0; index--)
-            {
-                value *= 256;
-                value += buf[offset + index];
-            }
-            if ((buf[offset + 7] & 0x80) != 0) value = -value;
-            return value;
+            return (long)(
+                   ((ulong)buf[offset + 0]) |
+                   ((ulong)buf[offset + 1] << 8) |
+                   ((ulong)buf[offset + 2] << 16) |
+                   ((ulong)buf[offset + 3] << 24) |
+                   ((ulong)buf[offset + 4] << 32) |
+                   ((ulong)buf[offset + 5] << 40) |
+                   ((ulong)buf[offset + 6] << 48) |
+                   ((ulong)buf[offset + 7] << 56));
         }
 
-        private void WriteInt64(long value, byte[] buf, int offset)
+        private static byte[] ReadExactly(Stream stream, int count)
         {
-            long valueToWrite = value < 0 ? -value : value;
-            for (int byteIndex = 0; byteIndex < 8; byteIndex++)
-            {
-                buf[offset + byteIndex] = unchecked((byte)valueToWrite);
-                valueToWrite >>= 8;
-            }
-            if (value < 0) buf[offset + 7] |= 0x80;
-        }
-
-        /// <summary>
-        /// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/>.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="count">The count of bytes to read.</param>
-        /// <returns>A new byte array containing the data read from the stream.</returns>
-        private byte[] ReadExactly(Stream stream, int count)
-        {
-            if (count < 0) throw new ArgumentOutOfRangeException("count");
-            byte[] buffer = new byte[count];
-            ReadExactly(stream, buffer, 0, count);
-            return buffer;
-        }
-
-        /// <summary>
-        /// Reads exactly <paramref name="count"/> bytes from <paramref name="stream"/> into
-        /// <paramref name="buffer"/>, starting at the byte given by <paramref name="offset"/>.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="buffer">The buffer to read data into.</param>
-        /// <param name="offset">The offset within the buffer at which data is first written.</param>
-        /// <param name="count">The count of bytes to read.</param>
-        private void ReadExactly(Stream stream, byte[] buffer, int offset, int count)
-        {
-            // check arguments
-            if (stream == null) throw new ArgumentNullException("stream");
-            if (buffer == null) throw new ArgumentNullException("buffer");
-            if (offset < 0 || offset > buffer.Length) throw new ArgumentOutOfRangeException("offset");
-            if (count < 0 || buffer.Length - offset < count) throw new ArgumentOutOfRangeException("count");
-
+            byte[] data = new byte[count];
+            int offset = 0;
             while (count > 0)
             {
-                // read data
+                int bytesRead = stream.Read(data, offset, count);
+                if (bytesRead == 0)
+                    throw new EndOfStreamException("Unexpected end of stream.");
+                offset += bytesRead;
+                count -= bytesRead;
+            }
+            return data;
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int offset, int count)
+        {
+            while (count > 0)
+            {
                 int bytesRead = stream.Read(buffer, offset, count);
-                // check for failure to read
-                if (bytesRead == 0) throw new EndOfStreamException();
-                // move to next block
+                if (bytesRead == 0)
+                    throw new EndOfStreamException("Unexpected end of stream.");
                 offset += bytesRead;
                 count -= bytesRead;
             }

--- a/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
+++ b/src/c#/GeneralUpdate.Differential/DifferentialCore.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using GeneralUpdate.Differential.Abstractions;
+using GeneralUpdate.Differential.Binary;
 using GeneralUpdate.Differential.Matchers;
 
 namespace GeneralUpdate.Differential
@@ -15,12 +18,20 @@ namespace GeneralUpdate.Differential
     /// <see cref="DefaultCleanStrategy"/> or <see cref="DefaultDirtyStrategy"/> with a
     /// custom <see cref="ICleanMatcher"/> or <see cref="IDirtyMatcher"/> respectively.
     /// </para>
+    /// <para>
+    /// Beginning with v2, you may also supply a custom <see cref="IBinaryDiffer"/>
+    /// implementation to replace the BSDIFF algorithm for different trade-offs
+    /// (speed, patch size, memory, streaming support).
+    /// </para>
     /// </summary>
     public static class DifferentialCore
     {
+        #region Clean (Patch Generation)
+
         /// <summary>
         /// Compares <paramref name="sourcePath"/> with <paramref name="targetPath"/> and
         /// writes patch artifacts to <paramref name="patchPath"/>.
+        /// Uses the default BSDIFF binary differ and default clean strategy.
         /// </summary>
         /// <param name="strategy">
         /// Optional strategy that fully controls the execution.
@@ -30,8 +41,36 @@ namespace GeneralUpdate.Differential
             => (strategy ?? new DefaultCleanStrategy()).ExecuteAsync(sourcePath, targetPath, patchPath);
 
         /// <summary>
+        /// Compares <paramref name="sourcePath"/> with <paramref name="targetPath"/> and
+        /// writes patch artifacts to <paramref name="patchPath"/> using the specified binary differ.
+        /// </summary>
+        /// <param name="sourcePath">The source (old-version) directory.</param>
+        /// <param name="targetPath">The target (new-version) directory.</param>
+        /// <param name="patchPath">Output patch directory.</param>
+        /// <param name="binaryDiffer">The binary differ algorithm to use.</param>
+        /// <param name="strategy">Optional strategy override.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        public static Task Clean(
+            string sourcePath,
+            string targetPath,
+            string patchPath,
+            IBinaryDiffer binaryDiffer,
+            ICleanStrategy? strategy = null,
+            CancellationToken cancellationToken = default)
+        {
+            var cleanMatcher = new DefaultCleanMatcher();
+            var usedStrategy = strategy ?? new DefaultCleanStrategy(cleanMatcher, binaryDiffer);
+            return usedStrategy.ExecuteAsync(sourcePath, targetPath, patchPath);
+        }
+
+        #endregion Clean (Patch Generation)
+
+        #region Dirty (Patch Application)
+
+        /// <summary>
         /// Applies patches from <paramref name="patchPath"/> to the application files in
         /// <paramref name="appPath"/>.
+        /// Uses the default BSDIFF binary differ and default dirty strategy.
         /// </summary>
         /// <param name="strategy">
         /// Optional strategy that fully controls the execution.
@@ -39,5 +78,28 @@ namespace GeneralUpdate.Differential
         /// </param>
         public static Task Dirty(string appPath, string patchPath, IDirtyStrategy? strategy = null)
             => (strategy ?? new DefaultDirtyStrategy()).ExecuteAsync(appPath, patchPath);
+
+        /// <summary>
+        /// Applies patches from <paramref name="patchPath"/> to the application files in
+        /// <paramref name="appPath"/> using the specified binary differ.
+        /// </summary>
+        /// <param name="appPath">The application directory to patch.</param>
+        /// <param name="patchPath">The patch directory.</param>
+        /// <param name="binaryDiffer">The binary differ algorithm to use.</param>
+        /// <param name="strategy">Optional strategy override.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        public static Task Dirty(
+            string appPath,
+            string patchPath,
+            IBinaryDiffer binaryDiffer,
+            IDirtyStrategy? strategy = null,
+            CancellationToken cancellationToken = default)
+        {
+            var dirtyMatcher = new DefaultDirtyMatcher();
+            var usedStrategy = strategy ?? new DefaultDirtyStrategy(dirtyMatcher, binaryDiffer);
+            return usedStrategy.ExecuteAsync(appPath, patchPath);
+        }
+
+        #endregion Dirty (Patch Application)
     }
 }

--- a/src/c#/GeneralUpdate.Differential/Matchers/DefaultCleanStrategy.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/DefaultCleanStrategy.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GeneralUpdate.Common.FileBasic;
 using GeneralUpdate.Common.Internal.JsonContext;
+using GeneralUpdate.Differential.Abstractions;
 using GeneralUpdate.Differential.Binary;
 
 namespace GeneralUpdate.Differential.Matchers
@@ -16,6 +17,10 @@ namespace GeneralUpdate.Differential.Matchers
     /// entire execution flow.  When no matcher is provided, <see cref="DefaultCleanMatcher"/>
     /// is used.
     /// </para>
+    /// <para>
+    /// An optional <see cref="IBinaryDiffer"/> can be supplied to customise the binary diff
+    /// algorithm.  When no differ is provided, the default <see cref="BinaryHandler"/> (BSDIFF + BZip2) is used.
+    /// </para>
     /// </summary>
     public class DefaultCleanStrategy : ICleanStrategy
     {
@@ -23,14 +28,18 @@ namespace GeneralUpdate.Differential.Matchers
         private const string DeleteFilesName = "generalupdate_delete_files.json";
 
         private readonly ICleanMatcher _matcher;
+        private readonly IBinaryDiffer _binaryDiffer;
 
         /// <summary>
-        /// Initialises a new instance, optionally using a custom file-matching strategy.
+        /// Initialises a new instance, optionally using a custom file-matching strategy
+        /// and/or a custom binary differ.
         /// If no matcher is provided, <see cref="DefaultCleanMatcher"/> is used.
+        /// If no binary differ is provided, <see cref="BinaryHandler"/> (BSDIFF + BZip2) is used.
         /// </summary>
-        public DefaultCleanStrategy(ICleanMatcher? matcher = null)
+        public DefaultCleanStrategy(ICleanMatcher? matcher = null, IBinaryDiffer? binaryDiffer = null)
         {
             _matcher = matcher ?? new DefaultCleanMatcher();
+            _binaryDiffer = binaryDiffer ?? new BinaryHandler();
         }
 
         /// <inheritdoc/>
@@ -48,7 +57,7 @@ namespace GeneralUpdate.Differential.Matchers
                     if (!StorageManager.HashEquals(oldFile.FullName, newFile.FullName))
                     {
                         var tempPatchPath = Path.Combine(tempDir, $"{file.Name}{PatchFormat}");
-                        await new BinaryHandler().Clean(oldFile.FullName, newFile.FullName, tempPatchPath);
+                        await _binaryDiffer.CleanAsync(oldFile.FullName, newFile.FullName, tempPatchPath);
                     }
                 }
                 else

--- a/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyStrategy.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyStrategy.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GeneralUpdate.Common.FileBasic;
 using GeneralUpdate.Common.HashAlgorithms;
 using GeneralUpdate.Common.Internal.JsonContext;
+using GeneralUpdate.Differential.Abstractions;
 using GeneralUpdate.Differential.Binary;
 
 namespace GeneralUpdate.Differential.Matchers
@@ -18,20 +19,26 @@ namespace GeneralUpdate.Differential.Matchers
     /// entire execution flow.  When no matcher is provided, <see cref="DefaultDirtyMatcher"/>
     /// is used.
     /// </para>
+    /// <para>
+    /// An optional <see cref="IBinaryDiffer"/> can be supplied to customise the binary diff
+    /// algorithm.  When no differ is provided, the default <see cref="BinaryHandler"/> (BSDIFF + BZip2) is used.
+    /// </para>
     /// </summary>
     public class DefaultDirtyStrategy : IDirtyStrategy
     {
         private const string DeleteFilesName = "generalupdate_delete_files.json";
 
         private readonly IDirtyMatcher _matcher;
+        private readonly IBinaryDiffer _binaryDiffer;
 
         /// <summary>
-        /// Initialises a new instance, optionally using a custom file-matching strategy.
-        /// If no matcher is provided, <see cref="DefaultDirtyMatcher"/> is used.
+        /// Initialises a new instance, optionally using a custom file-matching strategy
+        /// and/or a custom binary differ.
         /// </summary>
-        public DefaultDirtyStrategy(IDirtyMatcher? matcher = null)
+        public DefaultDirtyStrategy(IDirtyMatcher? matcher = null, IBinaryDiffer? binaryDiffer = null)
         {
             _matcher = matcher ?? new DefaultDirtyMatcher();
+            _binaryDiffer = binaryDiffer ?? new BinaryHandler();
         }
 
         /// <inheritdoc/>
@@ -76,13 +83,13 @@ namespace GeneralUpdate.Differential.Matchers
             }
         }
 
-        private static async Task ApplyPatch(string appFilePath, string patchFilePath)
+        private async Task ApplyPatch(string appFilePath, string patchFilePath)
         {
             if (!File.Exists(appFilePath) || !File.Exists(patchFilePath)) return;
             var newPath = Path.Combine(
                 Path.GetDirectoryName(appFilePath)!,
                 $"{Path.GetRandomFileName()}_{Path.GetFileName(appFilePath)}");
-            await new BinaryHandler().Dirty(appFilePath, newPath, patchFilePath);
+            await _binaryDiffer.DirtyAsync(appFilePath, newPath, patchFilePath);
         }
 
         private static async Task CopyUnknownFiles(string appPath, string patchPath)


### PR DESCRIPTION
Closes #258

## Summary
Extract core abstractions from GeneralUpdate.Differential to enable pluggable binary diff algorithms and compression providers.

## Changes
### New Files
- \Abstractions/IBinaryDiffer.cs\ — pluggable binary differ interface with \CleanAsync\/\DirtyAsync\ + \CancellationToken\
- \Abstractions/ICompressionProvider.cs\ — pluggable compression interface with format version byte
- \Abstractions/BZip2CompressionProvider.cs\ — backward-compatible BZip2 provider (format version 0x00)

### Modified Files
- \Binary/BinaryHandler.cs\ — now implements \IBinaryDiffer\, adds cancellation support
- \DifferentialCore.cs\ — new overloads accepting \IBinaryDiffer\ + \CancellationToken\
- \Matchers/DefaultCleanStrategy.cs\ — optional \IBinaryDiffer\ constructor parameter
- \Matchers/DefaultDirtyStrategy.cs\ — optional \IBinaryDiffer\ constructor parameter

## Backward Compatibility
- All existing public APIs remain unchanged
- Default behavior uses BSDIFF + BZip2, same as before
- New overloads are additive only
- No breaking changes

## Next Steps
This PR is Part 1 of 5 in the Differential v2 refactor series:
- \#258 ✅ (this PR): Abstract interfaces
- \#259: Brotli compression via ICompressionProvider
- \#260: Parallel pipeline + Channel scheduling
- \#261: Streaming HDiffPatch-style differ
- \#262: Default switch + performance report