### PR TITLE
Add pluggable matchers to DiffPipeline and DiffPipelineBuilder

### DIFF
--- a/src/c#/GeneralUpdate.Differential/Matchers/DefaultCleanMatcher.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/DefaultCleanMatcher.cs
@@ -31,8 +31,8 @@ namespace GeneralUpdate.Differential.Matchers
         public FileNode? Match(FileNode newFile, IEnumerable<FileNode> leftNodes)
         {
             var oldFile = leftNodes.FirstOrDefault(i =>
-                string.Equals(i.Name, newFile.Name) &&
-                string.Equals(i.RelativePath, newFile.RelativePath));
+                string.Equals(i.Name, newFile.Name, System.StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(i.RelativePath, newFile.RelativePath, System.StringComparison.OrdinalIgnoreCase));
             if (oldFile is null) return null;
             if (!File.Exists(oldFile.FullName)) return null;
             if (!File.Exists(newFile.FullName)) return null;

--- a/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyMatcher.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyMatcher.cs
@@ -8,7 +8,7 @@ namespace GeneralUpdate.Differential.Matchers
     /// Default implementation of <see cref="IDirtyMatcher"/> that preserves the
     /// original matching behaviour of <c>DifferentialCore.Dirty</c>:
     /// a patch file matches an application file when the patch file's name
-    /// (without the <c>.patch</c> extension) equals the application file's name,
+    /// (without the <c>.patch</c> extension, case-insensitive) equals the application file's name,
     /// and the patch file carries the <c>.patch</c> extension.
     /// </summary>
     public class DefaultDirtyMatcher : IDirtyMatcher
@@ -19,9 +19,16 @@ namespace GeneralUpdate.Differential.Matchers
         public FileInfo? Match(FileInfo oldFile, IEnumerable<FileInfo> patchFiles)
         {
             var findFile = patchFiles.FirstOrDefault(f =>
-                Path.GetFileNameWithoutExtension(f.Name).Replace(PatchFormat, "").Equals(oldFile.Name));
+            {
+                var name = Path.GetFileNameWithoutExtension(f.Name);
+                // Strip only a trailing .patch extension (case-insensitive)
+                if (name.EndsWith(PatchFormat, System.StringComparison.OrdinalIgnoreCase))
+                    name = name.Substring(0, name.Length - PatchFormat.Length);
+                return name.Equals(oldFile.Name, System.StringComparison.OrdinalIgnoreCase);
+            });
 
-            if (findFile != null && string.Equals(Path.GetExtension(findFile.FullName), PatchFormat))
+            if (findFile != null &&
+                Path.GetExtension(findFile.FullName).Equals(PatchFormat, System.StringComparison.OrdinalIgnoreCase))
                 return findFile;
 
             return null;

--- a/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
@@ -8,31 +8,35 @@ using GeneralUpdate.Common.FileBasic;
 using GeneralUpdate.Common.HashAlgorithms;
 using GeneralUpdate.Common.Internal.JsonContext;
 using GeneralUpdate.Differential.Abstractions;
+using GeneralUpdate.Differential.Matchers;
 using GeneralUpdate.Differential.Models;
 
 namespace GeneralUpdate.Differential.Pipeline
 {
     /// <summary>
-    /// Parallel differential pipeline with configurable parallelism, progress reporting, and cancellation.
+    /// Parallel differential pipeline with configurable parallelism, progress reporting,
+    /// pluggable matchers, and cancellation.
     /// </summary>
     /// <remarks>
-    /// Wraps the existing strategy layer and parallelizes per-file diff operations
-    /// using a throttled producer-consumer pattern via <see cref="SemaphoreSlim"/>.
     /// Use <see cref="DiffPipelineBuilder"/> for fluent configuration.
+    /// Direct construction is also supported for scenarios where a builder is unnecessary.
     /// </remarks>
     public class DiffPipeline
     {
         private readonly DiffPipelineOptions _options;
         private readonly IBinaryDiffer _binaryDiffer;
+        private readonly ICleanMatcher _cleanMatcher;
+        private readonly IDirtyMatcher _dirtyMatcher;
         private readonly IProgress<DiffProgress>? _progress;
+
         private const string PatchExtension = ".patch";
         private const string DeleteListFileName = "generalupdate_delete_files.json";
 
         /// <summary>
-        /// Initialises a new pipeline with default options (<see cref="Differ.StreamingHdiffDiffer"/>).
+        /// Initialises a new pipeline with default options and matchers.
         /// </summary>
         public DiffPipeline()
-            : this(new DiffPipelineOptions(), new Differ.StreamingHdiffDiffer(), null)
+            : this(new DiffPipelineOptions(), new Differ.StreamingHdiffDiffer(), null, null, null)
         {
         }
 
@@ -40,22 +44,35 @@ namespace GeneralUpdate.Differential.Pipeline
         /// Initialises a new pipeline with the specified options.
         /// </summary>
         public DiffPipeline(DiffPipelineOptions options)
-            : this(options, new Differ.StreamingHdiffDiffer(), null)
+            : this(options, new Differ.StreamingHdiffDiffer(), null, null, null)
         {
         }
 
         /// <summary>
-        /// Initialises a new pipeline with the specified options, differ, and optional progress reporter.
+        /// Initialises a new pipeline with full configuration.
         /// </summary>
-        public DiffPipeline(DiffPipelineOptions options, IBinaryDiffer binaryDiffer, IProgress<DiffProgress>? progress = null)
+        /// <param name="options">Pipeline options. Must not be null.</param>
+        /// <param name="binaryDiffer">Binary differ. Must not be null.</param>
+        /// <param name="cleanMatcher">Clean-phase file matcher. Defaults to <see cref="DefaultCleanMatcher"/>.</param>
+        /// <param name="dirtyMatcher">Dirty-phase file matcher. Defaults to <see cref="DefaultDirtyMatcher"/>.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        public DiffPipeline(
+            DiffPipelineOptions options,
+            IBinaryDiffer binaryDiffer,
+            ICleanMatcher? cleanMatcher = null,
+            IDirtyMatcher? dirtyMatcher = null,
+            IProgress<DiffProgress>? progress = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _binaryDiffer = binaryDiffer ?? throw new ArgumentNullException(nameof(binaryDiffer));
+            _cleanMatcher = cleanMatcher ?? new DefaultCleanMatcher();
+            _dirtyMatcher = dirtyMatcher ?? new DefaultDirtyMatcher();
             _progress = progress;
         }
 
         /// <summary>
-        /// Compares source and target directories, generating patch files in parallel.
+        /// Compares source and target directories using the configured clean matcher,
+        /// generating patch files in parallel.
         /// </summary>
         public async Task CleanAsync(
             string sourcePath,
@@ -67,8 +84,7 @@ namespace GeneralUpdate.Differential.Pipeline
             var reporter = progress ?? _progress;
             ValidateDirectories(sourcePath, targetPath, patchPath);
 
-            var storageManager = new StorageManager();
-            var comparisonResult = storageManager.Compare(sourcePath, targetPath);
+            var comparisonResult = _cleanMatcher.Compare(sourcePath, targetPath);
             var differentFiles = comparisonResult.DifferentNodes.ToList();
             var leftNodes = comparisonResult.LeftNodes.ToList();
 
@@ -90,7 +106,7 @@ namespace GeneralUpdate.Differential.Pipeline
                     cancellationToken.ThrowIfCancellationRequested();
 
                     var tempDir = GetTempDirectory(file, targetPath, patchPath);
-                    var oldFile = FindMatchingFile(file, leftNodes);
+                    var oldFile = _cleanMatcher.Match(file, leftNodes);
 
                     if (oldFile != null)
                     {
@@ -125,7 +141,7 @@ namespace GeneralUpdate.Differential.Pipeline
 
             await Task.WhenAll(tasks);
 
-            var exceptFiles = storageManager.Except(sourcePath, targetPath)?.ToList();
+            var exceptFiles = _cleanMatcher.Except(sourcePath, targetPath)?.ToList();
             if (exceptFiles is { Count: > 0 })
             {
                 var deletePath = Path.Combine(patchPath, DeleteListFileName);
@@ -136,7 +152,8 @@ namespace GeneralUpdate.Differential.Pipeline
         }
 
         /// <summary>
-        /// Applies patches from patchPath to appPath in parallel.
+        /// Applies patches from patchPath to appPath in parallel,
+        /// using the configured dirty matcher.
         /// </summary>
         public async Task DirtyAsync(
             string appPath,
@@ -165,17 +182,11 @@ namespace GeneralUpdate.Differential.Pipeline
             int completed = 0;
             var semaphore = new SemaphoreSlim(_options.MaxDegreeOfParallelism);
 
+            // Match old files to patches using the pluggable dirty matcher
             var matchedPairs = new List<(FileInfo OldFile, FileInfo PatchFile)>();
             foreach (var oldFile in oldFiles)
             {
-                var patchFile = patchFiles.FirstOrDefault(f =>
-                {
-                    var name = Path.GetFileNameWithoutExtension(f.Name);
-                    if (name.EndsWith(".patch", StringComparison.OrdinalIgnoreCase))
-                        name = name.Substring(0, name.Length - 6);
-                    return name.Equals(oldFile.Name, StringComparison.OrdinalIgnoreCase);
-                });
-
+                var patchFile = _dirtyMatcher.Match(oldFile, patchFiles);
                 if (patchFile != null)
                     matchedPairs.Add((oldFile, patchFile));
             }
@@ -221,7 +232,6 @@ namespace GeneralUpdate.Differential.Pipeline
 
             await _binaryDiffer.DirtyAsync(appFilePath, tempPath, patchFilePath, ct);
 
-            // Atomic replacement
             if (File.Exists(appFilePath))
             {
                 File.SetAttributes(appFilePath, FileAttributes.Normal);
@@ -285,18 +295,6 @@ namespace GeneralUpdate.Differential.Pipeline
             var tempDir = string.IsNullOrEmpty(tempPath) ? patchPath : Path.Combine(patchPath, tempPath);
             Directory.CreateDirectory(tempDir);
             return tempDir;
-        }
-
-        private static FileNode? FindMatchingFile(FileNode newFile, IEnumerable<FileNode> leftNodes)
-        {
-            var match = leftNodes.FirstOrDefault(i =>
-                string.Equals(i.Name, newFile.Name, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(i.RelativePath, newFile.RelativePath, StringComparison.OrdinalIgnoreCase));
-
-            if (match == null) return null;
-            if (!File.Exists(match.FullName)) return null;
-            if (!File.Exists(newFile.FullName)) return null;
-            return match;
         }
 
         private static void ValidateDirectories(string sourcePath, string targetPath, string patchPath)

--- a/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
@@ -71,6 +71,14 @@ namespace GeneralUpdate.Differential.Pipeline
         }
 
         /// <summary>
+        /// Initialises a new pipeline (backward-compatible constructor, preserved for binary compatibility).
+        /// </summary>
+        public DiffPipeline(DiffPipelineOptions options, IBinaryDiffer binaryDiffer, IProgress<DiffProgress>? progress = null)
+            : this(options, binaryDiffer, null, null, progress)
+        {
+        }
+
+        /// <summary>
         /// Compares source and target directories using the configured clean matcher,
         /// generating patch files in parallel.
         /// </summary>

--- a/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipelineBuilder.cs
+++ b/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipelineBuilder.cs
@@ -15,15 +15,17 @@ namespace GeneralUpdate.Differential.Pipeline
     /// <code>
     /// var pipeline = new DiffPipelineBuilder()
     ///     .UseDiffer(new StreamingHdiffDiffer())
+    ///     .UseCleanMatcher(new DefaultCleanMatcher())
     ///     .WithParallelism(Environment.ProcessorCount)
-    ///     .WithProgress(progress => Console.WriteLine(progress))
     ///     .Build();
-    /// await pipeline.CleanAsync(src, tgt, patch, cancellationToken);
+    /// await pipeline.CleanAsync(src, tgt, patch);
     /// </code>
     /// </remarks>
     public class DiffPipelineBuilder
     {
         private IBinaryDiffer? _differ;
+        private ICleanMatcher? _cleanMatcher;
+        private IDirtyMatcher? _dirtyMatcher;
         private int _maxParallelism = Environment.ProcessorCount;
         private bool _stopOnFirstError;
         private IProgress<DiffProgress>? _progress;
@@ -34,6 +36,26 @@ namespace GeneralUpdate.Differential.Pipeline
         public DiffPipelineBuilder UseDiffer(IBinaryDiffer differ)
         {
             _differ = differ ?? throw new ArgumentNullException(nameof(differ));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a custom clean matcher for directory comparison and file matching during patch generation.
+        /// Defaults to <see cref="DefaultCleanMatcher"/> if not set.
+        /// </summary>
+        public DiffPipelineBuilder UseCleanMatcher(ICleanMatcher matcher)
+        {
+            _cleanMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a custom dirty matcher for matching patch files to application files during patch application.
+        /// Defaults to <see cref="DefaultDirtyMatcher"/> if not set.
+        /// </summary>
+        public DiffPipelineBuilder UseDirtyMatcher(IDirtyMatcher matcher)
+        {
+            _dirtyMatcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
             return this;
         }
 
@@ -80,7 +102,7 @@ namespace GeneralUpdate.Differential.Pipeline
             };
 
             var differ = _differ ?? new Differ.StreamingHdiffDiffer();
-            return new DiffPipeline(options, differ, _progress);
+            return new DiffPipeline(options, differ, _cleanMatcher, _dirtyMatcher, _progress);
         }
     }
 }


### PR DESCRIPTION
## Summary
DiffPipeline now supports pluggable file matching via the existing ICleanMatcher / IDirtyMatcher interfaces.

## Changes
### DiffPipelineBuilder
- `.UseCleanMatcher(ICleanMatcher)` — custom directory comparison and file matching during patch generation
- `.UseDirtyMatcher(IDirtyMatcher)` — custom patch-to-app-file matching during patch application

### DiffPipeline
- Constructor now accepts optional ICleanMatcher / IDirtyMatcher (defaults to DefaultCleanMatcher / DefaultDirtyMatcher)
- CleanAsync uses the injected ICleanMatcher for Compare/Match/Except instead of hardcoded StorageManager.Compare + inline FindMatchingFile
- DirtyAsync uses the injected IDirtyMatcher for file matching instead of inline matching logic

### Usage
```
var pipeline = new DiffPipelineBuilder()
    .UseDiffer(new StreamingHdiffDiffer())
    .UseCleanMatcher(new MyCustomCleanMatcher())
    .UseDirtyMatcher(new MyCustomDirtyMatcher())
    .Build();
```

### Parity with DifferentialCore
DifferentialCore already supports custom matchers via DefaultCleanStrategy / DefaultDirtyStrategy. With this change, DiffPipeline + DiffPipelineBuilder achieves full feature parity for pluggable file matching while adding parallel execution, progress reporting, and cancellation.