### PR TITLE
Fix DiffPipeline.ApplyPatch: handle differs that do internal atomic replacement

### DIFF
--- a/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
@@ -240,12 +240,18 @@ namespace GeneralUpdate.Differential.Pipeline
 
             await _binaryDiffer.DirtyAsync(appFilePath, tempPath, patchFilePath, ct);
 
-            if (File.Exists(appFilePath))
+            // Some differ implementations (e.g., BinaryHandler) perform atomic replacement
+            // internally: they delete oldPath and copy tempPath back to oldPath, then delete tempPath.
+            // We only handle the replacement ourselves when the differ left tempPath intact.
+            if (File.Exists(tempPath))
             {
-                File.SetAttributes(appFilePath, FileAttributes.Normal);
-                File.Delete(appFilePath);
+                if (File.Exists(appFilePath))
+                {
+                    File.SetAttributes(appFilePath, FileAttributes.Normal);
+                    File.Delete(appFilePath);
+                }
+                File.Move(tempPath, appFilePath);
             }
-            File.Move(tempPath, appFilePath);
         }
 
         private static void HandleDeleteList(IEnumerable<FileInfo> patchFiles, IEnumerable<FileInfo> oldFiles)


### PR DESCRIPTION
## Summary
Fix DiffPipeline.ApplyPatch to correctly handle IBinaryDiffer implementations that perform atomic file replacement internally (e.g., BinaryHandler).

## Bug
BinaryHandler.DirtyAsync already does: delete old file, copy temp to old, delete temp. After it returns, tempPath no longer exists. DiffPipeline.ApplyPatch then:
1. Deletes old file (which was just restored)
2. Tries File.Move(temp, old) — temp doesn't exist — FileNotFoundException

## Fix
ApplyPatch now checks if tempPath still exists after DirtyAsync:
- **Exists**: differ left tempPath intact — do atomic replacement
- **Does not exist**: differ already handled it — old file is already correct