### PR TITLE
Add IPipelineStep interface and PipelineContext

### DIFF
--- a/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/IPipelineStep.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/IPipelineStep.cs
@@ -1,0 +1,31 @@
+using GeneralUpdate.Drivelution.Abstractions.Models;
+
+namespace GeneralUpdate.Drivelution.Core.Pipeline;
+
+/// <summary>
+/// Defines a single step in the driver update pipeline.
+/// Each step encapsulates one stage of the update process (validate, backup, install, verify, etc.).
+/// </summary>
+public interface IPipelineStep
+{
+    /// <summary>
+    /// Human-readable name of this step, used for logging and progress reporting.
+    /// </summary>
+    string StepName { get; }
+
+    /// <summary>
+    /// Determines whether this step should be executed given the current context.
+    /// Allows steps to conditionally skip based on strategy (e.g., backup step skipped when RequireBackup is false).
+    /// </summary>
+    /// <param name="context">Current pipeline context.</param>
+    /// <returns><c>true</c> if the step should run; otherwise <c>false</c>.</returns>
+    bool ShouldExecute(PipelineContext context);
+
+    /// <summary>
+    /// Executes the pipeline step asynchronously.
+    /// </summary>
+    /// <param name="context">Mutable pipeline context carrying driver info, strategy, and result.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="PipelineResult"/> indicating success or failure.</returns>
+    Task<PipelineResult> ExecuteAsync(PipelineContext context, CancellationToken cancellationToken);
+}

--- a/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/PipelineContext.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/PipelineContext.cs
@@ -1,0 +1,44 @@
+using GeneralUpdate.Drivelution.Abstractions.Models;
+
+namespace GeneralUpdate.Drivelution.Core.Pipeline;
+
+/// <summary>
+/// Mutable context object that flows through the driver update pipeline.
+/// Carries driver information, strategy configuration, and the accumulating result.
+/// </summary>
+public class PipelineContext
+{
+    /// <summary>
+    /// Initializes a new pipeline context.
+    /// </summary>
+    /// <param name="driverInfo">Driver information for the update.</param>
+    /// <param name="strategy">Update strategy configuration.</param>
+    /// <param name="result">Accumulating update result (mutated by each step).</param>
+    public PipelineContext(DriverInfo driverInfo, UpdateStrategy strategy, UpdateResult result)
+    {
+        DriverInfo = driverInfo ?? throw new ArgumentNullException(nameof(driverInfo));
+        Strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+        Result = result ?? throw new ArgumentNullException(nameof(result));
+    }
+
+    /// <summary>
+    /// Driver information for the update.
+    /// </summary>
+    public DriverInfo DriverInfo { get; }
+
+    /// <summary>
+    /// Update strategy configuration.
+    /// </summary>
+    public UpdateStrategy Strategy { get; }
+
+    /// <summary>
+    /// Accumulating update result (mutated by each pipeline step).
+    /// </summary>
+    public UpdateResult Result { get; }
+
+    /// <summary>
+    /// A mutable bag of key-value pairs for steps to share intermediate data.
+    /// Example: the backup step stores the backup path here, the rollback step reads it.
+    /// </summary>
+    public Dictionary<string, object?> Bag { get; } = new();
+}

--- a/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/PipelineResult.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/PipelineResult.cs
@@ -1,0 +1,39 @@
+namespace GeneralUpdate.Drivelution.Core.Pipeline;
+
+/// <summary>
+/// Represents the outcome of a single pipeline step execution.
+/// </summary>
+public class PipelineResult
+{
+    /// <summary>
+    /// Whether the step executed successfully.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Error message if the step failed (null when successful).
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Optional exception captured during step execution.
+    /// </summary>
+    public Exception? Exception { get; init; }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static PipelineResult Ok() => new() { Success = true };
+
+    /// <summary>
+    /// Creates a failed result with an error message.
+    /// </summary>
+    /// <param name="errorMessage">Description of the failure.</param>
+    /// <param name="exception">Optional exception that caused the failure.</param>
+    public static PipelineResult Fail(string errorMessage, Exception? exception = null) => new()
+    {
+        Success = false,
+        ErrorMessage = errorMessage,
+        Exception = exception
+    };
+}


### PR DESCRIPTION
## Summary
Add the core Pipeline abstractions for the Drivelution refactoring.

## Changes
- **IPipelineStep**: defines a single pipeline step contract with \ShouldExecute\ and \ExecuteAsync\
- **PipelineContext**: mutable context carrying \DriverInfo\, \Strategy\, \Result\, and a shared \Bag\ for inter-step data exchange
- **PipelineResult**: step execution outcome with \Ok()\ / \Fail()\ factory methods

## Why
These abstractions form the foundation for the \BaseDriverUpdater\ pipeline base class (coming in sub-task 2), which will eliminate ~60% code duplication between the Windows and Linux implementations.

Closes #279