### PR TITLE
Add ICommandRunner for safe cross-platform process execution

### DIFF
--- a/src/c#/GeneralUpdate.Drivelution/Core/DriverUpdaterFactory.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/DriverUpdaterFactory.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using GeneralUpdate.Common.Shared;
 using GeneralUpdate.Drivelution.Abstractions;
 using GeneralUpdate.Drivelution.Abstractions.Configuration;
+using GeneralUpdate.Drivelution.Core.Execution;
 using GeneralUpdate.Drivelution.Windows.Implementation;
 using GeneralUpdate.Drivelution.Linux.Implementation;
 using GeneralUpdate.Drivelution.MacOS.Implementation;
@@ -29,14 +30,16 @@ public static class DrivelutionFactory
             GeneralTracer.Info("Detected Windows platform, creating WindowsGeneralDrivelution");
             var validator = new WindowsDriverValidator();
             var backup = new WindowsDriverBackup();
-            return new WindowsGeneralDrivelution(validator, backup);
+            var commandRunner = new CommandRunner();
+            return new WindowsGeneralDrivelution(validator, backup, commandRunner, options);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             GeneralTracer.Info("Detected Linux platform, creating LinuxGeneralDrivelution");
             var validator = new LinuxDriverValidator();
             var backup = new LinuxDriverBackup();
-            return new LinuxGeneralDrivelution(validator, backup);
+            var commandRunner = new CommandRunner();
+            return new LinuxGeneralDrivelution(validator, backup, commandRunner, options);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {

--- a/src/c#/GeneralUpdate.Drivelution/Core/Execution/CommandResult.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Execution/CommandResult.cs
@@ -1,0 +1,35 @@
+namespace GeneralUpdate.Drivelution.Core.Execution;
+
+/// <summary>
+/// Structured result of a command execution.
+/// </summary>
+public class CommandResult
+{
+    /// <summary>
+    /// Process exit code.
+    /// </summary>
+    public int ExitCode { get; init; }
+
+    /// <summary>
+    /// Standard output text.
+    /// </summary>
+    public string StandardOutput { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Standard error text.
+    /// </summary>
+    public string StandardError { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the command succeeded (exit code 0).
+    /// </summary>
+    public bool Success => ExitCode == 0;
+
+    /// <summary>
+    /// Returns a summary of the result for logging.
+    /// </summary>
+    public override string ToString() =>
+        Success
+            ? $"ExitCode={ExitCode}, Output={StandardOutput.Trim()}"
+            : $"ExitCode={ExitCode}, Error={StandardError.Trim()}";
+}

--- a/src/c#/GeneralUpdate.Drivelution/Core/Execution/CommandRunner.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Execution/CommandRunner.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using System.Text;
+using GeneralUpdate.Common.Shared;
+
+namespace GeneralUpdate.Drivelution.Core.Execution;
+
+/// <summary>
+/// Default implementation of <see cref="ICommandRunner"/>.
+/// Uses <see cref="ProcessStartInfo.ArgumentList"/> for safe argument passing—no shell parsing,
+/// no injection risk from paths with spaces or special characters.
+/// </summary>
+public class CommandRunner : ICommandRunner
+{
+    /// <inheritdoc/>
+    public async Task<CommandResult> RunAsync(
+        string command,
+        string[] arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = command,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // Safe: each argument added individually, never parsed by a shell
+        foreach (var arg in arguments)
+            psi.ArgumentList.Add(arg);
+
+        GeneralTracer.Debug($"Running: {command} {string.Join(" ", arguments)}");
+
+        using var process = new Process { StartInfo = psi };
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                stdout.AppendLine(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                stderr.AppendLine(e.Data);
+        };
+
+        if (!process.Start())
+            throw new InvalidOperationException($"Failed to start process: {command}");
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new CommandResult
+        {
+            ExitCode = process.ExitCode,
+            StandardOutput = stdout.ToString(),
+            StandardError = stderr.ToString()
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task<CommandResult> RunOrThrowAsync(
+        string command,
+        string[] arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await RunAsync(command, arguments, cancellationToken);
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                $"Command '{command}' failed with exit code {result.ExitCode}. " +
+                $"Error: {result.StandardError.Trim()}");
+        }
+
+        return result;
+    }
+}

--- a/src/c#/GeneralUpdate.Drivelution/Core/Execution/ICommandRunner.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Execution/ICommandRunner.cs
@@ -1,0 +1,34 @@
+namespace GeneralUpdate.Drivelution.Core.Execution;
+
+/// <summary>
+/// Abstraction for safe, cross-platform command execution.
+/// Passes arguments individually to avoid shell injection—no string concatenation into Arguments.
+/// </summary>
+public interface ICommandRunner
+{
+    /// <summary>
+    /// Runs a command with the given arguments.
+    /// </summary>
+    /// <param name="command">Executable name or path.</param>
+    /// <param name="arguments">Arguments passed individually (not shell-parsed).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="CommandResult"/> containing exit code, stdout, and stderr.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the process cannot be started.</exception>
+    Task<CommandResult> RunAsync(
+        string command,
+        string[] arguments,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs a command and throws if the exit code is non-zero.
+    /// </summary>
+    /// <param name="command">Executable name or path.</param>
+    /// <param name="arguments">Arguments passed individually.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A successful <see cref="CommandResult"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the process exits with a non-zero code.</exception>
+    Task<CommandResult> RunOrThrowAsync(
+        string command,
+        string[] arguments,
+        CancellationToken cancellationToken = default);
+}

--- a/src/c#/GeneralUpdate.Drivelution/Linux/Implementation/LinuxGeneralDrivelution.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Linux/Implementation/LinuxGeneralDrivelution.cs
@@ -4,6 +4,7 @@ using GeneralUpdate.Drivelution.Abstractions;
 using GeneralUpdate.Drivelution.Abstractions.Configuration;
 using GeneralUpdate.Drivelution.Abstractions.Exceptions;
 using GeneralUpdate.Drivelution.Abstractions.Models;
+using GeneralUpdate.Drivelution.Core.Execution;
 using GeneralUpdate.Drivelution.Core.Pipeline;
 using GeneralUpdate.Drivelution.Core.Utilities;
 using GeneralUpdate.Drivelution.Linux.Helpers;
@@ -18,18 +19,23 @@ namespace GeneralUpdate.Drivelution.Linux.Implementation;
 [SupportedOSPlatform("linux")]
 public class LinuxGeneralDrivelution : BaseDriverUpdater
 {
+    private readonly ICommandRunner _commandRunner;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="LinuxGeneralDrivelution"/> class.
     /// </summary>
     /// <param name="validator">Driver validator.</param>
     /// <param name="backup">Driver backup manager.</param>
+    /// <param name="commandRunner">Command runner for Linux operations.</param>
     /// <param name="options">Configuration options (optional).</param>
     public LinuxGeneralDrivelution(
         IDriverValidator validator,
         IDriverBackup backup,
+        ICommandRunner commandRunner,
         DrivelutionOptions? options = null)
         : base(validator, backup, options)
     {
+        _commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
     }
 
     // ─── Pipeline overrides ────────────────────────────────────────────
@@ -108,7 +114,7 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
                     // Unload current module first
                     try
                     {
-                        await ExecuteCommandAsync("modprobe", $"-r {moduleName}", cancellationToken);
+                        await _commandRunner.RunOrThrowAsync("modprobe", new[] { "-r", moduleName }, cancellationToken);
                     }
                     catch
                     {
@@ -116,7 +122,7 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
                     }
 
                     // Reload the backed-up module
-                    await ExecuteCommandAsync("insmod", koFile, cancellationToken);
+                    await _commandRunner.RunOrThrowAsync("insmod", new[] { koFile }, cancellationToken);
                     GeneralTracer.Info($"Restored module: {moduleName}");
                 }
                 catch (Exception ex)
@@ -226,7 +232,7 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
 
     // ─── Private: Format-specific installers ───────────────────────────
 
-    private static async Task InstallKernelModuleAsync(
+    private async Task InstallKernelModuleAsync(
         string modulePath,
         CancellationToken cancellationToken)
     {
@@ -234,7 +240,7 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
 
         try
         {
-            await ExecuteCommandAsync("insmod", modulePath, cancellationToken);
+            await _commandRunner.RunOrThrowAsync("insmod", new[] { modulePath }, cancellationToken);
             GeneralTracer.Info("Module loaded via insmod");
         }
         catch
@@ -242,21 +248,21 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
             // Fallback: modprobe with the module name
             GeneralTracer.Info("insmod failed, trying modprobe...");
             var moduleName = Path.GetFileNameWithoutExtension(modulePath);
-            await ExecuteCommandAsync("modprobe", moduleName, cancellationToken);
+            await _commandRunner.RunOrThrowAsync("modprobe", new[] { moduleName }, cancellationToken);
             GeneralTracer.Info("Module loaded via modprobe");
         }
     }
 
-    private static async Task InstallDebPackageAsync(
+    private async Task InstallDebPackageAsync(
         string packagePath,
         CancellationToken cancellationToken)
     {
         GeneralTracer.Info($"Installing Debian package: {packagePath}");
-        await ExecuteCommandAsync("dpkg", $"-i {packagePath}", cancellationToken);
+        await _commandRunner.RunOrThrowAsync("dpkg", new[] { "-i", packagePath }, cancellationToken);
         GeneralTracer.Info("Debian package installed");
     }
 
-    private static async Task InstallRpmPackageAsync(
+    private async Task InstallRpmPackageAsync(
         string packagePath,
         CancellationToken cancellationToken)
     {
@@ -264,12 +270,12 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
 
         try
         {
-            await ExecuteCommandAsync("rpm", $"-ivh {packagePath}", cancellationToken);
+            await _commandRunner.RunOrThrowAsync("rpm", new[] { "-ivh", packagePath }, cancellationToken);
         }
         catch
         {
             // Fallback to dnf/yum
-            await ExecuteCommandAsync("dnf", $"install -y {packagePath}", cancellationToken);
+            await _commandRunner.RunOrThrowAsync("dnf", new[] { "install", "-y", packagePath }, cancellationToken);
         }
 
         GeneralTracer.Info("RPM package installed");
@@ -277,7 +283,7 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
 
     // ─── Private: File parsing ─────────────────────────────────────────
 
-    private static async Task<DriverInfo?> ParseLinuxDriverFileAsync(
+    private async Task<DriverInfo?> ParseLinuxDriverFileAsync(
         string filePath,
         CancellationToken cancellationToken)
     {
@@ -320,14 +326,15 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
         }
     }
 
-    private static async Task ParseKernelModuleAsync(
+    private async Task ParseKernelModuleAsync(
         string koPath,
         DriverInfo driverInfo,
         CancellationToken cancellationToken)
     {
         try
         {
-            var output = await ExecuteCommandAsync("modinfo", koPath, cancellationToken);
+            var result = await _commandRunner.RunAsync("modinfo", new[] { koPath }, cancellationToken);
+            var output = result.Success ? result.StandardOutput : string.Empty;
             var lines = output.Split('\n');
 
             foreach (var line in lines)
@@ -355,15 +362,16 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
         }
     }
 
-    private static async Task ParseDebPackageAsync(
+    private async Task ParseDebPackageAsync(
         string debPath,
         DriverInfo driverInfo,
         CancellationToken cancellationToken)
     {
         try
         {
-            var escapedPath = debPath.Replace("'", "'\\''");
-            var output = await ExecuteCommandAsync("dpkg-deb", $"-I '{escapedPath}'", cancellationToken);
+            // No shell escaping needed — ArgumentList bypasses the shell entirely
+            var result = await _commandRunner.RunAsync("dpkg-deb", new[] { "-I", debPath }, cancellationToken);
+            var output = result.Success ? result.StandardOutput : string.Empty;
 
             foreach (var line in output.Split('\n'))
             {
@@ -385,15 +393,16 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
         }
     }
 
-    private static async Task ParseRpmPackageAsync(
+    private async Task ParseRpmPackageAsync(
         string rpmPath,
         DriverInfo driverInfo,
         CancellationToken cancellationToken)
     {
         try
         {
-            var escapedPath = rpmPath.Replace("'", "'\\''");
-            var output = await ExecuteCommandAsync("rpm", $"-qip '{escapedPath}'", cancellationToken);
+            // No shell escaping needed — ArgumentList bypasses the shell entirely
+            var result = await _commandRunner.RunAsync("rpm", new[] { "-qip", rpmPath }, cancellationToken);
+            var output = result.Success ? result.StandardOutput : string.Empty;
 
             foreach (var line in output.Split('\n'))
             {
@@ -421,40 +430,6 @@ public class LinuxGeneralDrivelution : BaseDriverUpdater
             GeneralTracer.Debug($"Could not get package info for {rpmPath}: {ex.Message}");
             driverInfo.Version = "1.0.0";
         }
-    }
-
-    // ─── Private: Command execution ────────────────────────────────────
-
-    private static async Task<string> ExecuteCommandAsync(
-        string command,
-        string arguments,
-        CancellationToken cancellationToken)
-    {
-        var psi = new System.Diagnostics.ProcessStartInfo
-        {
-            FileName = command,
-            Arguments = arguments,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        using var process = System.Diagnostics.Process.Start(psi)
-            ?? throw new InvalidOperationException($"Failed to start process: {command}");
-
-        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var error = await process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-
-        if (process.ExitCode != 0)
-        {
-            GeneralTracer.Warn($"Command {command} {arguments} exited with code {process.ExitCode}. Error: {error}");
-            throw new InvalidOperationException(
-                $"Command '{command}' failed with exit code {process.ExitCode}: {error}");
-        }
-
-        return output;
     }
 
     // ─── Nested type ──────────────────────────────────────────────────

--- a/src/c#/GeneralUpdate.Drivelution/Windows/Implementation/WindowsGeneralDrivelution.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Windows/Implementation/WindowsGeneralDrivelution.cs
@@ -1,10 +1,10 @@
-using System.Diagnostics;
 using System.Runtime.Versioning;
 using GeneralUpdate.Common.Shared;
 using GeneralUpdate.Drivelution.Abstractions;
 using GeneralUpdate.Drivelution.Abstractions.Configuration;
 using GeneralUpdate.Drivelution.Abstractions.Exceptions;
 using GeneralUpdate.Drivelution.Abstractions.Models;
+using GeneralUpdate.Drivelution.Core.Execution;
 using GeneralUpdate.Drivelution.Core.Pipeline;
 using GeneralUpdate.Drivelution.Core.Utilities;
 using GeneralUpdate.Drivelution.Windows.Helpers;
@@ -19,18 +19,23 @@ namespace GeneralUpdate.Drivelution.Windows.Implementation;
 [SupportedOSPlatform("windows")]
 public class WindowsGeneralDrivelution : BaseDriverUpdater
 {
+    private readonly ICommandRunner _commandRunner;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="WindowsGeneralDrivelution"/> class.
     /// </summary>
     /// <param name="validator">Driver validator.</param>
     /// <param name="backup">Driver backup manager.</param>
+    /// <param name="commandRunner">Command runner for PnPUtil operations.</param>
     /// <param name="options">Configuration options (optional).</param>
     public WindowsGeneralDrivelution(
         IDriverValidator validator,
         IDriverBackup backup,
+        ICommandRunner commandRunner,
         DrivelutionOptions? options = null)
         : base(validator, backup, options)
     {
+        _commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
     }
 
     // ─── Pipeline overrides ────────────────────────────────────────────
@@ -64,31 +69,16 @@ public class WindowsGeneralDrivelution : BaseDriverUpdater
         {
             GeneralTracer.Info($"Verifying Windows driver installation for: {driverInfo.FilePath}");
 
-            var psi = new ProcessStartInfo
-            {
-                FileName = "pnputil.exe",
-                Arguments = "/enum-drivers",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(psi);
-            if (process is null)
-            {
-                GeneralTracer.Warn("Failed to start PnPUtil for verification");
-                return false;
-            }
-
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
+            var result = await _commandRunner.RunAsync(
+                "pnputil.exe",
+                new[] { "/enum-drivers" },
+                cancellationToken);
 
             var driverFileName = Path.GetFileName(driverInfo.FilePath);
             var driverName = Path.GetFileNameWithoutExtension(driverInfo.FilePath);
 
-            bool isInstalled = output.Contains(driverFileName, StringComparison.OrdinalIgnoreCase)
-                            || output.Contains(driverName, StringComparison.OrdinalIgnoreCase);
+            bool isInstalled = result.StandardOutput.Contains(driverFileName, StringComparison.OrdinalIgnoreCase)
+                            || result.StandardOutput.Contains(driverName, StringComparison.OrdinalIgnoreCase);
 
             GeneralTracer.Info($"Driver verification result: {isInstalled}");
             return isInstalled;
@@ -227,38 +217,26 @@ public class WindowsGeneralDrivelution : BaseDriverUpdater
     }
 
     /// <summary>
-    /// Installs a driver using the Windows PnPUtil command-line tool.
+    /// Installs a driver using the Windows PnPUtil command-line tool (via ICommandRunner).
     /// </summary>
-    private static async Task InstallDriverUsingPnPUtilAsync(
+    private async Task InstallDriverUsingPnPUtilAsync(
         string driverPath,
         CancellationToken cancellationToken)
     {
         GeneralTracer.Info($"PnPUtil installing: {driverPath}");
 
-        var psi = new ProcessStartInfo
+        var result = await _commandRunner.RunAsync(
+            "pnputil.exe",
+            new[] { "/add-driver", driverPath, "/install" },
+            cancellationToken);
+
+        GeneralTracer.Info($"PnPUtil output: {result.StandardOutput.Trim()}");
+
+        if (!result.Success)
         {
-            FileName = "pnputil.exe",
-            Arguments = $"/add-driver \"{driverPath}\" /install",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true
-        };
-
-        using var process = Process.Start(psi)
-            ?? throw new DriverInstallationException("Failed to start PnPUtil process.");
-
-        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var error = await process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-
-        GeneralTracer.Info($"PnPUtil output: {output}");
-
-        if (process.ExitCode != 0)
-        {
-            GeneralTracer.Error($"PnPUtil failed (exit {process.ExitCode}): {error}");
+            GeneralTracer.Error($"PnPUtil failed (exit {result.ExitCode}): {result.StandardError}");
             throw new DriverInstallationException(
-                $"PnPUtil failed with exit code {process.ExitCode}: {error}");
+                $"PnPUtil failed with exit code {result.ExitCode}: {result.StandardError}");
         }
     }
 


### PR DESCRIPTION
## Summary
Add ICommandRunner to eliminate direct Process.Start calls and command injection risks.

## New files
- ICommandRunner: interface with RunAsync and RunOrThrowAsync
- CommandRunner: safe Process wrapper using ArgumentList (no shell parsing)
- CommandResult: structured result with exit code, stdout, stderr

## Migrated
- Windows PnPUtil install/verify from Process.Start to ICommandRunner
- Linux all commands (insmod/modprobe/dpkg/rpm/dpkg-deb) to ICommandRunner
- Both platform constructors now accept ICommandRunner via injection
- DrivelutionFactory creates and passes CommandRunner

## Removed
- Linux ExecuteCommandAsync private method
- Shell escaping workarounds (no longer needed)

Closes #288