### PR TITLE
Add DI integration with ServiceCollectionExtensions.AddDrivelution()

### DIFF
--- a/src/c#/GeneralUpdate.Drivelution/Core/ServiceCollectionExtensions.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using GeneralUpdate.Drivelution.Abstractions;
+using GeneralUpdate.Drivelution.Abstractions.Configuration;
+using GeneralUpdate.Drivelution.Core.Execution;
+using GeneralUpdate.Drivelution.Windows.Implementation;
+using GeneralUpdate.Drivelution.Linux.Implementation;
+using GeneralUpdate.Drivelution.MacOS.Implementation;
+
+namespace GeneralUpdate.Drivelution.Core;
+
+/// <summary>
+/// Extension methods for registering Drivelution services in the DI container.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Drivelution driver update services for the current platform.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration action for <see cref="DrivelutionOptions"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// // ASP.NET / Generic Host
+    /// builder.Services.AddDrivelution();
+    ///
+    /// // With options
+    /// builder.Services.AddDrivelution(options =>
+    /// {
+    ///     options.DefaultRetryCount = 5;
+    ///     options.DefaultTimeoutSeconds = 600;
+    /// });
+    ///
+    /// // Consumer
+    /// public class MyService
+    /// {
+    ///     public MyService(IGeneralDrivelution updater) { ... }
+    /// }
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddDrivelution(
+        this IServiceCollection services,
+        Action<DrivelutionOptions>? configure = null)
+    {
+        // Configuration
+        var options = new DrivelutionOptions();
+        configure?.Invoke(options);
+        services.AddSingleton(options);
+
+        // Infrastructure
+        services.AddSingleton<ICommandRunner, CommandRunner>();
+
+        // Platform-specific registrations
+        if (OperatingSystem.IsWindows())
+        {
+            services.AddSingleton<IDriverValidator, WindowsDriverValidator>();
+            services.AddSingleton<IDriverBackup, WindowsDriverBackup>();
+            services.AddSingleton<IGeneralDrivelution, WindowsGeneralDrivelution>();
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            services.AddSingleton<IDriverValidator, LinuxDriverValidator>();
+            services.AddSingleton<IDriverBackup, LinuxDriverBackup>();
+            services.AddSingleton<IGeneralDrivelution, LinuxGeneralDrivelution>();
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            services.AddSingleton<IDriverValidator, MacOSDriverValidator>();
+            services.AddSingleton<IDriverBackup, MacOSDriverBackup>();
+            services.AddSingleton<IGeneralDrivelution, MacOsGeneralDrivelution>();
+        }
+
+        return services;
+    }
+}

--- a/src/c#/GeneralUpdate.Drivelution/GeneralDrivelution.cs
+++ b/src/c#/GeneralUpdate.Drivelution/GeneralDrivelution.cs
@@ -3,6 +3,7 @@ using GeneralUpdate.Drivelution.Abstractions;
 using GeneralUpdate.Drivelution.Abstractions.Configuration;
 using GeneralUpdate.Drivelution.Abstractions.Models;
 using GeneralUpdate.Drivelution.Core.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GeneralUpdate.Drivelution;
 
@@ -32,6 +33,22 @@ public static class GeneralDrivelution
     /// <exception cref="PlatformNotSupportedException">Thrown when platform is not supported</exception>
     public static IGeneralDrivelution Create(DrivelutionOptions? options = null)
     {
+        return Core.DrivelutionFactory.Create(options);
+    }
+
+    /// <summary>
+    /// Resolves a driver updater from the DI service provider.
+    /// Falls back to <see cref="Create(DrivelutionOptions?)"/> if not registered.
+    /// </summary>
+    /// <param name="serviceProvider">DI service provider.</param>
+    /// <returns>Platform-adapted driver updater.</returns>
+    public static IGeneralDrivelution Create(IServiceProvider serviceProvider)
+    {
+        var updater = serviceProvider.GetService<IGeneralDrivelution>();
+        if (updater is not null)
+            return updater;
+
+        var options = serviceProvider.GetService<DrivelutionOptions>();
         return Core.DrivelutionFactory.Create(options);
     }
 

--- a/src/c#/GeneralUpdate.Drivelution/GeneralUpdate.Drivelution.csproj
+++ b/src/c#/GeneralUpdate.Drivelution/GeneralUpdate.Drivelution.csproj
@@ -48,5 +48,8 @@
       <PackagePath>./</PackagePath>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Add Microsoft.Extensions.DependencyInjection integration so consumers can register Drivelution with services.AddDrivelution().

## Changes
- ServiceCollectionExtensions.AddDrivelution() extension method
- Registers ICommandRunner, IDriverValidator, IDriverBackup, IGeneralDrivelution per platform
- Supports DrivelutionOptions configuration via Action delegate
- GeneralDrivelution.Create(IServiceProvider) overload for DI resolution
- Falls back to factory-created instance when not registered in DI
- Added Microsoft.Extensions.DependencyInjection.Abstractions package reference

## Usage
`csharp
// ASP.NET / Generic Host
builder.Services.AddDrivelution(options =>
{
    options.DefaultRetryCount = 5;
    options.DefaultTimeoutSeconds = 600;
    options.UseExponentialBackoff = true;
});

// Consumer
public class MyService(IGeneralDrivelution updater) { ... }

// Static facade with DI
var updater = GeneralDrivelution.Create(serviceProvider);
`

## Backward Compatibility
Static GeneralDrivelution.Create() and GeneralDrivelution.Create(DrivelutionOptions?) still work — no breaking changes.

Closes #290