### PR TITLE
Add batch driver update support

### DIFF
--- a/src/c#/GeneralUpdate.Drivelution/Abstractions/IGeneralDrivelution.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Abstractions/IGeneralDrivelution.cs
@@ -54,4 +54,20 @@ public interface IGeneralDrivelution
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of driver information</returns>
     Task<List<DriverInfo>> GetDriversFromDirectoryAsync(string directoryPath, string? searchPattern = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates multiple drivers in a batch operation.
+    /// </summary>
+    /// <param name="drivers">Drivers to update.</param>
+    /// <param name="strategy">Update strategy applied to each driver.</param>
+    /// <param name="mode">Execution mode: Sequential or Parallel.</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Aggregated batch result with per-driver outcomes.</returns>
+    Task<BatchUpdateResult> BatchUpdateAsync(
+        IEnumerable<DriverInfo> drivers,
+        UpdateStrategy strategy,
+        BatchMode mode = BatchMode.Sequential,
+        IProgress<UpdateProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/c#/GeneralUpdate.Drivelution/Abstractions/Models/BatchUpdateResult.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Abstractions/Models/BatchUpdateResult.cs
@@ -1,0 +1,71 @@
+namespace GeneralUpdate.Drivelution.Abstractions.Models;
+
+/// <summary>
+/// Result of a batch driver update operation, containing per-driver outcomes.
+/// </summary>
+public class BatchUpdateResult
+{
+    /// <summary>
+    /// Overall batch success (true only when all drivers updated successfully).
+    /// </summary>
+    public bool AllSucceeded { get; set; }
+
+    /// <summary>
+    /// Number of drivers that succeeded.
+    /// </summary>
+    public int SucceededCount { get; set; }
+
+    /// <summary>
+    /// Number of drivers that failed.
+    /// </summary>
+    public int FailedCount { get; set; }
+
+    /// <summary>
+    /// Individual results per driver, in the same order as the input list.
+    /// </summary>
+    public List<DriverUpdateEntry> Results { get; set; } = new();
+
+    /// <summary>
+    /// Total wall-clock duration of the batch operation.
+    /// </summary>
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>
+    /// Returns a summary of the batch operation.
+    /// </summary>
+    public override string ToString()
+        => $"BatchComplete: {SucceededCount} succeeded, {FailedCount} failed, Duration={Duration.TotalSeconds:F1}s";
+}
+
+/// <summary>
+/// Entry in a batch update result — links a driver to its individual update outcome.
+/// </summary>
+public class DriverUpdateEntry
+{
+    /// <summary>
+    /// Driver information for this entry.
+    /// </summary>
+    public DriverInfo DriverInfo { get; init; } = default!;
+
+    /// <summary>
+    /// Whether this driver's update succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// The full update result from the pipeline.
+    /// </summary>
+    public UpdateResult? Result { get; init; }
+}
+
+/// <summary>
+/// Execution mode for batch driver updates.
+/// </summary>
+public enum BatchMode
+{
+    /// <summary>Process drivers one at a time in order.</summary>
+    Sequential,
+
+    /// <summary>Process drivers concurrently using Task.WhenAll.</summary>
+    Parallel
+}

--- a/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/BaseDriverUpdater.cs
+++ b/src/c#/GeneralUpdate.Drivelution/Core/Pipeline/BaseDriverUpdater.cs
@@ -302,6 +302,108 @@ public abstract class BaseDriverUpdater : IGeneralDrivelution
         }, cancellationToken);
     }
 
+    /// <inheritdoc/>
+    public virtual async Task<BatchUpdateResult> BatchUpdateAsync(
+        IEnumerable<DriverInfo> drivers,
+        UpdateStrategy strategy,
+        BatchMode mode = BatchMode.Sequential,
+        IProgress<UpdateProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var driverList = drivers.ToList();
+        var result = new BatchUpdateResult { Results = new List<DriverUpdateEntry>(driverList.Count) };
+        var startTime = DateTime.UtcNow;
+        int completed = 0;
+
+        GeneralTracer.Info($"Starting batch update: {driverList.Count} driver(s), mode={mode}");
+
+        if (mode == BatchMode.Parallel)
+        {
+            var tasks = driverList.Select(async (driver, index) =>
+            {
+                progress?.Report(new UpdateProgress
+                {
+                    CurrentStatus = UpdateStatus.NotStarted,
+                    StepName = $"Batch [{index + 1}/{driverList.Count}]",
+                    Percentage = 0,
+                    Message = $"Starting: {driver.Name}",
+                    StepIndex = index,
+                    TotalSteps = driverList.Count
+                });
+
+                var updateResult = await UpdateAsync(driver, strategy, cancellationToken: cancellationToken);
+
+                Interlocked.Increment(ref completed);
+                progress?.Report(new UpdateProgress
+                {
+                    CurrentStatus = updateResult.Status,
+                    StepName = $"Batch [{index + 1}/{driverList.Count}]",
+                    Percentage = (int)((float)Interlocked.CompareExchange(ref completed, completed, completed) / driverList.Count * 100),
+                    Message = updateResult.Success ? $"OK: {driver.Name}" : $"FAIL: {driver.Name}",
+                    StepIndex = index,
+                    TotalSteps = driverList.Count
+                });
+
+                return new DriverUpdateEntry
+                {
+                    DriverInfo = driver,
+                    Success = updateResult.Success,
+                    Result = updateResult
+                };
+            }).ToList();
+
+            var entries = await Task.WhenAll(tasks);
+            result.Results.AddRange(entries);
+        }
+        else
+        {
+            for (int i = 0; i < driverList.Count; i++)
+            {
+                var driver = driverList[i];
+
+                progress?.Report(new UpdateProgress
+                {
+                    CurrentStatus = UpdateStatus.NotStarted,
+                    StepName = $"Batch [{i + 1}/{driverList.Count}]",
+                    Percentage = (int)((float)i / driverList.Count * 100),
+                    Message = $"Starting: {driver.Name}",
+                    StepIndex = i,
+                    TotalSteps = driverList.Count
+                });
+
+                var updateResult = await UpdateAsync(driver, strategy, cancellationToken: cancellationToken);
+
+                completed++;
+                progress?.Report(new UpdateProgress
+                {
+                    CurrentStatus = updateResult.Status,
+                    StepName = $"Batch [{i + 1}/{driverList.Count}]",
+                    Percentage = (int)((float)completed / driverList.Count * 100),
+                    Message = updateResult.Success ? $"OK: {driver.Name}" : $"FAIL: {driver.Name}",
+                    StepIndex = i,
+                    TotalSteps = driverList.Count
+                });
+
+                result.Results.Add(new DriverUpdateEntry
+                {
+                    DriverInfo = driver,
+                    Success = updateResult.Success,
+                    Result = updateResult
+                });
+            }
+        }
+
+        result.SucceededCount = result.Results.Count(r => r.Success);
+        result.FailedCount = result.Results.Count(r => !r.Success);
+        result.AllSucceeded = result.FailedCount == 0;
+        result.Duration = DateTime.UtcNow - startTime;
+
+        GeneralTracer.Info($"Batch update completed: {result.SucceededCount} OK, {result.FailedCount} failed, " +
+                          $"duration={result.Duration.TotalSeconds:F1}s");
+
+        return result;
+    }
+
     // ─── Abstract / Virtual Members ────────────────────────────────────
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Drivelution/GeneralDrivelution.cs
+++ b/src/c#/GeneralUpdate.Drivelution/GeneralDrivelution.cs
@@ -151,6 +151,29 @@ public static class GeneralDrivelution
         GeneralTracer.Info($"GeneralDrivelution.GetDriversFromDirectoryAsync: found {drivers?.Count ?? 0} driver(s) in directory={directoryPath}");
         return drivers;
     }
+
+    /// <summary>
+    /// Batch updates multiple drivers
+    /// </summary>
+    /// <param name="drivers">Drivers to update</param>
+    /// <param name="strategy">Update strategy</param>
+    /// <param name="mode">Execution mode (Sequential or Parallel)</param>
+    /// <param name="progress">Optional progress reporter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Aggregated batch result</returns>
+    public static async Task<BatchUpdateResult> BatchUpdateAsync(
+        IEnumerable<DriverInfo> drivers,
+        UpdateStrategy strategy,
+        BatchMode mode = BatchMode.Sequential,
+        IProgress<UpdateProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        GeneralTracer.Info("GeneralDrivelution.BatchUpdateAsync: starting batch driver update");
+        var updater = Create();
+        var result = await updater.BatchUpdateAsync(drivers, strategy, mode, progress, cancellationToken);
+        GeneralTracer.Info($"GeneralDrivelution.BatchUpdateAsync: batch complete. OK={result.SucceededCount}, Failed={result.FailedCount}");
+        return result;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
Add batch update capability so multiple drivers can be updated in a single call.

## Changes
- BatchUpdateResult: per-driver entries, SucceededCount, FailedCount, duration
- BatchMode: Sequential and Parallel execution modes
- BatchUpdateAsync added to IGeneralDrivelution interface
- BaseDriverUpdater implementation with full IProgress reporting
- Static facade GeneralDrivelution.BatchUpdateAsync

## Usage
```csharp
// Sequential
var result = await updater.BatchUpdateAsync(drivers, strategy);

// Parallel
var result = await updater.BatchUpdateAsync(drivers, strategy, BatchMode.Parallel, progress);

// With progress
var progress = new Progress<UpdateProgress>(p =>
    Console.WriteLine($"[{p.Percentage}%] {p.StepName}: {p.Message}")
);
var result = await updater.BatchUpdateAsync(drivers, strategy, BatchMode.Parallel, progress);
```

## Diff
+212 lines

Closes #296
