### PR TITLE
PR: Sub Issue 7 - OSS options + mark legacy classes obsolete

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralClientOSS.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralClientOSS.cs
@@ -15,7 +15,7 @@ using GeneralUpdate.Core.Configuration;
 
 namespace GeneralUpdate.Core;
 
-public sealed class GeneralClientOSS
+[Obsolete("Use GeneralUpdateBootstrap with AppType=AppType.OSS instead.")] public sealed class GeneralClientOSS
 {
     private GeneralClientOSS() { }
 

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateOSS.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateOSS.cs
@@ -9,6 +9,7 @@ using GeneralUpdate.Core.Strategy;
 
 namespace GeneralUpdate.Core
 {
+    [Obsolete("Use GeneralUpdateBootstrap with AppType=AppType.OSS instead. See UpdateOptions.AppType.")]
     public sealed class GeneralUpdateOSS
     {
         private GeneralUpdateOSS() { }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
@@ -44,6 +44,10 @@ namespace GeneralUpdate.Core.Configuration
         public static readonly UpdateOption<string?> ProductId = UpdateOption.ValueOf<string?>("PRODUCTID");
         public static readonly UpdateOption<string?> PermissionScript = UpdateOption.ValueOf<string?>("PERMISSIONSCRIPT");
         public static readonly UpdateOption<string?> Scheme = UpdateOption.ValueOf<string?>("SCHEME");
-        public static readonly UpdateOption<string?> Token = UpdateOption.ValueOf<string?>("TOKEN");
+        public static readonly UpdateOption<string?> Token = UpdateOption.ValueOf<string?("TOKEN");
+
+        // ═══ OSS ═══
+        public static readonly UpdateOption<int?> OSSProvider = UpdateOption.ValueOf<int?>("OSSPROVIDER");
+        public static readonly UpdateOption<string?> OSSBucketRegion = UpdateOption.ValueOf<string?>("OSSBUCKETREGION");
     }
 }


### PR DESCRIPTION
## Summary
Closes #323

## Changes
- Add \UpdateOptions.OSSProvider\ and \OSSBucketRegion\
- Mark \GeneralUpdateOSS\, \GeneralClientOSS\, \SilentUpdateMode\ as \[Obsolete]\
- Migration guidance: use \GeneralUpdateBootstrap\ with \AppType.OSS\ or \.Option(UpdateOptions.Silent, true)\

## Build
✅ 0 errors