### PR TITLE
fix: UpdateOptions Token ValueOf syntax error

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
@@ -44,7 +44,7 @@ namespace GeneralUpdate.Core.Configuration
         public static readonly UpdateOption<string?> ProductId = UpdateOption.ValueOf<string?>("PRODUCTID");
         public static readonly UpdateOption<string?> PermissionScript = UpdateOption.ValueOf<string?>("PERMISSIONSCRIPT");
         public static readonly UpdateOption<string?> Scheme = UpdateOption.ValueOf<string?>("SCHEME");
-        public static readonly UpdateOption<string?> Token = UpdateOption.ValueOf<string?("TOKEN");
+        public static readonly UpdateOption<string?> Token = UpdateOption.ValueOf<string?>("TOKEN");
 
         // ═══ OSS ═══
         public static readonly UpdateOption<int?> OSSProvider = UpdateOption.ValueOf<int?>("OSSPROVIDER");


### PR DESCRIPTION
Copilot-flagged in PR 326. Missing closing bracket after string question-mark in ValueOf generic argument.