### PR TITLE
fix: restore Core project compilation — remove Compile Remove, fix API mismatches (#342)

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralClientBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralClientBootstrap.cs
@@ -180,7 +180,7 @@ public class GeneralClientBootstrap : AbstractBootstrap<GeneralClientBootstrap, 
 
             //black list initialization.
             BlackListManager.Instance?.AddBlackFiles(_configInfo.BlackFiles);
-            BlackListManager.Instance?.AddBlackFileFormats(_configInfo.BlackFormats);
+            BlackListManager.Instance?.AddBlackFormats(_configInfo.BlackFormats);
             BlackListManager.Instance?.AddSkipDirectorys(_configInfo.SkipDirectorys);
 
             _configInfo.Encoding = GetOption(UpdateOption.Encoding) ?? Encoding.Default;
@@ -211,7 +211,7 @@ public class GeneralClientBootstrap : AbstractBootstrap<GeneralClientBootstrap, 
                 var processInfo = ConfigurationMapper.MapToProcessInfo(
                     _configInfo,
                     mainResp.Body,
-                    BlackListManager.Instance.BlackFileFormats.ToList(),
+                    BlackListManager.Instance.BlackFormats.ToList(),
                     BlackListManager.Instance.BlackFiles.ToList(),
                     BlackListManager.Instance.SkipDirectorys.ToList());
 

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -205,7 +205,7 @@ namespace GeneralUpdate.Core
 
             if (processInfo == null) return;
 
-            BlackListManager.Instance.AddBlackFileFormats(processInfo.BlackFileFormats);
+            BlackListManager.Instance.AddBlackFormats(processInfo.BlackFileFormats);
             BlackListManager.Instance.AddBlackFiles(processInfo.BlackFiles);
             BlackListManager.Instance.AddSkipDirectorys(processInfo.SkipDirectorys);
 
@@ -245,7 +245,7 @@ namespace GeneralUpdate.Core
         private void InitBlackList()
         {
             BlackListManager.Instance.AddBlackFiles(_configInfo.BlackFiles);
-            BlackListManager.Instance.AddBlackFileFormats(_configInfo.BlackFormats);
+            BlackListManager.Instance.AddBlackFormats(_configInfo.BlackFormats);
             BlackListManager.Instance.AddSkipDirectorys(_configInfo.SkipDirectorys);
         }
 

--- a/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
+++ b/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
@@ -13,6 +13,7 @@
         <Version>10.0.0-preview</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
         <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
@@ -21,16 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- DrivelutionMiddleware: requires net10.0 target, Core is netstandard2.0 -->
         <Compile Remove="Pipeline\DrivelutionMiddleware.cs" />
-        <Compile Remove="Pipeline\PatchMiddleware.cs" />
-        <Compile Remove="Strategy\WindowsStrategy.cs" />
-        <Compile Remove="Strategy\LinuxStrategy.cs" />
-        <Compile Remove="Strategy\OSSStrategy.cs" />
-        <Compile Remove="Strategy\MacStrategy.cs" />
-        <Compile Remove="Bootstrap\GeneralUpdateBootstrap.cs" />
-        <Compile Remove="Bootstrap\GeneralClientBootstrap.cs" />
-        <Compile Remove="Bootstrap\GeneralUpdateOSS.cs" />
-        <Compile Remove="Bootstrap\GeneralClientOSS.cs" />
-        <Compile Remove="Silent\SilentUpdateMode.cs" />
     </ItemGroup>
 </Project>

--- a/src/c#/GeneralUpdate.Core/Pipeline/PatchMiddleware.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/PatchMiddleware.cs
@@ -2,26 +2,20 @@ using System;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Pipeline;
 using GeneralUpdate.Core;
-using GeneralUpdate.Differential;
 
 namespace GeneralUpdate.Core.Pipeline;
 
+/// <summary>
+/// Differential patch middleware.
+/// Full implementation requires GeneralUpdate.Differential (circular dependency — see T2).
+/// Currently a no-op placeholder; patches are applied externally.
+/// </summary>
 public class PatchMiddleware : IMiddleware
 {
     public async Task InvokeAsync(PipelineContext context)
     {
-        var sourcePath = context.Get<string>("SourcePath");
-        var targetPath = context.Get<string>("PatchPath");
-        GeneralTracer.Info($"PatchMiddleware.InvokeAsync: applying differential patch. SourcePath={sourcePath}, PatchPath={targetPath}");
-        try
-        {
-            await DifferentialCore.Dirty(sourcePath, targetPath);
-            GeneralTracer.Info("PatchMiddleware.InvokeAsync: differential patch applied successfully.");
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Error("PatchMiddleware.InvokeAsync: failed to apply differential patch.", ex);
-            throw;
-        }
+        GeneralTracer.Info("PatchMiddleware.InvokeAsync: differential patching is not available in this build. " +
+            "IBinaryDiffer injection via Bootstrap.BinaryDiffer<T>() will be re-enabled in a future PR.");
+        await Task.CompletedTask;
     }
 }

--- a/src/c#/GeneralUpdate.Core/Silent/SilentUpdateMode.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentUpdateMode.cs
@@ -116,7 +116,7 @@ internal sealed class SilentUpdateMode
         }
 
         BlackListManager.Instance?.AddBlackFiles(_configInfo.BlackFiles);
-        BlackListManager.Instance?.AddBlackFileFormats(_configInfo.BlackFormats);
+        BlackListManager.Instance?.AddBlackFormats(_configInfo.BlackFormats);
         BlackListManager.Instance?.AddSkipDirectorys(_configInfo.SkipDirectorys);
 
         _configInfo.Encoding = _encoding;
@@ -139,7 +139,7 @@ internal sealed class SilentUpdateMode
         var processInfo = ConfigurationMapper.MapToProcessInfo(
             _configInfo,
             versions,
-            BlackListManager.Instance.BlackFileFormats.ToList(),
+            BlackListManager.Instance.BlackFormats.ToList(),
             BlackListManager.Instance.BlackFiles.ToList(),
             BlackListManager.Instance.SkipDirectorys.ToList());
         _configInfo.ProcessInfo = JsonSerializer.Serialize(processInfo, ProcessInfoJsonContext.Default.ProcessInfo);

--- a/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
@@ -55,10 +55,10 @@ public class MacStrategy : AbstractStrategy
 
     protected override PipelineBuilder BuildPipeline(PipelineContext context)
     {
-        var builder = new PipelineBuilder(context);
-        builder.Use(new HashMiddleware());
-        builder.Use(new CompressMiddleware());
-        builder.Use(new PatchMiddleware());
+        var builder = new PipelineBuilder(context)
+            .UseMiddleware<HashMiddleware>()
+            .UseMiddleware<CompressMiddleware>()
+            .UseMiddleware<PatchMiddleware>();
         return builder;
     }
 }


### PR DESCRIPTION
## Summary
Restores compilation for the entire \GeneralUpdate.Core\ project. Previously, all Bootstrap, Strategy, SilentUpdateMode, and Pipeline files were excluded via \<Compile Remove>\ directives — only the abstract base layer compiled. Now the full project builds.

## Changes
- **Removed \<Compile Remove>\** for Bootstrap (GeneralUpdateBootstrap, GeneralClientBootstrap, GeneralUpdateOSS, GeneralClientOSS), all Strategies (Windows, Linux, OSS, Mac), SilentUpdateMode, and PatchMiddleware
- **PatchMiddleware** rewritten as no-op stub — waits for T2 (IBinaryDiffer interface extraction) to resolve circular dependency with GeneralUpdate.Differential
- **MacStrategy** fixed: \.Use(new HashMiddleware())\ → \.UseMiddleware<HashMiddleware>()\ (matching PipelineBuilder API)
- **BlackListManager API mismatches** fixed: \AddBlackFileFormats\ → \AddBlackFormats\, \BlackFileFormats\ → \BlackFormats\ in Bootstrap and SilentUpdateMode callers
- **DrivelutionMiddleware** remains excluded (requires net10.0; Core targets netstandard2.0)

## Verification
- \dotnet build src/c#/GeneralUpdate.slnx\ → **0 errors, 0 warnings** across all 11 projects
- All tests compile successfully

Closes #342