### PR TITLE
refactor: Phase 2 — extension points + Download orchestrator + BlackListConfigBuilder (#356)

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -26,10 +26,6 @@ namespace GeneralUpdate.Core.Configuration
             PopulateDefaults();
         }
 
-        /// <summary>
-        /// Populate all UpdateOptions with their best-practice defaults.
-        /// Subclasses can override to customize.
-        /// </summary>
         protected virtual void PopulateDefaults()
         {
             Option(UpdateOptions.MaxConcurrency, 3);
@@ -45,9 +41,6 @@ namespace GeneralUpdate.Core.Configuration
         protected abstract Task ExecuteStrategyAsync();
         protected abstract TBootstrap StrategyFactory();
 
-        /// <summary>
-        /// Setting update configuration.
-        /// </summary>
         public TBootstrap Option<T>(UpdateOption<T> option, T value)
         {
             if (value == null)
@@ -86,6 +79,9 @@ namespace GeneralUpdate.Core.Configuration
         public TBootstrap BinaryDiffer<T>() where T : Differential.IBinaryDiffer, new()
         { _extensions[typeof(Differential.IBinaryDiffer)] = typeof(T); return (TBootstrap)this; }
 
+        public TBootstrap PipelineFactory<T>() where T : Pipeline.IUpdatePipelineFactory, new()
+        { _extensions[typeof(Pipeline.IUpdatePipelineFactory)] = typeof(T); return (TBootstrap)this; }
+
         public TBootstrap DownloadPolicy<T>() where T : Download.Abstractions.IDownloadPolicy, new()
         { _extensions[typeof(Download.Abstractions.IDownloadPolicy)] = typeof(T); return (TBootstrap)this; }
 
@@ -94,6 +90,9 @@ namespace GeneralUpdate.Core.Configuration
 
         public TBootstrap DownloadSource<T>() where T : Download.Abstractions.IDownloadSource, new()
         { _extensions[typeof(Download.Abstractions.IDownloadSource)] = typeof(T); return (TBootstrap)this; }
+
+        public TBootstrap DownloadPipeline<T>() where T : Download.Abstractions.IDownloadPipeline, new()
+        { _extensions[typeof(Download.Abstractions.IDownloadPipeline)] = typeof(T); return (TBootstrap)this; }
 
         public TBootstrap UpdateReporter<T>() where T : Download.Reporting.IUpdateReporter, new()
         { _extensions[typeof(Download.Reporting.IUpdateReporter)] = typeof(T); return (TBootstrap)this; }

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackListConfigBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackListConfigBuilder.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using GeneralUpdate.Core.Configuration;
+
+namespace GeneralUpdate.Core.FileSystem;
+
+/// <summary>
+/// Fluent builder for <see cref="BlackListConfig"/>.
+/// Used via <c>Bootstrap.ConfigureBlackList(cfg => cfg.AddBlackFiles(...))</c>.
+/// </summary>
+public class BlackListConfigBuilder
+{
+    private readonly List<string> _blackFiles = new();
+    private readonly List<string> _blackFormats = new();
+    private readonly List<string> _skipDirectories = new();
+
+    public BlackListConfigBuilder AddBlackFiles(params string[] files)
+    {
+        _blackFiles.AddRange(files);
+        return this;
+    }
+
+    public BlackListConfigBuilder AddBlackFormats(params string[] formats)
+    {
+        _blackFormats.AddRange(formats);
+        return this;
+    }
+
+    public BlackListConfigBuilder AddSkipDirectories(params string[] directories)
+    {
+        _skipDirectories.AddRange(directories);
+        return this;
+    }
+
+    public BlackListConfig Build() => new(
+        BlackFiles: _blackFiles.Count > 0 ? _blackFiles.AsReadOnly() : null,
+        BlackFormats: _blackFormats.Count > 0 ? _blackFormats.AsReadOnly() : null,
+        SkipDirectorys: _skipDirectories.Count > 0 ? _skipDirectories.AsReadOnly() : null
+    );
+}

--- a/src/c#/GeneralUpdate.Core/Pipeline/IUpdatePipelineFactory.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/IUpdatePipelineFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Core.Pipeline;
+
+/// <summary>
+/// Factory for creating update pipelines.
+/// Injected via <c>Bootstrap.PipelineFactory&lt;T&gt;()</c>.
+/// </summary>
+public interface IUpdatePipelineFactory
+{
+    /// <summary>Create a pipeline for the given context.</summary>
+    Task ExecutePipelineAsync(PipelineContext context, CancellationToken token = default);
+}


### PR DESCRIPTION
Phase 2 of the v2 refactoring: completes extension point system, wires Download orchestrator into strategies, and adds BlackListConfigBuilder.

Changes:
- IUpdatePipelineFactory interface + .PipelineFactory<T>() extension point
- .DownloadPipeline<T>() extension point
- ClientUpdateStrategy and UpgradeUpdateStrategy accept optional IDownloadOrchestrator via constructor
- BlackListConfigBuilder with fluent AddBlackFiles/Formats/Dirs API
- ConfigureBlackList(Action<BlackListConfigBuilder>) builder overload

Full solution: 0 errors
Closes #356