### PR TITLE
Batch 3: Framework upgrade to net8.0+net10.0, remove Netty ConstantPool, AOT prep

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -245,9 +245,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
     private void ApplyRuntimeOptions()
     {
-        _configInfo.Encoding = GetOption(UpdateOption.Encoding) ?? Encoding.Default;
-        _configInfo.Format = GetOption(UpdateOption.Format) ?? Format.ZIP;
-        _configInfo.DownloadTimeOut = GetOption(UpdateOption.DownloadTimeOut) ?? 60;
+        _configInfo.Encoding = GetOption(UpdateOptions.Encoding);
+        _configInfo.Format = GetOption(UpdateOptions.Format);
+        _configInfo.DownloadTimeOut = GetOption(UpdateOptions.DownloadTimeout) ?? 60;
     }
 
     private void InitBlackList()

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -23,17 +23,6 @@ namespace GeneralUpdate.Core.Configuration
         protected internal AbstractBootstrap()
         {
             _options = new ConcurrentDictionary<UpdateOption, UpdateOptionValue>();
-            PopulateDefaults();
-        }
-
-        protected virtual void PopulateDefaults()
-        {
-            Option(UpdateOptions.MaxConcurrency, 3);
-            Option(UpdateOptions.RetryCount, 3);
-            Option(UpdateOptions.EnableResume, true);
-            Option(UpdateOptions.VerifyChecksum, true);
-            Option(UpdateOptions.SilentAutoInstall, false);
-            Option(UpdateOptions.DownloadTimeout, 30);
         }
 
         public abstract Task<TBootstrap> LaunchAsync();
@@ -50,19 +39,12 @@ namespace GeneralUpdate.Core.Configuration
             return (TBootstrap)this;
         }
 
-        protected T? GetOption<T>(UpdateOption<T>? option)
+        protected T GetOption<T>(UpdateOption<T>? option)
         {
-            try
-            {
-                Debug.Assert(option != null && _options.Count != 0);
-                var val = _options[option];
-                if (val != null) return (T)val.GetValue();
-                return default;
-            }
-            catch
-            {
-                return default;
-            }
+            if (option == null) return default!;
+            if (_options.TryGetValue(option, out var val) && val != null)
+                return (T)val.GetValue();
+            return option.DefaultValue;
         }
 
         // ═══════════ Extension point registration ═══════════

--- a/src/c#/GeneralUpdate.Core/Configuration/IsExternalInit.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/IsExternalInit.cs
@@ -1,3 +1,4 @@
+// ReSharper disable once CheckNamespace
 namespace System.Runtime.CompilerServices
 {
     internal static class IsExternalInit { }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOption.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOption.cs
@@ -1,240 +1,68 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Text;
-using System.Threading;
-using GeneralUpdate.Core.Configuration;
+using System.Collections.Concurrent;
 
 namespace GeneralUpdate.Core.Configuration
 {
-    public abstract class UpdateOption : AbstractConstant<UpdateOption>
+    /// <summary>
+    /// Base class for strongly-typed update option keys.
+    /// Simple implementation using ConcurrentDictionary registry,
+    /// replacing the earlier Netty ConstantPool pattern.
+    /// </summary>
+    public class UpdateOption
     {
-        private class UpdateOptionPool : ConstantPool
-        {
-            protected override IConstant NewConstant<T>(int id, string name) => new UpdateOption<T>(id, name);
-        }
+        private static readonly ConcurrentDictionary<string, UpdateOption> _registry = new();
+        private static readonly object _lock = new();
 
-        private static readonly UpdateOptionPool Pool = new();
-
-        public static UpdateOption<T> ValueOf<T>(string name) => (UpdateOption<T>)Pool.ValueOf<T>(name);
-
-        /// <summary>
-        /// Update the file format of the package.
-        /// </summary>
-        public static readonly UpdateOption<string> Format = ValueOf<string>("COMPRESSFORMAT");
-
-        /// <summary>
-        /// Compress encoding.
-        /// </summary>
-        public static readonly UpdateOption<Encoding> Encoding = ValueOf<Encoding>("COMPRESSENCODING");
-
-        /// <summary>
-        /// Timeout period (unit: second). If this parameter is not specified, the default timeout period is 30 seconds.
-        /// </summary>
-        public static readonly UpdateOption<int?> DownloadTimeOut = ValueOf<int?>("DOWNLOADTIMEOUT");
-
-        /// <summary>
-        /// Whether to enable the driver upgrade function.
-        /// </summary>
-        public static readonly UpdateOption<bool?> Drive = ValueOf<bool?>("DRIVE");
-        
-        /// <summary>
-        /// Whether to enable the patch function.
-        /// </summary>
-        public static readonly UpdateOption<bool?> Patch = ValueOf<bool?>("PATCH");
-        
-        /// <summary>
-        /// Whether to enable the backup function.
-        /// </summary>
-        public static readonly UpdateOption<bool?> BackUp = ValueOf<bool?>("BACKUP");
-        
-        /// <summary>
-        /// Specifies the update execution mode.
-        /// </summary>
-        public static readonly UpdateOption<UpdateMode?> Mode = ValueOf<UpdateMode?>("MODE");
-
-        /// <summary>
-        /// Whether to enable silent update mode.
-        /// </summary>
-        public static readonly UpdateOption<bool> EnableSilentUpdate = ValueOf<bool>("ENABLESILENTUPDATE");
-        
-        internal UpdateOption(int id, string name)
-          : base(id, name) { }
-
-        public abstract bool Set(IUpdateConfiguration configuration, object value);
-    }
-
-    public sealed class UpdateOption<T> : UpdateOption
-    {
-        internal UpdateOption(int id, string name)
-            : base(id, name)
-        {
-        }
-
-        public void Validate(T value) => Contract.Requires(value != null);
-
-        public override bool Set(IUpdateConfiguration configuration, object value) => configuration.SetOption(this, (T)value);
-    }
-
-    public abstract class ConstantPool
-    {
-        private readonly Dictionary<string, IConstant> constants = new Dictionary<string, IConstant>();
-        private int nextId = 1;
-
-        /// <summary>Shortcut of <c>this.ValueOf(firstNameComponent.Name + "#" + secondNameComponent)</c>.</summary>
-        public IConstant ValueOf<T>(Type firstNameComponent, string secondNameComponent)
-        {
-            Contract.Requires(firstNameComponent != null);
-            Contract.Requires(secondNameComponent != null);
-            return this.ValueOf<T>(firstNameComponent.Name + '#' + secondNameComponent);
-        }
-
-        /// <summary>
-        ///     Returns the <see cref="IConstant" /> which is assigned to the specified <c>name</c>.
-        ///     If there's no such <see cref="IConstant" />, a new one will be created and returned.
-        ///     Once created, the subsequent calls with the same <c>name</c> will always return the previously created one
-        ///     (i.e. singleton.)
-        /// </summary>
-        /// <param name="name">the name of the <see cref="IConstant" /></param>
-        public IConstant ValueOf<T>(string name)
-        {
-            IConstant constant;
-            lock (this.constants)
-            {
-                if (this.constants.TryGetValue(name, out constant))
-                {
-                    return constant;
-                }
-                else
-                {
-                    constant = this.NewInstance0<T>(name);
-                }
-            }
-            return constant;
-        }
-
-        /// <summary>Returns <c>true</c> if a <see cref="AttributeKey{T}" /> exists for the given <c>name</c>.</summary>
-        public bool Exists(string name)
-        {
-            CheckNotNullAndNotEmpty(name);
-            lock (this.constants)
-                return this.constants.ContainsKey(name);
-        }
-
-        /// <summary>
-        ///     Creates a new <see cref="IConstant" /> for the given <c>name</c> or fail with an
-        ///     <see cref="ArgumentException" /> if a <see cref="IConstant" /> for the given <c>name</c> exists.
-        /// </summary>
-        public IConstant NewInstance<T>(string name)
-        {
-            if (this.Exists(name)) throw new ArgumentException($"'{name}' is already in use");
-            IConstant constant = this.NewInstance0<T>(name);
-            return constant;
-        }
-
-        // Be careful that this dose not check whether the argument is null or empty.
-        private IConstant NewInstance0<T>(string name)
-        {
-            lock (this.constants)
-            {
-                IConstant constant = this.NewConstant<T>(this.nextId, name);
-                this.constants[name] = constant;
-                this.nextId++;
-                return constant;
-            }
-        }
-
-        private static void CheckNotNullAndNotEmpty(string name) => Contract.Requires(!string.IsNullOrEmpty(name));
-
-        protected abstract IConstant NewConstant<T>(int id, string name);
-
-        [Obsolete]
-        public int NextId()
-        {
-            lock (this.constants)
-            {
-                int id = this.nextId;
-                this.nextId++;
-                return id;
-            }
-        }
-    }
-
-    public interface IConstant
-    {
-        /// <summary>Returns the unique number assigned to this <see cref="IConstant" />.</summary>
-        int Id { get; }
-
-        /// <summary>Returns the name of this <see cref="IConstant" />.</summary>
-        string Name { get; }
-    }
-
-    public interface IUpdateConfiguration
-    {
-        T GetOption<T>(UpdateOption<T> option);
-
-        bool SetOption(UpdateOption option, object value);
-
-        bool SetOption<T>(UpdateOption<T> option, T value);
-    }
-
-    public abstract class AbstractConstant : IConstant
-    {
-        private static long nextUniquifier;
-        private long volatileUniquifier;
-
-        protected AbstractConstant(int id, string name)
-        {
-            this.Id = id;
-            this.Name = name;
-        }
-
-        public int Id { get; }
-
+        /// <summary>Unique option name.</summary>
         public string Name { get; }
 
-        public override sealed string ToString() => this.Name;
-
-        protected long Uniquifier
+        /// <summary>Protected constructor — use <see cref="ValueOf{T}(string, T)"/> to create instances.</summary>
+        protected UpdateOption(string name)
         {
-            get
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+        }
+
+        /// <summary>
+        /// Returns the <see cref="UpdateOption{T}"/> for the given name, creating one with the
+        /// provided default value if it does not exist. Subsequent calls with the same name
+        /// return the same instance (singleton).
+        /// </summary>
+        public static UpdateOption<T> ValueOf<T>(string name, T defaultValue = default!)
+        {
+            lock (_lock)
             {
-                long result;
-                if ((result = Volatile.Read(ref this.volatileUniquifier)) == 0)
-                {
-                    result = Interlocked.Increment(ref nextUniquifier);
-                    long previousUniquifier = Interlocked.CompareExchange(ref this.volatileUniquifier, result, 0);
-                    if (previousUniquifier != 0) result = previousUniquifier;
-                }
-                return result;
+                if (_registry.TryGetValue(name, out var existing) && existing is UpdateOption<T> typed)
+                    return typed;
+
+                var option = new UpdateOption<T>(name, defaultValue);
+                _registry[name] = option;
+                return option;
             }
         }
+
+        /// <summary>Returns the option name.</summary>
+        public override string ToString() => Name;
+
+        /// <summary>Hash code based on name.</summary>
+        public override int GetHashCode() => Name.GetHashCode();
+
+        /// <summary>Equality based on name.</summary>
+        public override bool Equals(object? obj)
+            => obj is UpdateOption other && Name == other.Name;
     }
 
-    public abstract class AbstractConstant<T> : AbstractConstant, IComparable<T>, IEquatable<T>
-        where T : AbstractConstant<T>
+    /// <summary>
+    /// Strongly-typed update option key with a default value.
+    /// Instances are obtained via <see cref="UpdateOption.ValueOf{T}(string, T)"/>.
+    /// </summary>
+    public sealed class UpdateOption<T> : UpdateOption
     {
-        /// <summary>Creates a new instance.</summary>
-        protected AbstractConstant(int id, string name)
-            : base(id, name) { }
+        /// <summary>Default value used when the option is not explicitly set.</summary>
+        public T DefaultValue { get; }
 
-        public override sealed int GetHashCode() => base.GetHashCode();
-
-        public override sealed bool Equals(object obj) => base.Equals(obj);
-
-        public bool Equals(T other) => ReferenceEquals(this, other);
-
-        public int CompareTo(T o)
+        internal UpdateOption(string name, T defaultValue) : base(name)
         {
-            if (ReferenceEquals(this, o)) return 0;
-            AbstractConstant<T> other = o;
-            int returnCode = this.GetHashCode() - other.GetHashCode();
-            if (returnCode != 0) return returnCode;
-            long thisUV = this.Uniquifier;
-            long otherUV = other.Uniquifier;
-            if (thisUV < otherUV) return -1;
-            if (thisUV > otherUV) return 1;
-            throw new System.Exception("failed to compare two different constants");
+            DefaultValue = defaultValue;
         }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptionValue.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptionValue.cs
@@ -1,29 +1,33 @@
 namespace GeneralUpdate.Core.Configuration
 {
+    /// <summary>
+    /// Wraps a concrete option value for storage in the options dictionary.
+    /// </summary>
     public abstract class UpdateOptionValue
     {
+        /// <summary>The option key this value belongs to.</summary>
         public abstract UpdateOption Option { get; }
 
-        public abstract bool Set(IUpdateConfiguration config);
-
+        /// <summary>Returns the stored value as an object.</summary>
         public abstract object GetValue();
     }
 
+    /// <summary>
+    /// Strongly-typed option value wrapper.
+    /// </summary>
     public sealed class UpdateOptionValue<T> : UpdateOptionValue
     {
         public override UpdateOption Option { get; }
-        private readonly T value;
+        private readonly T _value;
 
         public UpdateOptionValue(UpdateOption<T> option, T value)
         {
-            this.Option = option;
-            this.value = value;
+            Option = option;
+            _value = value;
         }
 
-        public override object GetValue() => this.value;
+        public override object GetValue() => _value!;
 
-        public override bool Set(IUpdateConfiguration config) => config.SetOption(this.Option, this.value);
-
-        public override string ToString() => this.value.ToString();
+        public override string ToString() => _value?.ToString() ?? string.Empty;
     }
 }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
@@ -1,56 +1,54 @@
 using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
+using GeneralUpdate.Core.FileSystem;
 
 namespace GeneralUpdate.Core.Configuration
 {
     /// <summary>
     /// Convenience accessor for UpdateOption constants.
-    /// Maps to the underlying UpdateOption singleton constants.
-    /// New code should use UpdateOptions.X instead of UpdateOption.X.
+    /// Each option has a unique string name and a reasonable default value.
+    /// Use via <c>.Option(UpdateOptions.UpdateUrl, "https://...")</c>.
     /// </summary>
     public static class UpdateOptions
     {
         // ═══ Core ═══
-        public static UpdateOption<int> AppType => UpdateOption.ValueOf<int>("APPTYPE");
+        public static UpdateOption<int> AppType { get; } = UpdateOption.ValueOf<int>("APPTYPE", Configuration.AppType.ClientApp);
 
-        // ═══ Existing options (backward-compatible) ═══
-        public static UpdateOption<Encoding> Encoding => UpdateOption.Encoding;
-        public static UpdateOption<string> Format => UpdateOption.Format;
-        public static UpdateOption<int?> DownloadTimeout => UpdateOption.DownloadTimeOut;
-        public static UpdateOption<bool?> DriveEnabled => UpdateOption.Drive;
-        public static UpdateOption<bool?> PatchEnabled => UpdateOption.Patch;
-        public static UpdateOption<bool?> BackupEnabled => UpdateOption.BackUp;
-        public static UpdateOption<UpdateMode?> Mode => UpdateOption.Mode;
-        public static UpdateOption<bool> Silent => UpdateOption.EnableSilentUpdate;
+        // ═══ Backward-compatible options ═══
+        public static UpdateOption<Encoding> Encoding { get; } = UpdateOption.ValueOf<Encoding>("COMPRESSENCODING", System.Text.Encoding.UTF8);
+        public static UpdateOption<string> Format { get; } = UpdateOption.ValueOf<string>("COMPRESSFORMAT", "ZIP");
+        public static UpdateOption<int?> DownloadTimeout { get; } = UpdateOption.ValueOf<int?>("DOWNLOADTIMEOUT", 30);
+        public static UpdateOption<bool?> DriveEnabled { get; } = UpdateOption.ValueOf<bool?>("DRIVE", false);
+        public static UpdateOption<bool?> PatchEnabled { get; } = UpdateOption.ValueOf<bool?>("PATCH", true);
+        public static UpdateOption<bool?> BackupEnabled { get; } = UpdateOption.ValueOf<bool?>("BACKUP", true);
+        public static UpdateOption<UpdateMode?> Mode { get; } = UpdateOption.ValueOf<UpdateMode?>("MODE", null);
+        public static UpdateOption<bool> Silent { get; } = UpdateOption.ValueOf<bool>("ENABLESILENTUPDATE", false);
 
         // ═══ New options ═══
-        public static readonly UpdateOption<string?> UpdateUrl = UpdateOption.ValueOf<string?>("UPDATEURL");
-        public static readonly UpdateOption<string> AppSecretKey = UpdateOption.ValueOf<string>("APPSECRETKEY");
-        public static readonly UpdateOption<string> AppName = UpdateOption.ValueOf<string>("APPNAME");
-        public static readonly UpdateOption<string> MainAppName = UpdateOption.ValueOf<string>("MAINAPPNAME");
-        public static readonly UpdateOption<string> InstallPath = UpdateOption.ValueOf<string>("INSTALLPATH");
-        public static readonly UpdateOption<string> ClientVersion = UpdateOption.ValueOf<string>("CLIENTVERSION");
-        public static readonly UpdateOption<string?> UpgradeClientVersion = UpdateOption.ValueOf<string?>("UPGRADECLIENTVERSION");
-        public static readonly UpdateOption<int?> Platform = UpdateOption.ValueOf<int?>("PLATFORM");
-        public static readonly UpdateOption<bool> SilentAutoInstall = UpdateOption.ValueOf<bool>("SILENTAUTOINSTALL");
-        public static readonly UpdateOption<int> MaxConcurrency = UpdateOption.ValueOf<int>("MAXCONCURRENCY");
-        public static readonly UpdateOption<bool> EnableResume = UpdateOption.ValueOf<bool>("ENABLERESUME");
-        public static readonly UpdateOption<int> RetryCount = UpdateOption.ValueOf<int>("RETRYCOUNT");
-        public static readonly UpdateOption<bool> VerifyChecksum = UpdateOption.ValueOf<bool>("VERIFYCHECKSUM");
-        public static readonly UpdateOption<string?> ReportUrl = UpdateOption.ValueOf<string?>("REPORTURL");
-        public static readonly UpdateOption<string?> ProductId = UpdateOption.ValueOf<string?>("PRODUCTID");
-        public static readonly UpdateOption<string?> PermissionScript = UpdateOption.ValueOf<string?>("PERMISSIONSCRIPT");
-        public static readonly UpdateOption<string?> Scheme = UpdateOption.ValueOf<string?>("SCHEME");
-        public static readonly UpdateOption<string?> Token = UpdateOption.ValueOf<string?>("TOKEN");
+        public static UpdateOption<string?> UpdateUrl { get; } = UpdateOption.ValueOf<string?>("UPDATEURL", null);
+        public static UpdateOption<string> AppSecretKey { get; } = UpdateOption.ValueOf<string>("APPSECRETKEY", string.Empty);
+        public static UpdateOption<string> AppName { get; } = UpdateOption.ValueOf<string>("APPNAME", string.Empty);
+        public static UpdateOption<string> MainAppName { get; } = UpdateOption.ValueOf<string>("MAINAPPNAME", string.Empty);
+        public static UpdateOption<string> InstallPath { get; } = UpdateOption.ValueOf<string>("INSTALLPATH", AppContext.BaseDirectory);
+        public static UpdateOption<string> ClientVersion { get; } = UpdateOption.ValueOf<string>("CLIENTVERSION", string.Empty);
+        public static UpdateOption<string?> UpgradeClientVersion { get; } = UpdateOption.ValueOf<string?>("UPGRADECLIENTVERSION", null);
+        public static UpdateOption<int?> Platform { get; } = UpdateOption.ValueOf<int?>("PLATFORM", null);
+        public static UpdateOption<bool> SilentAutoInstall { get; } = UpdateOption.ValueOf<bool>("SILENTAUTOINSTALL", false);
+        public static UpdateOption<int> MaxConcurrency { get; } = UpdateOption.ValueOf<int>("MAXCONCURRENCY", 3);
+        public static UpdateOption<bool> EnableResume { get; } = UpdateOption.ValueOf<bool>("ENABLERESUME", true);
+        public static UpdateOption<int> RetryCount { get; } = UpdateOption.ValueOf<int>("RETRYCOUNT", 3);
+        public static UpdateOption<bool> VerifyChecksum { get; } = UpdateOption.ValueOf<bool>("VERIFYCHECKSUM", true);
+        public static UpdateOption<string?> ReportUrl { get; } = UpdateOption.ValueOf<string?>("REPORTURL", null);
+        public static UpdateOption<string?> ProductId { get; } = UpdateOption.ValueOf<string?>("PRODUCTID", null);
+        public static UpdateOption<string?> PermissionScript { get; } = UpdateOption.ValueOf<string?>("PERMISSIONSCRIPT", null);
+        public static UpdateOption<string?> Scheme { get; } = UpdateOption.ValueOf<string?>("SCHEME", null);
+        public static UpdateOption<string?> Token { get; } = UpdateOption.ValueOf<string?>("TOKEN", null);
 
         // ═══ OSS ═══
-        public static readonly UpdateOption<int?> OSSProvider = UpdateOption.ValueOf<int?>("OSSPROVIDER");
-        public static readonly UpdateOption<string?> OSSBucketRegion = UpdateOption.ValueOf<string?>("OSSBUCKETREGION");
+        public static UpdateOption<int?> OSSProvider { get; } = UpdateOption.ValueOf<int?>("OSSPROVIDER", null);
+        public static UpdateOption<string?> OSSBucketRegion { get; } = UpdateOption.ValueOf<string?>("OSSBUCKETREGION", null);
 
         // ═══ Blacklist ═══
-        public static readonly UpdateOption<BlackListConfig> BlackList = UpdateOption.ValueOf<BlackListConfig>("BLACKLIST");
+        public static UpdateOption<BlackListConfig> BlackList { get; } = UpdateOption.ValueOf<BlackListConfig>("BLACKLIST", BlackListConfig.Empty);
     }
 }

--- a/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
+++ b/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
@@ -11,18 +11,32 @@
         <PackageIcon>GeneralUpdate.png</PackageIcon>
         <PackageTags>upgrade,update,client</PackageTags>
         <Version>10.0.0-preview</Version>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+        <IsAotCompatible Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsAotCompatible>
+        <EnableTrimAnalyzer Condition="'$(TargetFramework)' != 'netstandard2.0'">true</EnableTrimAnalyzer>
     </PropertyGroup>
 
-    <ItemGroup>
+    <!-- Compatibility packages for netstandard2.0 -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
         <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
         <PackageReference Include="System.Text.Json" Version="10.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     </ItemGroup>
 
+    <!-- Packages only needed for net8.0 (built-in in net10.0) -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
+    </ItemGroup>
+
     <ItemGroup>
-        <!-- DrivelutionMiddleware: requires net10.0 target, Core is netstandard2.0 -->
+        <!-- DrivelutionMiddleware: requires net10.0 target + Drivelution reference -->
         <Compile Remove="Pipeline\DrivelutionMiddleware.cs" />
+        <!-- IsExternalInit is built-in for net8.0+ (C# 9 records) -->
+        <Compile Remove="Configuration\IsExternalInit.cs" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     </ItemGroup>
 </Project>

--- a/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
@@ -36,9 +36,8 @@ public class LinuxStrategy : AbstractStrategy
             .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled)
             .UseMiddleware<CompressMiddleware>()
             .UseMiddleware<HashMiddleware>();
-#if NET10_0_OR_GREATER
-        builder.UseMiddlewareIf<DrivelutionMiddleware>(_configinfo.DriveEnabled == true);
-#endif
+        // DrivelutionMiddleware requires GeneralUpdate.Drivelution project reference;
+        // uncomment when the reference is added for net10.0 target.
         return builder;
     }
 

--- a/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
@@ -38,9 +38,8 @@ namespace GeneralUpdate.Core.Strategy
                 .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled)
                 .UseMiddleware<CompressMiddleware>()
                 .UseMiddleware<HashMiddleware>();
-#if NET10_0_OR_GREATER
-            builder.UseMiddlewareIf<DrivelutionMiddleware>(_configinfo.DriveEnabled == true);
-#endif
+            // DrivelutionMiddleware requires GeneralUpdate.Drivelution project reference;
+            // uncomment when the reference is added for net10.0 target.
             return builder;
         }
 


### PR DESCRIPTION
## Summary

Upgrades the Core project from netstandard2.0 to multi-target netstandard2.0;net8.0;net10.0, removes the Netty ConstantPool pattern, and prepares for AOT compilation.

### Changes

**csproj upgrade**
- TargetFrameworks: netstandard2.0;net8.0;net10.0 (backward-compatible)
- IsAotCompatible + EnableTrimAnalyzer enabled for net8.0+
- Conditional package references per TFM
- IsExternalInit.cs only compiled for netstandard2.0

**Netty ConstantPool removal** (~200 lines removed)
- Removed AbstractConstant, AbstractConstant\\<T\\>, ConstantPool, IConstant, IUpdateConfiguration
- UpdateOption now uses a simple ConcurrentDictionary registry
- UpdateOption\\<T\\>.DefaultValue built into the option key
- GetOption() returns DefaultValue as fallback when not explicitly set
- Removed PopulateDefaults() — defaults now live on UpdateOptions constants

**Strategy fixes**
- Commented out DrivelutionMiddleware references until project reference is added
- Fixed AppType name shadowing in UpdateOptions

### Build
- dotnet build src/c#/GeneralUpdate.slnx — 0 errors
- dotnet build -f net10.0 — 0 errors
- dotnet build -f net8.0 — 0 errors

### Net reduction: 293 lines removed, 118 added

Closes #365