### PR TITLE
Batch 7: Extension points + configuration completion

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -82,6 +82,12 @@ namespace GeneralUpdate.Core.Configuration
         public TBootstrap UpdateAuth<T>() where T : Security.IHttpAuthProvider, new()
         { _extensions[typeof(Security.IHttpAuthProvider)] = typeof(T); return (TBootstrap)this; }
 
+        public TBootstrap DownloadOrchestrator<T>() where T : Download.Abstractions.IDownloadOrchestrator, new()
+        { _extensions[typeof(Download.Abstractions.IDownloadOrchestrator)] = typeof(T); return (TBootstrap)this; }
+
+        // ICleanStrategy / IDirtyStrategy extension points are in GeneralUpdate.Differential.
+        // Add via external extension methods once the project reference is established.
+
         public TBootstrap ConfigureBlackList(BlackListConfig config)
         {
             _instances[typeof(BlackListConfig)] = config ?? BlackListConfig.Empty;

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
@@ -14,6 +14,9 @@ namespace GeneralUpdate.Core.Configuration
         // ═══ Core ═══
         public static UpdateOption<int> AppType { get; } = UpdateOption.ValueOf<int>("APPTYPE", Configuration.AppType.ClientApp);
 
+        // ═══ Diff mode ═══
+        public static UpdateOption<DiffMode> DiffMode { get; } = UpdateOption.ValueOf<DiffMode>("DIFFMODE", Configuration.DiffMode.Serial);
+
         // ═══ Backward-compatible options ═══
         public static UpdateOption<Encoding> Encoding { get; } = UpdateOption.ValueOf<Encoding>("COMPRESSENCODING", System.Text.Encoding.UTF8);
         public static UpdateOption<string> Format { get; } = UpdateOption.ValueOf<string>("COMPRESSFORMAT", "ZIP");


### PR DESCRIPTION
## Summary

Adds missing extension point and configuration options.

### Changes

**AbstractBootstrap**
- Add DownloadOrchestrator\\<T\\>() extension point
- Placeholder comments for ICleanStrategy/IDirtyStrategy (require cross-project reference to Differential)

**UpdateOptions**
- Add DiffMode option (Serial default)

### Build
- dotnet build src/c#/GeneralUpdate.slnx — 0 errors

Closes #373