### PR TITLE
Move ICleanStrategy/IDirtyStrategy to Core — Core owns Differential contracts

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -85,13 +85,11 @@ namespace GeneralUpdate.Core.Configuration
         public TBootstrap DownloadOrchestrator<T>() where T : Download.Abstractions.IDownloadOrchestrator, new()
         { _extensions[typeof(Download.Abstractions.IDownloadOrchestrator)] = typeof(T); return (TBootstrap)this; }
 
-        /// <summary>Register a custom clean strategy by type name (interface lives in GeneralUpdate.Differential).</summary>
-        public TBootstrap CleanStrategy<T>() where T : class, new()
-        { _extensions[typeof(T)] = typeof(T); return (TBootstrap)this; }
+        public TBootstrap CleanStrategy<T>() where T : Differential.ICleanStrategy, new()
+        { _extensions[typeof(Differential.ICleanStrategy)] = typeof(T); return (TBootstrap)this; }
 
-        /// <summary>Register a custom dirty strategy by type name (interface lives in GeneralUpdate.Differential).</summary>
-        public TBootstrap DirtyStrategy<T>() where T : class, new()
-        { _extensions[typeof(T)] = typeof(T); return (TBootstrap)this; }
+        public TBootstrap DirtyStrategy<T>() where T : Differential.IDirtyStrategy, new()
+        { _extensions[typeof(Differential.IDirtyStrategy)] = typeof(T); return (TBootstrap)this; }
 
         public TBootstrap ConfigureBlackList(BlackListConfig config)
         {

--- a/src/c#/GeneralUpdate.Core/Differential/ICleanStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Differential/ICleanStrategy.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Core.Differential;
+
+/// <summary>
+/// Defines the complete execution strategy for the Clean (patch-generation) phase.
+/// Implement this interface to fully control how source and target directories are
+/// compared and how the patch output is produced.
+/// </summary>
+public interface ICleanStrategy
+{
+    /// <summary>
+    /// Executes the Clean phase: compares <paramref name="sourcePath"/> with
+    /// <paramref name="targetPath"/> and writes the resulting patch artifacts to
+    /// <paramref name="patchPath"/>.
+    /// </summary>
+    Task ExecuteAsync(string sourcePath, string targetPath, string patchPath);
+}

--- a/src/c#/GeneralUpdate.Core/Differential/IDirtyStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Differential/IDirtyStrategy.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace GeneralUpdate.Core.Differential;
+
+/// <summary>
+/// Defines the complete execution strategy for the Dirty (patch-application) phase.
+/// Implement this interface to fully control how patch files are applied to the
+/// target application directory.
+/// </summary>
+public interface IDirtyStrategy
+{
+    /// <summary>
+    /// Executes the Dirty phase: applies patches from <paramref name="patchPath"/>
+    /// to the application files in <paramref name="appPath"/>.
+    /// </summary>
+    Task ExecuteAsync(string appPath, string patchPath);
+}

--- a/src/c#/GeneralUpdate.Differential/Matchers/ICleanStrategy.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/ICleanStrategy.cs
@@ -1,19 +1,6 @@
-using System.Threading.Tasks;
-
+// ReSharper disable once CheckNamespace
 namespace GeneralUpdate.Differential.Matchers
 {
-    /// <summary>
-    /// Defines the complete execution strategy for the Clean (patch-generation) phase.
-    /// Implement this interface to fully control how source and target directories are
-    /// compared and how the patch output is produced.
-    /// </summary>
-    public interface ICleanStrategy
-    {
-        /// <summary>
-        /// Executes the Clean phase: compares <paramref name="sourcePath"/> with
-        /// <paramref name="targetPath"/> and writes the resulting patch artifacts to
-        /// <paramref name="patchPath"/>.
-        /// </summary>
-        Task ExecuteAsync(string sourcePath, string targetPath, string patchPath);
-    }
+    /// <summary>Backward-compatible alias for <see cref="Core.Differential.ICleanStrategy"/>.</summary>
+    public interface ICleanStrategy : GeneralUpdate.Core.Differential.ICleanStrategy { }
 }

--- a/src/c#/GeneralUpdate.Differential/Matchers/IDirtyStrategy.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/IDirtyStrategy.cs
@@ -1,18 +1,6 @@
-using System.Threading.Tasks;
-
+// ReSharper disable once CheckNamespace
 namespace GeneralUpdate.Differential.Matchers
 {
-    /// <summary>
-    /// Defines the complete execution strategy for the Dirty (patch-application) phase.
-    /// Implement this interface to fully control how patch files are applied to the
-    /// target application directory.
-    /// </summary>
-    public interface IDirtyStrategy
-    {
-        /// <summary>
-        /// Executes the Dirty phase: applies patches from <paramref name="patchPath"/>
-        /// to the application files in <paramref name="appPath"/>.
-        /// </summary>
-        Task ExecuteAsync(string appPath, string patchPath);
-    }
+    /// <summary>Backward-compatible alias for <see cref="Core.Differential.IDirtyStrategy"/>.</summary>
+    public interface IDirtyStrategy : GeneralUpdate.Core.Differential.IDirtyStrategy { }
 }


### PR DESCRIPTION
## Summary

Moves the ICleanStrategy and IDirtyStrategy interface definitions into Core, so Core truly owns them. Differential keeps backward-compatible aliases that extend Core's interfaces.

### Architecture


Core (owns interfaces)
├── ICleanStrategy
├── IDirtyStrategy 
└── IBinaryDiffer

Differential → Core (implements Core's interfaces)
├── ICleanStrategy : Core.Differential.ICleanStrategy (alias)
├── IDirtyStrategy : Core.Differential.IDirtyStrategy (alias)
├── DefaultCleanStrategy : ICleanStrategy
├── DefaultDirtyStrategy : IDirtyStrategy
└── IBinaryDiffer : Core.Differential.IBinaryDiffer (alias)


**No circular dependency.** Differential references Core, not the reverse.

### Changes
- Create ICleanStrategy.cs and IDirtyStrategy.cs in Core.Differential
- Update AbstractBootstrap to use the actual interface constraints
- Differential interfaces become empty alias interfaces extending Core's
- Default implementations use local (Diff) interface types for backward compat

### Build
- dotnet build src/c#/GeneralUpdate.slnx — 0 errors

### Related
Addresses the remaining dependency architecture concern.