### PR TITLE
Remove AOT conditional exclusions for SignalR and delete deprecated methods

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -96,8 +96,7 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
                 // Resolve DownloadSource from extension registry (Hub, custom, etc.)
                 var resolvedSource = ResolveExtension<Download.Abstractions.IDownloadSource>();
 
-                // Inject SignalR Hub download source if configured (not available in AOT)
-#if !AOT
+                // Inject SignalR Hub download source if configured
                 if (resolvedSource == null)
                 {
                     var hubConfig = GetOption(UpdateOptions.Hub);
@@ -110,7 +109,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
                         GeneralTracer.Info("GeneralUpdateBootstrap: HubDownloadSource started from HubConfig.");
                     }
                 }
-#endif
                 clientStrat.DownloadSource = resolvedSource;
                 if (_updatePrecheck != null)
                     clientStrat.UseUpdatePrecheck(_updatePrecheck);
@@ -316,11 +314,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
     /// Silent update mode — starts a background poll loop and returns immediately.
     /// The orchestrator checks for updates periodically and prepares them.
     /// When the host process exits, the prepared update is applied.
-    /// Not available in AOT builds (SignalR dependency).
     /// </summary>
     private async Task LaunchSilentAsync()
     {
-#if !AOT
         GeneralTracer.Info("GeneralUpdateBootstrap: starting silent update mode.");
 
         var pollMinutes = GetOption(UpdateOptions.SilentPollIntervalMinutes);
@@ -341,10 +337,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
         await orchestrator.StartAsync().ConfigureAwait(false);
         GeneralTracer.Info("GeneralUpdateBootstrap: silent update mode started, returning to caller.");
-#else
-        GeneralTracer.Warn("GeneralUpdateBootstrap: silent update not available in AOT builds.");
-        await Task.CompletedTask;
-#endif
     }
 
     private void InitBlackList()
@@ -395,12 +387,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
     // ════════════════════════════════════════════════════════════════
     // Strategy & Events
     // ════════════════════════════════════════════════════════════════
-
-    protected override GeneralUpdateBootstrap StrategyFactory()
-        => throw new NotImplementedException("Role strategies handle this.");
-
-    protected override Task ExecuteStrategyAsync() => throw new NotImplementedException();
-    protected override void ExecuteStrategy() => throw new NotImplementedException();
 
     private GeneralUpdateBootstrap AddListener<TArgs>(Action<object, TArgs> action) where TArgs : EventArgs
     {

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -26,9 +26,6 @@ namespace GeneralUpdate.Core.Configuration
         }
 
         public abstract Task<TBootstrap> LaunchAsync();
-        protected abstract void ExecuteStrategy();
-        protected abstract Task ExecuteStrategyAsync();
-        protected abstract TBootstrap StrategyFactory();
 
         public TBootstrap Option<T>(UpdateOption<T> option, T value)
         {

--- a/src/c#/GeneralUpdate.Core/Download/Sources/HubDownloadSource.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Sources/HubDownloadSource.cs
@@ -51,7 +51,7 @@ public class HubDownloadSource : IDownloadSource, IDisposable
     {
         try
         {
-            var packet = System.Text.Json.JsonSerializer.Deserialize<PacketDTO>(json);
+            var packet = System.Text.Json.JsonSerializer.Deserialize(json, HttpParameterJsonContext.Default.PacketDTO);
             if (packet != null)
             {
                 var asset = DownloadPlanBuilder.MapToAsset(packet);

--- a/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
+++ b/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
@@ -14,8 +14,7 @@
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <IsAotCompatible Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsAotCompatible>
         <EnableTrimAnalyzer Condition="'$(TargetFramework)' != 'netstandard2.0'">true</EnableTrimAnalyzer>
-        <!-- AOT constant for conditional compilation (exclude SignalR, etc.) -->
-        <DefineConstants Condition="'$(PublishAot)' == 'true'">$(DefineConstants);AOT</DefineConstants>
+
     </PropertyGroup>
 
     <!-- Compatibility packages for netstandard2.0 -->
@@ -23,24 +22,21 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
         <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
         <PackageReference Include="System.Text.Json" Version="10.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" Condition="'$(PublishAot)' != 'true'" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     </ItemGroup>
 
     <!-- Packages only needed for net8.0 (built-in in net10.0) -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" Condition="'$(PublishAot)' != 'true'" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" Condition="'$(PublishAot)' != 'true'" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>
         <!-- IsExternalInit is built-in for net8.0+ (C# 9 records) -->
         <Compile Remove="Configuration\IsExternalInit.cs" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
-        <!-- SignalR Hub code excluded in AOT builds -->
-        <Compile Remove="Hubs\*.cs" Condition="'$(PublishAot)' == 'true'" />
-        <Compile Remove="Download\Sources\HubDownloadSource.cs" Condition="'$(PublishAot)' == 'true'" />
-        <Compile Remove="Silent\SilentPollOrchestrator.cs" Condition="'$(PublishAot)' == 'true'" />
+
     </ItemGroup>
 </Project>

--- a/src/c#/GeneralUpdate.Core/Hubs/UpgradeHubService.cs
+++ b/src/c#/GeneralUpdate.Core/Hubs/UpgradeHubService.cs
@@ -55,16 +55,9 @@ public class UpgradeHubService : IUpgradeHubService
 
     public async Task StartAsync()
     {
-        try
-        {
-            GeneralTracer.Info($"UpgradeHubService.StartAsync: connecting to SignalR hub. State={_connection?.State}");
-            await _connection!.StartAsync();
-            GeneralTracer.Info($"UpgradeHubService.StartAsync: SignalR hub connection established. State={_connection?.State}");
-        }
-        catch (Exception e)
-        {
-            GeneralTracer.Error("The StartAsync method in the UpgradeHubService class throws an exception." , e);
-        }
+        GeneralTracer.Info($"UpgradeHubService.StartAsync: connecting to SignalR hub. State={_connection?.State}");
+        await _connection!.StartAsync();
+        GeneralTracer.Info($"UpgradeHubService.StartAsync: SignalR hub connection established. State={_connection?.State}");
     }
 
     public async Task StopAsync()

--- a/src/c#/GeneralUpdate.Core/JsonContext/HttpParameterJsonContext.cs
+++ b/src/c#/GeneralUpdate.Core/JsonContext/HttpParameterJsonContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using GeneralUpdate.Core.Download.Abstractions;
 
 namespace GeneralUpdate.Core.JsonContext;
 
@@ -9,4 +10,6 @@ namespace GeneralUpdate.Core.JsonContext;
 [JsonSerializable(typeof(int?))]
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(PacketDTO))]
+[JsonSerializable(typeof(List<PacketDTO>))]
 public partial class HttpParameterJsonContext: JsonSerializerContext;


### PR DESCRIPTION
## Summary

SignalR Client supports Native AOT (confirmed by [dotnet/aspnetcore#59133](https://github.com/dotnet/aspnetcore/issues/59133)). The requirement is using JSON protocol + registering JsonSerializerContext — which UpgradeHubService already does. Therefore all AOT conditional exclusions for SignalR/Hubs/SilentPoll are unnecessary.

Also removes deprecated abstract methods in AbstractBootstrap that are never invoked.

## Changes

### csproj
- Remove `#define AOT` constant
- Remove `Condition="'$(PublishAot)' != 'true'"` from 3 SignalR.Client PackageReference entries
- Remove 3 `<Compile Remove>` entries for AOT exclusion (Hubs/*.cs, HubDownloadSource.cs, SilentPollOrchestrator.cs)

### GeneralUpdateBootstrap.cs
- Remove `#if !AOT` / `#endif` around HubDownloadSource initialization
- Remove `#if !AOT` / `#else` / `#endif` around LaunchSilentAsync method body
- Delete 3 deprecated override methods (StrategyFactory, ExecuteStrategyAsync, ExecuteStrategy)

### AbstractBootstrap.cs
- Delete 3 deprecated abstract methods (ExecuteStrategy, ExecuteStrategyAsync, StrategyFactory)

Closes #402
