### PR TITLE
fix: add missing hook/reporter calls in ClientUpdateStrategy and OSSUpdateStrategy

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -189,7 +189,10 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
                 return this;
             }
 
-            var upgradeAppName = "GeneralUpdate.Upgrade.exe";
+            // Use user-configured AppName, fall back to default updater name
+            var upgradeAppName = !string.IsNullOrWhiteSpace(_configInfo.AppName) && _configInfo.AppName != "Update.exe"
+                ? _configInfo.AppName
+                : "GeneralUpdate.Upgrade.exe";
             var appPath = Path.Combine(basePath, upgradeAppName);
             if (!File.Exists(appPath))
                 throw new Exception($"Upgrade application not found: {upgradeAppName}");

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
@@ -208,9 +208,12 @@ public class ClientUpdateStrategy : IStrategy
         }
 
         await SafeReportDownloadCompletedAsync(hooksCtx).ConfigureAwait(false);
+        await SafeOnDownloadCompletedAsync(hooksCtx).ConfigureAwait(false);
 
         // Apply updates and start app
         await _osStrategy.ExecuteAsync();
+        await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
+        await SafeReportUpdateAppliedAsync(hooksCtx).ConfigureAwait(false);
         await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
         _osStrategy.StartApp();
     }
@@ -318,6 +321,25 @@ public class ClientUpdateStrategy : IStrategy
         catch (Exception ex) { GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}"); }
     }
 
+    private async Task SafeOnAfterUpdateAsync(Hooks.UpdateContext ctx)
+    {
+        try { await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}"); }
+    }
+
+    private async Task SafeOnDownloadCompletedAsync(Hooks.UpdateContext ctx)
+    {
+        try
+        {
+            var downloadCtx = new Hooks.DownloadContext(
+                _configInfo?.MainAppName ?? _configInfo?.AppName ?? "unknown",
+                _configInfo?.LastVersion ?? "",
+                0, TimeSpan.Zero, _configInfo?.TempPath, true);
+            await Hooks.OnDownloadCompletedAsync(downloadCtx).ConfigureAwait(false);
+        }
+        catch (Exception ex) { GeneralTracer.Warn($"OnDownloadCompletedAsync hook failed: {ex.Message}"); }
+    }
+
     private async Task SafeReportUpdateStartedAsync(Hooks.UpdateContext ctx)
     {
         try
@@ -353,6 +375,18 @@ public class ClientUpdateStrategy : IStrategy
             )).ConfigureAwait(false);
         }
         catch (Exception ex) { GeneralTracer.Warn($"Report UpdateFailed failed: {ex.Message}"); }
+    }
+
+    private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx)
+    {
+        try
+        {
+            await Reporter.ReportAsync(new Download.Reporting.UpdateReport(
+                ctx.AppName, ctx.CurrentVersion, ctx.TargetVersion,
+                Download.Reporting.UpdateEvent.UpdateApplied, ctx.AppType, DateTimeOffset.UtcNow
+            )).ConfigureAwait(false);
+        }
+        catch (Exception ex) { GeneralTracer.Warn($"Report UpdateApplied failed: {ex.Message}"); }
     }
 
     #endregion

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -109,6 +109,10 @@ public class OSSUpdateStrategy : IStrategy
             GeneralTracer.Debug("OSSUpdateStrategy: 4. Decompressing packages.");
             DecompressAssets(assets);
 
+            // Hooks: download + decompress completed
+            await SafeOnDownloadCompletedAsync(ctx).ConfigureAwait(false);
+            await SafeOnAfterUpdateAsync(ctx).ConfigureAwait(false);
+
             // Report: update applied
             await SafeReportUpdateAppliedAsync(ctx).ConfigureAwait(false);
 
@@ -208,6 +212,25 @@ public class OSSUpdateStrategy : IStrategy
     {
         try { await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false); }
         catch (Exception ex) { GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}"); }
+    }
+
+    private async Task SafeOnAfterUpdateAsync(Hooks.UpdateContext ctx)
+    {
+        try { await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}"); }
+    }
+
+    private async Task SafeOnDownloadCompletedAsync(Hooks.UpdateContext ctx)
+    {
+        try
+        {
+            var downloadCtx = new Hooks.DownloadContext(
+                _configInfo?.MainAppName ?? _configInfo?.AppName ?? "unknown",
+                _configInfo?.LastVersion ?? "",
+                0, TimeSpan.Zero, _appPath, true);
+            await Hooks.OnDownloadCompletedAsync(downloadCtx).ConfigureAwait(false);
+        }
+        catch (Exception ex) { GeneralTracer.Warn($"OnDownloadCompletedAsync hook failed: {ex.Message}"); }
     }
 
     private async Task SafeReportUpdateStartedAsync(Hooks.UpdateContext ctx)


### PR DESCRIPTION
Closes #406

## Summary

After review of hook/reporter lifecycle across all update strategies, ClientUpdateStrategy and OSSUpdateStrategy were missing several calls that UpgradeUpdateStrategy and SilentPollOrchestrator already had.

## Changes (3 files, +61/-1)

### ClientUpdateStrategy
- \Hooks.OnDownloadCompletedAsync()\ — after download completes
- \Hooks.OnAfterUpdateAsync()\ — after pipeline execution
- \Reporter.ReportAsync(UpdateApplied)\ — after pipeline success

### OSSUpdateStrategy
- \Hooks.OnDownloadCompletedAsync()\ — after download + decompress
- \Hooks.OnAfterUpdateAsync()\ — after decompress

### Bootstrap
- OSS upgrade app name: use user-configured \AppName\, fall back to \GeneralUpdate.Upgrade.exe\

All four entry points now have consistent hook/reporter lifecycle.
Build: **0 errors**