### PR TITLE
refactor: Unify OSS update path through OSSUpdateStrategy

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -27,7 +27,8 @@ namespace GeneralUpdate.Core;
 /// <list type="bullet">
 ///   <item><see cref="AppType.Client"/> — validate versions, download, start upgrade process</item>
 ///   <item><see cref="AppType.Upgrade"/> — receive ProcessInfo, apply updates, start main app</item>
-///   <item><see cref="AppType.OSS"/> — OSS-based cloud storage update</item>
+///   <item><see cref="AppType.OSSClient"/> — OSS client: download version config, start upgrade process</item>
+///   <item><see cref="AppType.OSSUpgrade"/> — OSS upgrade: download packages from cloud, start main app</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -71,7 +72,8 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         {
             AppType.Client  => await LaunchWithStrategy(new ClientUpdateStrategy()),
             AppType.Upgrade => await LaunchWithStrategy(new UpgradeUpdateStrategy()),
-            AppType.OSS     => await LaunchWithStrategy(new OSSUpdateStrategy()),
+            AppType.OSSClient  => await LaunchWithStrategy(new OSSUpdateStrategy(AppType.OSSClient)),
+            AppType.OSSUpgrade => await LaunchWithStrategy(new OSSUpdateStrategy(AppType.OSSUpgrade)),
             _ => await LaunchWithStrategy(new ClientUpdateStrategy())
         };
     }

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -71,7 +71,7 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         {
             AppType.Client  => await LaunchWithStrategy(new ClientUpdateStrategy()),
             AppType.Upgrade => await LaunchWithStrategy(new UpgradeUpdateStrategy()),
-            AppType.OSS     => await LaunchOssAsync(),
+            AppType.OSS     => await LaunchWithStrategy(new OSSUpdateStrategy()),
             _ => await LaunchWithStrategy(new ClientUpdateStrategy())
         };
     }
@@ -153,73 +153,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         return this;
     }
 
-    /// <summary>OSS workflow: download packages from cloud storage, apply updates.</summary>
-    private async Task<GeneralUpdateBootstrap> LaunchOssAsync()
-    {
-        try
-        {
-            GeneralTracer.Debug("LaunchOssAsync start.");
-
-            var json = Environments.GetEnvironmentVariable("GlobalConfigInfoOSS");
-            if (!string.IsNullOrWhiteSpace(json))
-            {
-                var strategy = new OSSUpdateStrategy();
-                strategy.Create(_configInfo);
-                await strategy.ExecuteAsync();
-                return this;
-            }
-
-            // Client-side OSS
-            var basePath = AppDomain.CurrentDomain.BaseDirectory;
-            var versionFileName = $"{_configInfo.MainAppName ?? _configInfo.AppName}_versions.json";
-            var versionsFilePath = Path.Combine(basePath, versionFileName);
-
-            DownloadOssFile(_configInfo.UpdateUrl, versionsFilePath);
-            if (!File.Exists(versionsFilePath)) return this;
-
-            var versions = StorageManager.GetJson<List<VersionOSS>>(versionsFilePath,
-                VersionOSSJsonContext.Default.ListVersionOSS);
-            if (versions == null || versions.Count == 0) return this;
-
-            versions = versions.OrderByDescending(x => x.PubTime).ToList();
-            var newVersion = versions.First();
-
-            if (!IsOssUpgrade(_configInfo.ClientVersion, newVersion.Version))
-            {
-                GeneralTracer.Info("LaunchOssAsync: no upgrade needed.");
-                return this;
-            }
-
-            // Use user-configured AppName, fall back to default updater name
-            var upgradeAppName = !string.IsNullOrWhiteSpace(_configInfo.AppName) && _configInfo.AppName != "Update.exe"
-                ? _configInfo.AppName
-                : "GeneralUpdate.Upgrade.exe";
-            var appPath = Path.Combine(basePath, upgradeAppName);
-            if (!File.Exists(appPath))
-                throw new Exception($"Upgrade application not found: {upgradeAppName}");
-
-            var ossConfig = new GlobalConfigInfoOSS
-            {
-                AppName = _configInfo.MainAppName ?? _configInfo.AppName,
-                CurrentVersion = _configInfo.ClientVersion,
-                VersionFileName = versionFileName,
-                Encoding = (_configInfo.Encoding?.CodePage ?? Encoding.UTF8.CodePage).ToString(),
-                Url = _configInfo.UpdateUrl
-            };
-
-            var serialized = JsonSerializer.Serialize(ossConfig,
-                GlobalConfigInfoOSSJsonContext.Default.GlobalConfigInfoOSS);
-            Environments.SetEnvironmentVariable("GlobalConfigInfoOSS", serialized);
-            Process.Start(appPath);
-            await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Error("LaunchOssAsync failed.", ex);
-            EventManager.Instance.Dispatch(this, new ExceptionEventArgs(ex, ex.Message));
-        }
-        return this;
-    }
 
     // ════════════════════════════════════════════════════════════════
     // Configuration
@@ -371,26 +304,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         {
             GeneralTracer.Error("CallSmallBowlHomeAsync failed.", ex);
         }
-    }
-
-    private static void DownloadOssFile(string url, string path)
-    {
-        if (File.Exists(path))
-        {
-            File.SetAttributes(path, FileAttributes.Normal);
-            File.Delete(path);
-        }
-        using var webClient = new System.Net.WebClient();
-        webClient.DownloadFile(new Uri(url), path);
-    }
-
-    private static bool IsOssUpgrade(string clientVersion, string serverVersion)
-    {
-        if (string.IsNullOrWhiteSpace(clientVersion) || string.IsNullOrWhiteSpace(serverVersion))
-            return false;
-        return Version.TryParse(clientVersion, out var cv)
-            && Version.TryParse(serverVersion, out var sv)
-            && cv < sv;
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/src/c#/GeneralUpdate.Core/Configuration/AppType.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AppType.cs
@@ -11,6 +11,9 @@ public enum AppType
     /// <summary>Upgrade application — applies downloaded update packages, starts main app.</summary>
     Upgrade = 2,
 
-    /// <summary>OSS (Object Storage Service) update mode — downloads from cloud storage.</summary>
-    OSS = 3
+    /// <summary>OSS client mode — checks version config, starts upgrade process.</summary>
+    OSSClient = 3,
+
+    /// <summary>OSS upgrade mode — downloads packages from OSS, deploys to client.</summary>
+    OSSUpgrade = 4
 }

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -105,20 +105,6 @@ public class OSSUpdateStrategy : IStrategy
         if (!File.Exists(appPath))
             throw new FileNotFoundException($"Upgrade application not found: {upgradeAppName}");
 
-        // Pass config to the upgrade process via AES-encrypted file
-        var ossConfig = new GlobalConfigInfoOSS
-        {
-            AppName = _configInfo.MainAppName ?? _configInfo.AppName,
-            CurrentVersion = _configInfo.ClientVersion,
-            VersionFileName = versionFileName,
-            Encoding = (_configInfo.Encoding?.CodePage ?? Encoding.UTF8.CodePage).ToString(),
-            Url = _configInfo.UpdateUrl
-        };
-
-        Environments.SetEnvironmentVariable("GlobalConfigInfoOSS",
-            JsonSerializer.Serialize(ossConfig,
-                JsonContext.GlobalConfigInfoOSSJsonContext.Default.GlobalConfigInfoOSS));
-
         Process.Start(appPath);
         await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
     }

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -4,7 +4,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Compress;
 using GeneralUpdate.Core.Download;
@@ -17,11 +19,13 @@ using GeneralUpdate.Core.Configuration;
 namespace GeneralUpdate.Core.Strategy;
 
 /// <summary>
-/// OSS (Object Storage Service) update strategy.
-/// Downloads version configuration, fetches update packages from OSS,
-/// decompresses them, and launches the main application.
-/// </summary>
-/// <remarks>
+/// OSS (Object Storage Service) update strategy — handles both client and upgrade roles.
+/// <list type="bullet">
+///   <item><b>Client side</b>: downloads version configuration from server, checks for new
+///        version, starts the upgrade process, and exits.</item>
+///   <item><b>Upgrade side</b>: reads version config, downloads update packages from OSS,
+///        decompresses them, and launches the main application.</item>
+/// </list>
 /// This replaces the legacy <c>OSSStrategy</c> and <c>GeneralUpdateOSS</c> classes.
 /// The OSS workflow is OS-agnostic — no platform-specific pipeline is required.
 /// </remarks>
@@ -50,6 +54,107 @@ public class OSSUpdateStrategy : IStrategy
         if (_configInfo == null)
             throw new InvalidOperationException("OSSUpdateStrategy not configured. Call Create() first.");
 
+        // Upgrade side: GlobalConfigInfoOSS env var was set by the client,
+        // so we download packages, decompress, and start the main app.
+        var ossJson = Environments.GetEnvironmentVariable("GlobalConfigInfoOSS");
+        if (!string.IsNullOrWhiteSpace(ossJson))
+        {
+            await ExecuteUpgradeAsync();
+            return;
+        }
+
+        // Client side: download version config, check for new version,
+        // start the upgrade process, and exit.
+        await ExecuteClientAsync();
+    }
+
+    #region Client-side OSS
+
+    private async Task ExecuteClientAsync()
+    {
+        GeneralTracer.Debug("OSSUpdateStrategy: client-side OSS flow.");
+
+        var basePath = AppDomain.CurrentDomain.BaseDirectory;
+        var versionFileName = $"{_configInfo!.MainAppName ?? _configInfo.AppName}_versions.json";
+        var versionsFilePath = Path.Combine(basePath, versionFileName);
+
+        DownloadOssVersionFile(_configInfo.UpdateUrl, versionsFilePath);
+        if (!File.Exists(versionsFilePath))
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");
+            return;
+        }
+
+        var versions = JsonSerializer.Deserialize(
+            File.ReadAllText(versionsFilePath),
+            JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
+        if (versions == null || versions.Count == 0)
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: no versions found, aborting.");
+            return;
+        }
+
+        versions = versions.OrderByDescending(x => x.PubTime).ToList();
+        var newVersion = versions.First();
+
+        if (!IsOssUpgrade(_configInfo.ClientVersion, newVersion.Version))
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: no upgrade needed.");
+            return;
+        }
+
+        // Use user-configured AppName or default upgrade exe
+        var upgradeAppName = !string.IsNullOrWhiteSpace(_configInfo.AppName) && _configInfo.AppName != "Update.exe"
+            ? _configInfo.AppName
+            : "GeneralUpdate.Upgrade.exe";
+        var appPath = Path.Combine(basePath, upgradeAppName);
+        if (!File.Exists(appPath))
+            throw new FileNotFoundException($"Upgrade application not found: {upgradeAppName}");
+
+        var ossConfig = new GlobalConfigInfoOSS
+        {
+            AppName = _configInfo.MainAppName ?? _configInfo.AppName,
+            CurrentVersion = _configInfo.ClientVersion,
+            VersionFileName = versionFileName,
+            Encoding = (_configInfo.Encoding?.CodePage ?? Encoding.UTF8.CodePage).ToString(),
+            Url = _configInfo.UpdateUrl
+        };
+
+        Environments.SetEnvironmentVariable("GlobalConfigInfoOSS",
+            JsonSerializer.Serialize(ossConfig,
+                JsonContext.GlobalConfigInfoOSSJsonContext.Default.GlobalConfigInfoOSS));
+
+        Process.Start(appPath);
+        await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
+    }
+
+    private static void DownloadOssVersionFile(string url, string path)
+    {
+        if (File.Exists(path))
+        {
+            File.SetAttributes(path, FileAttributes.Normal);
+            File.Delete(path);
+        }
+        using var httpClient = new HttpClient();
+        var bytes = httpClient.GetByteArrayAsync(url).GetAwaiter().GetResult();
+        File.WriteAllBytes(path, bytes);
+    }
+
+    private static bool IsOssUpgrade(string clientVersion, string serverVersion)
+    {
+        if (string.IsNullOrWhiteSpace(clientVersion) || string.IsNullOrWhiteSpace(serverVersion))
+            return false;
+        return Version.TryParse(clientVersion, out var cv)
+            && Version.TryParse(serverVersion, out var sv)
+            && cv < sv;
+    }
+
+    #endregion
+
+    #region Upgrade-side OSS
+
+    private async Task ExecuteUpgradeAsync()
+    {
         var ctx = BuildUpdateContext();
         try
         {
@@ -148,6 +253,8 @@ public class OSSUpdateStrategy : IStrategy
         Process.Start(appPath);
         GeneralTracer.Debug("OSSUpdateStrategy: application started.");
     }
+
+    #endregion
 
     #region Helpers
 

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -72,7 +72,11 @@ public class OSSUpdateStrategy : IStrategy
         var versionFileName = $"{_configInfo!.MainAppName ?? _configInfo.AppName}_versions.json";
         var versionsFilePath = Path.Combine(_appPath, versionFileName);
 
-        DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
+        if (!string.IsNullOrEmpty(_configInfo.UpdateUrl))
+        {
+            DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
+        }
+
         if (!File.Exists(versionsFilePath))
         {
             GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -16,19 +16,25 @@ using GeneralUpdate.Core.Download.Orchestrators;
 namespace GeneralUpdate.Core.Strategy;
 
 /// <summary>
-/// OSS (Object Storage Service) update strategy — client/upgrade split.
+/// OSS (Object Storage Service) update strategy — client/upgrade split via AppType.
 /// <list type="bullet">
-///   <item><b>Client side</b>: downloads version config, checks for updates,
-///        starts the upgrade process with config, and exits.</item>
-///   <item><b>Upgrade side</b>: reads version config, downloads packages from OSS,
+///   <item><see cref="AppType.OSSClient"/> — downloads version config, checks for updates,
+///        starts the upgrade process, and exits.</item>
+///   <item><see cref="AppType.OSSUpgrade"/> — reads version config, downloads packages from OSS,
 ///        decompresses them, starts the main app, and exits.</item>
 /// </list>
 /// </summary>
 public class OSSUpdateStrategy : IStrategy
 {
+    private readonly AppType _role;
     private GlobalConfigInfo? _configInfo;
     private readonly string _appPath = AppDomain.CurrentDomain.BaseDirectory;
     private const int DefaultTimeOut = 60;
+
+    public OSSUpdateStrategy(AppType role = AppType.OSSClient)
+    {
+        _role = role;
+    }
 
     public Hooks.IUpdateHooks Hooks { get; set; } = new Hooks.NoOpUpdateHooks();
     public Download.Reporting.IUpdateReporter Reporter { get; set; } = new Download.Reporting.NoOpUpdateReporter();
@@ -45,17 +51,13 @@ public class OSSUpdateStrategy : IStrategy
         if (_configInfo == null)
             throw new InvalidOperationException("OSSUpdateStrategy not configured. Call Create() first.");
 
-        // Upgrade side: GlobalConfigInfoOSS env var was set by the client process.
-        // We download packages, decompress, start the main app, and exit.
-        var ossJson = Environments.GetEnvironmentVariable("GlobalConfigInfoOSS");
-        if (!string.IsNullOrWhiteSpace(ossJson))
+        // Dispatch by role — no env-var detection needed.
+        if (_role == AppType.OSSUpgrade)
         {
             await ExecuteUpgradeAsync();
             return;
         }
 
-        // Client side: download version config, check for update,
-        // start the upgrade process, and exit.
         await ExecuteClientAsync();
     }
 
@@ -278,7 +280,7 @@ public class OSSUpdateStrategy : IStrategy
             _configInfo?.InstallPath ?? _appPath,
             _configInfo?.ClientVersion ?? "0.0.0",
             _configInfo?.LastVersion,
-            AppType.OSS
+            AppType.OSSUpgrade
         );
     }
 

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -16,9 +16,13 @@ using GeneralUpdate.Core.Download.Orchestrators;
 namespace GeneralUpdate.Core.Strategy;
 
 /// <summary>
-/// OSS (Object Storage Service) update strategy — single-process, no separate upgrade.
-/// Downloads version configuration, fetches update packages from OSS,
-/// decompresses them, starts the main application, and exits.
+/// OSS (Object Storage Service) update strategy — client/upgrade split.
+/// <list type="bullet">
+///   <item><b>Client side</b>: downloads version config, checks for updates,
+///        starts the upgrade process with config, and exits.</item>
+///   <item><b>Upgrade side</b>: reads version config, downloads packages from OSS,
+///        decompresses them, starts the main app, and exits.</item>
+/// </list>
 /// </summary>
 public class OSSUpdateStrategy : IStrategy
 {
@@ -26,13 +30,9 @@ public class OSSUpdateStrategy : IStrategy
     private readonly string _appPath = AppDomain.CurrentDomain.BaseDirectory;
     private const int DefaultTimeOut = 60;
 
-    /// <summary>Lifecycle hooks injected by the bootstrap.</summary>
     public Hooks.IUpdateHooks Hooks { get; set; } = new Hooks.NoOpUpdateHooks();
-    /// <summary>Update status reporter injected by the bootstrap.</summary>
     public Download.Reporting.IUpdateReporter Reporter { get; set; } = new Download.Reporting.NoOpUpdateReporter();
-    /// <summary>Download source for OSS version listing. Override via <c>.DownloadSource&lt;OssDownloadSource&gt;()</c>.</summary>
     public IDownloadSource? DownloadSource { get; set; }
-    /// <summary>Download orchestrator. Override via <c>.DownloadOrchestrator&lt;T&gt;()</c>.</summary>
     public IDownloadOrchestrator? DownloadOrchestrator { get; set; }
 
     public void Create(GlobalConfigInfo parameter)
@@ -45,82 +45,143 @@ public class OSSUpdateStrategy : IStrategy
         if (_configInfo == null)
             throw new InvalidOperationException("OSSUpdateStrategy not configured. Call Create() first.");
 
+        // Upgrade side: GlobalConfigInfoOSS env var was set by the client process.
+        // We download packages, decompress, start the main app, and exit.
+        var ossJson = Environments.GetEnvironmentVariable("GlobalConfigInfoOSS");
+        if (!string.IsNullOrWhiteSpace(ossJson))
+        {
+            await ExecuteUpgradeAsync();
+            return;
+        }
+
+        // Client side: download version config, check for update,
+        // start the upgrade process, and exit.
+        await ExecuteClientAsync();
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Client side: check version, start upgrade process
+    // ════════════════════════════════════════════════════════════════
+
+    private async Task ExecuteClientAsync()
+    {
+        GeneralTracer.Debug("OSSUpdateStrategy (client): checking for updates.");
+
+        var versionFileName = $"{_configInfo!.MainAppName ?? _configInfo.AppName}_versions.json";
+        var versionsFilePath = Path.Combine(_appPath, versionFileName);
+
+        DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
+        if (!File.Exists(versionsFilePath))
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");
+            return;
+        }
+
+        var versions = JsonSerializer.Deserialize(
+            File.ReadAllText(versionsFilePath),
+            JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
+        if (versions == null || versions.Count == 0)
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: no versions found, aborting.");
+            return;
+        }
+
+        versions = versions.OrderByDescending(x => x.PubTime).ToList();
+        var latest = versions.First();
+
+        if (!IsOssUpgrade(_configInfo.ClientVersion, latest.Version))
+        {
+            GeneralTracer.Info("OSSUpdateStrategy: no upgrade needed.");
+            return;
+        }
+
+        // Use user-configured AppName or default upgrade exe
+        var upgradeAppName = !string.IsNullOrWhiteSpace(_configInfo.AppName) && _configInfo.AppName != "Update.exe"
+            ? _configInfo.AppName
+            : "GeneralUpdate.Upgrade.exe";
+        var appPath = Path.Combine(_appPath, upgradeAppName);
+        if (!File.Exists(appPath))
+            throw new FileNotFoundException($"Upgrade application not found: {upgradeAppName}");
+
+        // Pass config to the upgrade process via AES-encrypted file
+        var ossConfig = new GlobalConfigInfoOSS
+        {
+            AppName = _configInfo.MainAppName ?? _configInfo.AppName,
+            CurrentVersion = _configInfo.ClientVersion,
+            VersionFileName = versionFileName,
+            Encoding = (_configInfo.Encoding?.CodePage ?? Encoding.UTF8.CodePage).ToString(),
+            Url = _configInfo.UpdateUrl
+        };
+
+        Environments.SetEnvironmentVariable("GlobalConfigInfoOSS",
+            JsonSerializer.Serialize(ossConfig,
+                JsonContext.GlobalConfigInfoOSSJsonContext.Default.GlobalConfigInfoOSS));
+
+        Process.Start(appPath);
+        await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Upgrade side: download packages, decompress, start main app
+    // ════════════════════════════════════════════════════════════════
+
+    private async Task ExecuteUpgradeAsync()
+    {
         var ctx = BuildUpdateContext();
         try
         {
-            // 1. Download version configuration from server
-            GeneralTracer.Debug("OSSUpdateStrategy: 1. Downloading version configuration.");
-            var versionFileName = $"{_configInfo.MainAppName ?? _configInfo.AppName}_versions.json";
-            var versionsFilePath = Path.Combine(_appPath, versionFileName);
+            var versionFileName = $"{_configInfo!.MainAppName ?? _configInfo.AppName}_versions.json";
+            var jsonPath = Path.Combine(_appPath, versionFileName);
 
-            DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
-            if (!File.Exists(versionsFilePath))
-            {
-                GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");
-                return;
-            }
-
-            var versions = JsonSerializer.Deserialize(
-                File.ReadAllText(versionsFilePath),
-                JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
-            if (versions == null || versions.Count == 0)
-            {
-                GeneralTracer.Info("OSSUpdateStrategy: no versions found, aborting.");
-                return;
-            }
-
-            // 2. Check if upgrade is needed
-            versions = versions.OrderByDescending(x => x.PubTime).ToList();
-            var latest = versions.First();
-            if (!IsOssUpgrade(_configInfo.ClientVersion, latest.Version))
-            {
-                GeneralTracer.Info("OSSUpdateStrategy: no upgrade needed.");
-                return;
-            }
+            if (!File.Exists(jsonPath) && DownloadSource == null)
+                throw new FileNotFoundException($"Version config not found: {jsonPath}");
 
             // Hooks: allow cancellation before download
             if (!await SafeOnBeforeUpdateAsync(ctx).ConfigureAwait(false))
             {
-                GeneralTracer.Info("OSSUpdateStrategy: update cancelled by hook.");
+                GeneralTracer.Info("OSSUpdateStrategy (upgrade): cancelled by hook.");
                 return;
             }
 
-            // Report: update started
             await SafeReportUpdateStartedAsync(ctx).ConfigureAwait(false);
 
-            // 3. Build download assets
+            // Build download assets from version config or injected source
             List<DownloadAsset> assets;
             if (DownloadSource != null)
             {
-                GeneralTracer.Debug("OSSUpdateStrategy: 2. Using injected IDownloadSource.");
                 assets = (await DownloadSource.ListAsync().ConfigureAwait(false)).ToList();
             }
             else
             {
-                GeneralTracer.Debug("OSSUpdateStrategy: 2. Building assets from version config.");
-                assets = versions.OrderBy(v => v.PubTime).Select(v =>
-                {
-                    if (string.IsNullOrWhiteSpace(v.Url))
-                        throw new InvalidOperationException(
-                            $"OSS version '{v.PacketName ?? v.Version}' has no download URL.");
-                    var zipName = $"{v.PacketName ?? v.Version}zip";
-                    if (!zipName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
-                        zipName += ".zip";
-                    return new DownloadAsset(
-                        Name: zipName, Url: v.Url, Size: 0,
-                        SHA256: v.Hash, Version: v.Version ?? "0.0.0");
-                }).ToList();
+                var versions = JsonSerializer.Deserialize(
+                    File.ReadAllText(jsonPath),
+                    JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
+                if (versions == null || versions.Count == 0)
+                    throw new InvalidOperationException("No versions found in OSS configuration.");
+
+                assets = versions.OrderBy(v => v.PubTime)
+                    .Where(v => new Version(v.Version ?? "0.0.0") > new Version(_configInfo.ClientVersion))
+                    .Select(v =>
+                    {
+                        if (string.IsNullOrWhiteSpace(v.Url))
+                            throw new InvalidOperationException(
+                                $"OSS version '{v.PacketName ?? v.Version}' has no download URL.");
+                        var zipName = $"{v.PacketName ?? v.Version}zip";
+                        if (!zipName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                            zipName += ".zip";
+                        return new DownloadAsset(
+                            Name: zipName, Url: v.Url, Size: 0,
+                            SHA256: v.Hash, Version: v.Version ?? "0.0.0");
+                    }).ToList();
             }
 
             if (assets.Count == 0)
                 throw new InvalidOperationException("No assets to download.");
 
-            // 4. Download packages
-            GeneralTracer.Debug($"OSSUpdateStrategy: 3. Downloading {assets.Count} asset(s).");
+            GeneralTracer.Debug($"OSSUpdateStrategy (upgrade): downloading {assets.Count} asset(s).");
             await DownloadAssetsAsync(assets).ConfigureAwait(false);
 
-            // 5. Decompress
-            GeneralTracer.Debug("OSSUpdateStrategy: 4. Decompressing packages.");
+            GeneralTracer.Debug("OSSUpdateStrategy (upgrade): decompressing.");
             DecompressAssets(assets);
 
             await SafeOnDownloadCompletedAsync(ctx).ConfigureAwait(false);
@@ -128,24 +189,19 @@ public class OSSUpdateStrategy : IStrategy
             await SafeReportUpdateAppliedAsync(ctx).ConfigureAwait(false);
             await SafeOnBeforeStartAppAsync(ctx).ConfigureAwait(false);
 
-            // 6. Start main app and exit
-            GeneralTracer.Debug("OSSUpdateStrategy: 5. Launching main application.");
+            GeneralTracer.Debug("OSSUpdateStrategy (upgrade): launching main app.");
             StartApp();
-            await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             await SafeOnUpdateErrorAsync(ctx, ex).ConfigureAwait(false);
             await SafeReportUpdateFailedAsync(ctx, ex).ConfigureAwait(false);
-            GeneralTracer.Error("OSSUpdateStrategy.ExecuteAsync failed.", ex);
+            GeneralTracer.Error("OSSUpdateStrategy.ExecuteUpgradeAsync failed.", ex);
             throw;
         }
     }
 
-    public void Execute()
-    {
-        ExecuteAsync().GetAwaiter().GetResult();
-    }
+    public void Execute() => ExecuteAsync().GetAwaiter().GetResult();
 
     public void StartApp()
     {
@@ -157,7 +213,7 @@ public class OSSUpdateStrategy : IStrategy
             throw new FileNotFoundException($"Application not found: {appPath}");
 
         Process.Start(appPath);
-        GeneralTracer.Debug("OSSUpdateStrategy: application started.");
+        GeneralTracer.Debug("OSSUpdateStrategy: main application started.");
     }
 
     #region Helpers
@@ -186,14 +242,16 @@ public class OSSUpdateStrategy : IStrategy
     private async Task DownloadAssetsAsync(List<DownloadAsset> assets)
     {
         var plan = new DownloadPlan(assets, false);
-
         if (DownloadOrchestrator != null)
         {
             await DownloadOrchestrator.ExecuteAsync(plan, _appPath).ConfigureAwait(false);
         }
         else
         {
-            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut) };
+            using var httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut)
+            };
             var orchestrator = new DefaultDownloadOrchestrator(httpClient);
             await orchestrator.ExecuteAsync(plan, _appPath).ConfigureAwait(false);
         }
@@ -213,10 +271,6 @@ public class OSSUpdateStrategy : IStrategy
         }
     }
 
-    // ════════════════════════════════════════════════════════════════
-    // Hooks & Reporter safe wrappers
-    // ════════════════════════════════════════════════════════════════
-
     private Hooks.UpdateContext BuildUpdateContext()
     {
         return new Hooks.UpdateContext(
@@ -233,38 +287,32 @@ public class OSSUpdateStrategy : IStrategy
         try { return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false); }
         catch (Exception ex) { GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}"); return true; }
     }
-
     private async Task SafeOnBeforeStartAppAsync(Hooks.UpdateContext ctx)
     {
         try { await Hooks.OnBeforeStartAppAsync(ctx).ConfigureAwait(false); }
         catch (Exception ex) { GeneralTracer.Warn($"OnBeforeStartAppAsync hook failed: {ex.Message}"); }
     }
-
     private async Task SafeOnUpdateErrorAsync(Hooks.UpdateContext ctx, Exception error)
     {
         try { await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false); }
         catch (Exception ex) { GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}"); }
     }
-
     private async Task SafeOnAfterUpdateAsync(Hooks.UpdateContext ctx)
     {
         try { await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false); }
         catch (Exception ex) { GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}"); }
     }
-
     private async Task SafeOnDownloadCompletedAsync(Hooks.UpdateContext ctx)
     {
         try
         {
             var downloadCtx = new Hooks.DownloadContext(
                 _configInfo?.MainAppName ?? _configInfo?.AppName ?? "unknown",
-                _configInfo?.LastVersion ?? "",
-                0, TimeSpan.Zero, _appPath, true);
+                _configInfo?.LastVersion ?? "", 0, TimeSpan.Zero, _appPath, true);
             await Hooks.OnDownloadCompletedAsync(downloadCtx).ConfigureAwait(false);
         }
         catch (Exception ex) { GeneralTracer.Warn($"OnDownloadCompletedAsync hook failed: {ex.Message}"); }
     }
-
     private async Task SafeReportUpdateStartedAsync(Hooks.UpdateContext ctx)
     {
         try
@@ -276,7 +324,6 @@ public class OSSUpdateStrategy : IStrategy
         }
         catch (Exception ex) { GeneralTracer.Warn($"Report UpdateStarted failed: {ex.Message}"); }
     }
-
     private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx)
     {
         try
@@ -288,7 +335,6 @@ public class OSSUpdateStrategy : IStrategy
         }
         catch (Exception ex) { GeneralTracer.Warn($"Report UpdateApplied failed: {ex.Message}"); }
     }
-
     private async Task SafeReportUpdateFailedAsync(Hooks.UpdateContext ctx, Exception error)
     {
         try

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -4,31 +4,22 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Compress;
-using GeneralUpdate.Core.Download;
+using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Download.Abstractions;
 using GeneralUpdate.Core.Download.Models;
 using GeneralUpdate.Core.Download.Orchestrators;
-using GeneralUpdate.Core.Download.Sources;
-using GeneralUpdate.Core.Configuration;
 
 namespace GeneralUpdate.Core.Strategy;
 
 /// <summary>
-/// OSS (Object Storage Service) update strategy — handles both client and upgrade roles.
-/// <list type="bullet">
-///   <item><b>Client side</b>: downloads version configuration from server, checks for new
-///        version, starts the upgrade process, and exits.</item>
-///   <item><b>Upgrade side</b>: reads version config, downloads update packages from OSS,
-///        decompresses them, and launches the main application.</item>
-/// </list>
-/// This replaces the legacy <c>OSSStrategy</c> and <c>GeneralUpdateOSS</c> classes.
-/// The OSS workflow is OS-agnostic — no platform-specific pipeline is required.
-/// </remarks>
+/// OSS (Object Storage Service) update strategy — single-process, no separate upgrade.
+/// Downloads version configuration, fetches update packages from OSS,
+/// decompresses them, starts the main application, and exits.
+/// </summary>
 public class OSSUpdateStrategy : IStrategy
 {
     private GlobalConfigInfo? _configInfo;
@@ -54,143 +45,59 @@ public class OSSUpdateStrategy : IStrategy
         if (_configInfo == null)
             throw new InvalidOperationException("OSSUpdateStrategy not configured. Call Create() first.");
 
-        // Upgrade side: GlobalConfigInfoOSS env var was set by the client,
-        // so we download packages, decompress, and start the main app.
-        var ossJson = Environments.GetEnvironmentVariable("GlobalConfigInfoOSS");
-        if (!string.IsNullOrWhiteSpace(ossJson))
-        {
-            await ExecuteUpgradeAsync();
-            return;
-        }
-
-        // Client side: download version config, check for new version,
-        // start the upgrade process, and exit.
-        await ExecuteClientAsync();
-    }
-
-    #region Client-side OSS
-
-    private async Task ExecuteClientAsync()
-    {
-        GeneralTracer.Debug("OSSUpdateStrategy: client-side OSS flow.");
-
-        var basePath = AppDomain.CurrentDomain.BaseDirectory;
-        var versionFileName = $"{_configInfo!.MainAppName ?? _configInfo.AppName}_versions.json";
-        var versionsFilePath = Path.Combine(basePath, versionFileName);
-
-        DownloadOssVersionFile(_configInfo.UpdateUrl, versionsFilePath);
-        if (!File.Exists(versionsFilePath))
-        {
-            GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");
-            return;
-        }
-
-        var versions = JsonSerializer.Deserialize(
-            File.ReadAllText(versionsFilePath),
-            JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
-        if (versions == null || versions.Count == 0)
-        {
-            GeneralTracer.Info("OSSUpdateStrategy: no versions found, aborting.");
-            return;
-        }
-
-        versions = versions.OrderByDescending(x => x.PubTime).ToList();
-        var newVersion = versions.First();
-
-        if (!IsOssUpgrade(_configInfo.ClientVersion, newVersion.Version))
-        {
-            GeneralTracer.Info("OSSUpdateStrategy: no upgrade needed.");
-            return;
-        }
-
-        // Use user-configured AppName or default upgrade exe
-        var upgradeAppName = !string.IsNullOrWhiteSpace(_configInfo.AppName) && _configInfo.AppName != "Update.exe"
-            ? _configInfo.AppName
-            : "GeneralUpdate.Upgrade.exe";
-        var appPath = Path.Combine(basePath, upgradeAppName);
-        if (!File.Exists(appPath))
-            throw new FileNotFoundException($"Upgrade application not found: {upgradeAppName}");
-
-        var ossConfig = new GlobalConfigInfoOSS
-        {
-            AppName = _configInfo.MainAppName ?? _configInfo.AppName,
-            CurrentVersion = _configInfo.ClientVersion,
-            VersionFileName = versionFileName,
-            Encoding = (_configInfo.Encoding?.CodePage ?? Encoding.UTF8.CodePage).ToString(),
-            Url = _configInfo.UpdateUrl
-        };
-
-        Environments.SetEnvironmentVariable("GlobalConfigInfoOSS",
-            JsonSerializer.Serialize(ossConfig,
-                JsonContext.GlobalConfigInfoOSSJsonContext.Default.GlobalConfigInfoOSS));
-
-        Process.Start(appPath);
-        await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
-    }
-
-    private static void DownloadOssVersionFile(string url, string path)
-    {
-        if (File.Exists(path))
-        {
-            File.SetAttributes(path, FileAttributes.Normal);
-            File.Delete(path);
-        }
-        using var httpClient = new HttpClient();
-        var bytes = httpClient.GetByteArrayAsync(url).GetAwaiter().GetResult();
-        File.WriteAllBytes(path, bytes);
-    }
-
-    private static bool IsOssUpgrade(string clientVersion, string serverVersion)
-    {
-        if (string.IsNullOrWhiteSpace(clientVersion) || string.IsNullOrWhiteSpace(serverVersion))
-            return false;
-        return Version.TryParse(clientVersion, out var cv)
-            && Version.TryParse(serverVersion, out var sv)
-            && cv < sv;
-    }
-
-    #endregion
-
-    #region Upgrade-side OSS
-
-    private async Task ExecuteUpgradeAsync()
-    {
         var ctx = BuildUpdateContext();
         try
         {
+            // 1. Download version configuration from server
+            GeneralTracer.Debug("OSSUpdateStrategy: 1. Downloading version configuration.");
             var versionFileName = $"{_configInfo.MainAppName ?? _configInfo.AppName}_versions.json";
+            var versionsFilePath = Path.Combine(_appPath, versionFileName);
 
-            GeneralTracer.Debug("OSSUpdateStrategy: 1. Reading version configuration.");
-            var jsonPath = Path.Combine(_appPath, versionFileName);
-            if (!File.Exists(jsonPath) && DownloadSource == null)
-                throw new FileNotFoundException($"Version config not found: {jsonPath}");
+            DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
+            if (!File.Exists(versionsFilePath))
+            {
+                GeneralTracer.Info("OSSUpdateStrategy: version config download failed, aborting.");
+                return;
+            }
+
+            var versions = JsonSerializer.Deserialize(
+                File.ReadAllText(versionsFilePath),
+                JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
+            if (versions == null || versions.Count == 0)
+            {
+                GeneralTracer.Info("OSSUpdateStrategy: no versions found, aborting.");
+                return;
+            }
+
+            // 2. Check if upgrade is needed
+            versions = versions.OrderByDescending(x => x.PubTime).ToList();
+            var latest = versions.First();
+            if (!IsOssUpgrade(_configInfo.ClientVersion, latest.Version))
+            {
+                GeneralTracer.Info("OSSUpdateStrategy: no upgrade needed.");
+                return;
+            }
 
             // Hooks: allow cancellation before download
             if (!await SafeOnBeforeUpdateAsync(ctx).ConfigureAwait(false))
             {
-                GeneralTracer.Info("OSSUpdateStrategy: update cancelled by OnBeforeUpdateAsync hook.");
+                GeneralTracer.Info("OSSUpdateStrategy: update cancelled by hook.");
                 return;
             }
 
             // Report: update started
             await SafeReportUpdateStartedAsync(ctx).ConfigureAwait(false);
 
+            // 3. Build download assets
             List<DownloadAsset> assets;
             if (DownloadSource != null)
             {
                 GeneralTracer.Debug("OSSUpdateStrategy: 2. Using injected IDownloadSource.");
-                var sourceAssets = await DownloadSource.ListAsync().ConfigureAwait(false);
-                assets = sourceAssets.ToList();
+                assets = (await DownloadSource.ListAsync().ConfigureAwait(false)).ToList();
             }
             else
             {
-                GeneralTracer.Debug("OSSUpdateStrategy: 2. Parsing version configuration from local JSON.");
-                var versions = System.Text.Json.JsonSerializer.Deserialize(
-                    File.ReadAllText(jsonPath),
-                    JsonContext.VersionOSSJsonContext.Default.ListVersionOSS);
-                if (versions == null || versions.Count == 0)
-                    throw new InvalidOperationException("No versions found in OSS configuration.");
-
+                GeneralTracer.Debug("OSSUpdateStrategy: 2. Building assets from version config.");
                 assets = versions.OrderBy(v => v.PubTime).Select(v =>
                 {
                     if (string.IsNullOrWhiteSpace(v.Url))
@@ -199,7 +106,7 @@ public class OSSUpdateStrategy : IStrategy
                     var zipName = $"{v.PacketName ?? v.Version}zip";
                     if (!zipName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
                         zipName += ".zip";
-                    return new Download.Models.DownloadAsset(
+                    return new DownloadAsset(
                         Name: zipName, Url: v.Url, Size: 0,
                         SHA256: v.Hash, Version: v.Version ?? "0.0.0");
                 }).ToList();
@@ -208,24 +115,23 @@ public class OSSUpdateStrategy : IStrategy
             if (assets.Count == 0)
                 throw new InvalidOperationException("No assets to download.");
 
+            // 4. Download packages
             GeneralTracer.Debug($"OSSUpdateStrategy: 3. Downloading {assets.Count} asset(s).");
-            await DownloadAssetsAsync(assets);
+            await DownloadAssetsAsync(assets).ConfigureAwait(false);
 
+            // 5. Decompress
             GeneralTracer.Debug("OSSUpdateStrategy: 4. Decompressing packages.");
             DecompressAssets(assets);
 
-            // Hooks: download + decompress completed
             await SafeOnDownloadCompletedAsync(ctx).ConfigureAwait(false);
             await SafeOnAfterUpdateAsync(ctx).ConfigureAwait(false);
-
-            // Report: update applied
             await SafeReportUpdateAppliedAsync(ctx).ConfigureAwait(false);
-
-            // Hooks: before starting main app
             await SafeOnBeforeStartAppAsync(ctx).ConfigureAwait(false);
 
+            // 6. Start main app and exit
             GeneralTracer.Debug("OSSUpdateStrategy: 5. Launching main application.");
             StartApp();
+            await GracefulExit.CurrentProcessAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -254,9 +160,28 @@ public class OSSUpdateStrategy : IStrategy
         GeneralTracer.Debug("OSSUpdateStrategy: application started.");
     }
 
-    #endregion
-
     #region Helpers
+
+    private static void DownloadVersionConfig(string url, string path)
+    {
+        if (File.Exists(path))
+        {
+            File.SetAttributes(path, FileAttributes.Normal);
+            File.Delete(path);
+        }
+        using var httpClient = new HttpClient();
+        var bytes = httpClient.GetByteArrayAsync(url).GetAwaiter().GetResult();
+        File.WriteAllBytes(path, bytes);
+    }
+
+    private static bool IsOssUpgrade(string clientVersion, string serverVersion)
+    {
+        if (string.IsNullOrWhiteSpace(clientVersion) || string.IsNullOrWhiteSpace(serverVersion))
+            return false;
+        return Version.TryParse(clientVersion, out var cv)
+            && Version.TryParse(serverVersion, out var sv)
+            && cv < sv;
+    }
 
     private async Task DownloadAssetsAsync(List<DownloadAsset> assets)
     {
@@ -268,7 +193,7 @@ public class OSSUpdateStrategy : IStrategy
         }
         else
         {
-            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(_configInfo.DownloadTimeOut > 0 ? _configInfo.DownloadTimeOut : DefaultTimeOut) };
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut) };
             var orchestrator = new DefaultDownloadOrchestrator(httpClient);
             await orchestrator.ExecuteAsync(plan, _appPath).ConfigureAwait(false);
         }

--- a/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
+++ b/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
@@ -47,7 +47,8 @@ namespace CoreTest.Bootstrap
         #region Core
         [Fact] public void AppType_Client() => Assert.NotNull(B().Option(UpdateOptions.AppType, AppType.Client));
         [Fact] public void AppType_Upgrade() => Assert.NotNull(B().Option(UpdateOptions.AppType, AppType.Upgrade));
-        [Fact] public void AppType_OSS() => Assert.NotNull(B().Option(UpdateOptions.AppType, AppType.OSS));
+        [Fact] public void AppType_OSSClient() => Assert.NotNull(B().Option(UpdateOptions.AppType, AppType.OSSClient));
+        [Fact] public void AppType_OSSUpgrade() => Assert.NotNull(B().Option(UpdateOptions.AppType, AppType.OSSUpgrade));
         [Fact] public void DiffMode_Serial() => Assert.NotNull(B().Option(UpdateOptions.DiffMode, DiffMode.Serial));
         [Fact] public void DiffMode_Parallel() => Assert.NotNull(B().Option(UpdateOptions.DiffMode, DiffMode.Parallel));
         [Fact] public void Encoding_Utf8() => Assert.NotNull(B().Option(UpdateOptions.Encoding, Encoding.UTF8));

--- a/tests/CoreTest/Configuration/ConfigurationModelsTests.cs
+++ b/tests/CoreTest/Configuration/ConfigurationModelsTests.cs
@@ -258,7 +258,9 @@ namespace CoreTest.Configuration
         [Fact]
         public void AppType_UpgradeIs2() => Assert.Equal(2, (int)AppType.Upgrade);
         [Fact]
-        public void AppType_OSSIs3() => Assert.Equal(3, (int)AppType.OSS);
+        public void AppType_OSSClientIs3() => Assert.Equal(3, (int)AppType.OSSClient);
+        [Fact]
+        public void AppType_OSSUpgradeIs4() => Assert.Equal(4, (int)AppType.OSSUpgrade);
 
         [Fact]
         public void DiffMode_SerialAndParallel_AreDefined()


### PR DESCRIPTION
## Summary
Removes the dual OSS code path by merging \LaunchOssAsync()\ from \GeneralUpdateBootstrap\ into \OSSUpdateStrategy\, making the dispatch consistent across all \AppType\ values.

## Changes

### OSSUpdateStrategy
- Added \ExecuteClientAsync()\ — client-side OSS flow: download version config, check for updates, start upgrade process, graceful exit
- Added \ExecuteUpgradeAsync()\ — upgrade-side flow: download packages, decompress, start main app (existing logic)
- \ExecuteAsync()\ now detects role via \GlobalConfigInfoOSS\ env var and dispatches

### GeneralUpdateBootstrap
- \AppType.OSS\ now goes through \LaunchWithStrategy(new OSSUpdateStrategy())\ — consistent with Client and Upgrade
- Deleted \LaunchOssAsync()\, \DownloadOssFile()\, \IsOssUpgrade()\

## Benefits
- Single OSS code path, same as Client/Upgrade
- Consistent hooks + reporter invocation via \LaunchWithStrategy\
- Net -5 lines of code in Bootstrap (+ removed duplication)

Closes #409