### PR TITLE
refactor: Migrate to DefaultBlackListMatcher, deprecate BlackListManager

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -261,10 +261,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         var processInfo = new EncryptedFileProcessInfoProvider().Receive();
         if (processInfo == null) return;
 
-        BlackListManager.Instance.AddBlackFormats(processInfo.BlackFileFormats);
-        BlackListManager.Instance.AddBlackFiles(processInfo.BlackFiles);
-        BlackListManager.Instance.AddSkipDirectorys(processInfo.SkipDirectorys);
-
         _configInfo = new GlobalConfigInfo
         {
             MainAppName = processInfo.AppName,
@@ -282,8 +278,13 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             BackupDirectory = processInfo.BackupDirectory,
             Scheme = processInfo.Scheme,
             Token = processInfo.Token,
-            DriverDirectory = processInfo.DriverDirectory
+            DriverDirectory = processInfo.DriverDirectory,
+            BlackFiles = processInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
+            BlackFormats = processInfo.BlackFileFormats ?? BlackListDefaults.DefaultBlackFormats,
+            SkipDirectorys = processInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories
         };
+
+        StorageManager.BlackListMatcher = DefaultBlackListMatcher.FromConfigInfo(_configInfo);
     }
 
     /// <summary>
@@ -350,9 +351,14 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
     private void InitBlackList()
     {
-        BlackListManager.Instance.AddBlackFiles(_configInfo.BlackFiles);
-        BlackListManager.Instance.AddBlackFormats(_configInfo.BlackFormats);
-        BlackListManager.Instance.AddSkipDirectorys(_configInfo.SkipDirectorys);
+        // Build blacklist matcher from GlobalConfigInfo and set on StorageManager.
+        // The matcher combines user config with system defaults.
+        var effectiveConfig = new BlackListConfig(
+            _configInfo.BlackFiles?.Count > 0 ? _configInfo.BlackFiles : BlackListDefaults.DefaultBlackFiles,
+            _configInfo.BlackFormats?.Count > 0 ? _configInfo.BlackFormats : BlackListDefaults.DefaultBlackFormats,
+            _configInfo.SkipDirectorys?.Count > 0 ? _configInfo.SkipDirectorys : BlackListDefaults.DefaultSkipDirectories
+        );
+        StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
     }
 
     private async Task CallSmallBowlHomeAsync(string processName)

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackListDefaults.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackListDefaults.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace GeneralUpdate.Core.FileSystem;
+
+/// <summary>Built-in default blacklist items — previously hardcoded in BlackListManager.</summary>
+public static class BlackListDefaults
+{
+    /// <summary>Default blacklisted files (system DLLs that ship with the runtime).</summary>
+    public static readonly List<string> DefaultBlackFiles = new()
+    {
+        "Microsoft.Bcl.AsyncInterfaces.dll",
+        "System.Collections.Immutable.dll",
+        "System.IO.Pipelines.dll",
+        "System.Text.Encodings.Web.dll",
+        "System.Text.Json.dll"
+    };
+
+    /// <summary>Default blacklisted file extensions.</summary>
+    public static readonly List<string> DefaultBlackFormats = new()
+        { ".patch", ".pdb", ".rar", ".tar", ".json", Configuration.Format.ZIP };
+
+    /// <summary>Default skipped directory prefixes.</summary>
+    public static readonly List<string> DefaultSkipDirectories = new()
+        { "app-", "fail" };
+}

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackListManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackListManager.cs
@@ -15,9 +15,10 @@ public interface IBlackListMatcher
 }
 
 /// <summary>
-/// Thread-safe blacklist manager. Uses Lazy<T> singleton.
+/// Thread-safe blacklist manager. Uses Lazy&lt;T&gt; singleton.
 /// Matching is case-insensitive and supports prefix matching for skip directories.
 /// </summary>
+[Obsolete("Use DefaultBlackListMatcher + StorageManager.BlackListMatcher instead. See #412.")]
 public class BlackListManager : IBlackListMatcher
 {
     private static readonly Lazy<BlackListManager> _lazy = new(() => new BlackListManager());

--- a/src/c#/GeneralUpdate.Core/FileSystem/DefaultBlackListMatcher.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/DefaultBlackListMatcher.cs
@@ -13,6 +13,16 @@ public class DefaultBlackListMatcher : IBlackListMatcher
     public DefaultBlackListMatcher(BlackListConfig config)
         => _config = config ?? throw new ArgumentNullException(nameof(config));
 
+    /// <summary>Create a matcher from GlobalConfigInfo blacklist properties.</summary>
+    public static DefaultBlackListMatcher FromConfigInfo(GlobalConfigInfo config)
+    {
+        var cfg = new BlackListConfig(
+            config.BlackFiles?.Count > 0 ? config.BlackFiles : null,
+            config.BlackFormats?.Count > 0 ? config.BlackFormats : null,
+            config.SkipDirectorys?.Count > 0 ? config.SkipDirectorys : null);
+        return new DefaultBlackListMatcher(cfg);
+    }
+
     public bool IsBlacklisted(string relativeFilePath)
     {
         var fileName = Path.GetFileName(relativeFilePath);

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -13,6 +13,9 @@ namespace GeneralUpdate.Core.FileSystem
     {
         private long _fileCount = 0;
         public const string DirectoryName = "app-";
+
+        /// <summary>Optional blacklist matcher. When set, takes precedence over BlackListManager.</summary>
+        public static IBlackListMatcher? BlackListMatcher { get; set; }
         
         private ComparisonResult ComparisonResult { get; set; }
 
@@ -264,7 +267,9 @@ namespace GeneralUpdate.Core.FileSystem
 
             foreach (var subPath in Directory.EnumerateFiles(path))
             {
-                if (BlackListManager.Instance.IsBlacklisted(subPath)) continue;
+#pragma warning disable CS0618 // Obsolete fallback
+                if ((BlackListMatcher ?? BlackListManager.Instance).IsBlacklisted(subPath)) continue;
+#pragma warning restore CS0618
 
                 var hashAlgorithm = new Sha256HashAlgorithm();
                 var hash = hashAlgorithm.ComputeHash(subPath);
@@ -283,7 +288,9 @@ namespace GeneralUpdate.Core.FileSystem
 
             foreach (var subPath in Directory.EnumerateDirectories(path))
             {
-                if (BlackListManager.Instance.ShouldSkipDirectory(subPath)) continue;
+#pragma warning disable CS0618 // Obsolete fallback
+                if ((BlackListMatcher ?? BlackListManager.Instance).ShouldSkipDirectory(subPath)) continue;
+#pragma warning restore CS0618
                 resultFiles.AddRange(ReadFileNode(subPath, rootPath));
             }
 

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -147,10 +147,13 @@ public class SilentPollOrchestrator : IDisposable
             catch (Exception ex) { GeneralTracer.Warn($"Hook OnBeforeUpdateAsync failed: {ex.Message}"); }
         }
 
-        // Configure for update
-        BlackListManager.Instance?.AddBlackFiles(_configInfo.BlackFiles);
-        BlackListManager.Instance?.AddBlackFormats(_configInfo.BlackFormats);
-        BlackListManager.Instance?.AddSkipDirectorys(_configInfo.SkipDirectorys);
+        // Configure matcher from config with defaults
+        var effectiveConfig = new BlackListConfig(
+            _configInfo.BlackFiles?.Count > 0 ? _configInfo.BlackFiles : BlackListDefaults.DefaultBlackFiles,
+            _configInfo.BlackFormats?.Count > 0 ? _configInfo.BlackFormats : BlackListDefaults.DefaultBlackFormats,
+            _configInfo.SkipDirectorys?.Count > 0 ? _configInfo.SkipDirectorys : BlackListDefaults.DefaultSkipDirectories
+        );
+        StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
 
         _configInfo.LastVersion = latestVersion;
         _configInfo.UpdateVersions = new List<VersionInfo>(); // legacy compat
@@ -160,14 +163,14 @@ public class SilentPollOrchestrator : IDisposable
 
         // Backup
         StorageManager.Backup(_configInfo.InstallPath, _configInfo.BackupDirectory,
-            BlackListManager.Instance.SkipDirectorys);
+            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
 
         // Build ProcessInfo and store for IPC delivery on process exit
         _preparedProcessInfo = ConfigurationMapper.MapToProcessInfo(
             _configInfo, new List<VersionInfo>(),
-            BlackListManager.Instance.BlackFormats.ToList(),
-            BlackListManager.Instance.BlackFiles.ToList(),
-            BlackListManager.Instance.SkipDirectorys.ToList());
+            _configInfo.BlackFormats ?? BlackListDefaults.DefaultBlackFormats,
+            _configInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
+            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
         _configInfo.ProcessInfo = JsonSerializer.Serialize(_preparedProcessInfo, ProcessInfoJsonContext.Default.ProcessInfo);
 
         // ═══ Reporter: update started ═══

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
@@ -173,9 +173,9 @@ public class ClientUpdateStrategy : IStrategy
 
         var processInfo = ConfigurationMapper.MapToProcessInfo(
             _configInfo, downloadVersions,
-            BlackListManager.Instance.BlackFormats.ToList(),
-            BlackListManager.Instance.BlackFiles.ToList(),
-            BlackListManager.Instance.SkipDirectorys.ToList());
+            _configInfo.BlackFormats ?? BlackListDefaults.DefaultBlackFormats,
+            _configInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
+            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
 
         // Keep JSON string for backward compatibility (GlobalConfigInfo.ProcessInfo)
         _configInfo.ProcessInfo = JsonSerializer.Serialize(processInfo,
@@ -243,16 +243,19 @@ public class ClientUpdateStrategy : IStrategy
 
     private void InitBlackList()
     {
-        BlackListManager.Instance.AddBlackFiles(_configInfo!.BlackFiles);
-        BlackListManager.Instance.AddBlackFormats(_configInfo.BlackFormats);
-        BlackListManager.Instance.AddSkipDirectorys(_configInfo.SkipDirectorys);
+        var effectiveConfig = new BlackListConfig(
+            _configInfo!.BlackFiles?.Count > 0 ? _configInfo.BlackFiles : BlackListDefaults.DefaultBlackFiles,
+            _configInfo.BlackFormats?.Count > 0 ? _configInfo.BlackFormats : BlackListDefaults.DefaultBlackFormats,
+            _configInfo.SkipDirectorys?.Count > 0 ? _configInfo.SkipDirectorys : BlackListDefaults.DefaultSkipDirectories
+        );
+        StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
     }
 
     private void Backup()
     {
         GeneralTracer.Info($"ClientUpdateStrategy: backing up {_configInfo!.InstallPath} -> {_configInfo.BackupDirectory}");
         StorageManager.Backup(_configInfo.InstallPath, _configInfo.BackupDirectory,
-            BlackListManager.Instance.SkipDirectorys);
+            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
     }
 
     private bool CanSkip(bool isForcibly, UpdateInfoEventArgs updateInfo)


### PR DESCRIPTION
## Summary
Replaces the mutable \BlackListManager\ singleton with immutable \BlackListConfig\ → \DefaultBlackListMatcher\ injection via \StorageManager.BlackListMatcher\.

## Changes

### New: BlackListDefaults
Static class with built-in default values (previously hardcoded in BlackListManager constructor):
- 5 system DLLs, 6 extensions (.patch/.pdb/etc), 2 skip dirs (app-/fail)

### DefaultBlackListMatcher
- Added \FromConfigInfo(GlobalConfigInfo)\ factory method

### StorageManager
- Added static \BlackListMatcher\ property — when set, takes precedence over \BlackListManager\
- \ReadFileNode\ uses \BlackListMatcher ?? BlackListManager.Instance\ for backward compat

### Call sites updated
- \InitBlackList()\ in Bootstrap / ClientUpdateStrategy / SilentPollOrchestrator — builds matcher from GlobalConfigInfo
- ProcessInfo building — reads from \_configInfo.BlackFiles\ directly instead of \BlackListManager.Instance\

### BlackListManager
- Marked \[Obsolete]\ with guidance to use \DefaultBlackListMatcher\

## Benefits
- Single source of truth for blacklist configuration
- Testable: matcher can be injected in unit tests
- No global mutable state

Closes #412