### PR TITLE
chore: Clean up redundant code and align model signatures

### DIFF
--- a/src/c#/GeneralUpdate.Core/Download/Abstractions/IDownloadExecutor.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Abstractions/IDownloadExecutor.cs
@@ -9,7 +9,7 @@ namespace GeneralUpdate.Core.Download.Abstractions;
 public interface IDownloadExecutor
 {
     Task<DownloadResult> ExecuteAsync(
-        string url, string destPath,
+        DownloadAsset asset, string destPath,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken token = default);
 }

--- a/src/c#/GeneralUpdate.Core/Download/Executors/HttpDownloadExecutor.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Executors/HttpDownloadExecutor.cs
@@ -26,7 +26,7 @@ public class HttpDownloadExecutor : IDownloadExecutor
     }
 
     public async Task<DownloadResult> ExecuteAsync(
-        string url, string destPath,
+        DownloadAsset asset, string destPath,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken token = default)
     {
@@ -42,7 +42,7 @@ public class HttpDownloadExecutor : IDownloadExecutor
 
         try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var request = new HttpRequestMessage(HttpMethod.Get, asset.Url);
             if (_enableResume && existingBytes > 0)
                 request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
 
@@ -74,12 +74,12 @@ public class HttpDownloadExecutor : IDownloadExecutor
                 totalBytes > 0 ? totalBytes + existingBytes : null,
                 100, DownloadStatus.Completed));
 
-            return new DownloadResult(url, destPath, downloaded, elapsed, retries, true, null);
+            return new DownloadResult(asset, destPath, downloaded, elapsed, retries, true, null);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
-            return new DownloadResult(url, null, existingBytes, sw.Elapsed, retries, false, ex.Message);
+            return new DownloadResult(asset, null, existingBytes, sw.Elapsed, retries, false, ex.Message);
         }
     }
 

--- a/src/c#/GeneralUpdate.Core/Download/Executors/OssDownloadExecutor.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Executors/OssDownloadExecutor.cs
@@ -17,14 +17,14 @@ public class OssDownloadExecutor : IDownloadExecutor
         => _client = client ?? throw new ArgumentNullException(nameof(client));
 
     public async Task<DownloadResult> ExecuteAsync(
-        string url, string destPath,
+        DownloadAsset asset, string destPath,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken token = default)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
-            using var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token)
+            using var response = await _client.GetAsync(asset.Url, HttpCompletionOption.ResponseHeadersRead, token)
                 .ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             var total = response.Content.Headers.ContentLength ?? -1;
@@ -37,12 +37,12 @@ public class OssDownloadExecutor : IDownloadExecutor
 
             progress?.Report(new DownloadProgress(
                 Path.GetFileName(destPath), downloaded, total > 0 ? total : null, 100, DownloadStatus.Completed));
-            return new DownloadResult(url, destPath, downloaded, elapsed, 0, true, null);
+            return new DownloadResult(asset, destPath, downloaded, elapsed, 0, true, null);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
-            return new DownloadResult(url, null, 0, sw.Elapsed, 0, false, ex.Message);
+            return new DownloadResult(asset, null, 0, sw.Elapsed, 0, false, ex.Message);
         }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Download/Models/DownloadProgress.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Models/DownloadProgress.cs
@@ -15,7 +15,7 @@ public record DownloadProgress(
 );
 
 public record DownloadResult(
-    string? Url,
+    DownloadAsset Asset,
     string? LocalPath,
     long DownloadedBytes,
     TimeSpan Duration,

--- a/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
@@ -80,7 +80,7 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
                 {
                     // Download
                     var downloadResult = await executor.ExecuteAsync(
-                        asset.Url, destPath,
+                        asset, destPath,
                         progress != null ? new AssetProgressReporter(progress, asset.Name) : null,
                         ct).ConfigureAwait(false);
 
@@ -100,7 +100,7 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
                     }
                     catch (Exception ex)
                     {
-                        return new DownloadResult(asset.Url, destPath,
+                        return new DownloadResult(asset, destPath,
                             downloadResult.DownloadedBytes, downloadResult.Duration,
                             downloadResult.RetryCount, false, $"SHA256 verification failed: {ex.Message}");
                     }
@@ -122,7 +122,7 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
 
         // Dispatch all-completed event ONCE after all assets finish (only failed results)
         var failedDetails = results.Where(r => !r.Success)
-            .Select(r => ((object)r.Url, r.ErrorMessage ?? "failed")).ToList();
+            .Select(r => ((object)r.Asset.Url, r.ErrorMessage ?? "failed")).ToList();
         DownloadProgressReporter.DispatchAllCompleted(
             this,
             results.All(r => r.Success),

--- a/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
+++ b/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
@@ -129,9 +129,9 @@ namespace CoreTest.Bootstrap
 
         private sealed class StubDownloadExecutor : GeneralUpdate.Core.Download.Abstractions.IDownloadExecutor
         {
-            public Task<GeneralUpdate.Core.Download.Models.DownloadResult> ExecuteAsync(string url, string destPath,
+            public Task<GeneralUpdate.Core.Download.Models.DownloadResult> ExecuteAsync(GeneralUpdate.Core.Download.Models.DownloadAsset asset, string destPath,
                 IProgress<GeneralUpdate.Core.Download.Models.DownloadProgress>? progress = null, CancellationToken token = default)
-                => Task.FromResult(new GeneralUpdate.Core.Download.Models.DownloadResult(url, destPath, 0, TimeSpan.Zero, 0, true, null));
+                => Task.FromResult(new GeneralUpdate.Core.Download.Models.DownloadResult(asset, destPath, 0, TimeSpan.Zero, 0, true, null));
         }
 
         private sealed class StubDownloadSource : GeneralUpdate.Core.Download.Abstractions.IDownloadSource

--- a/tests/CoreTest/Configuration/ConfigurationModelsTests.cs
+++ b/tests/CoreTest/Configuration/ConfigurationModelsTests.cs
@@ -219,7 +219,7 @@ namespace CoreTest.Configuration
         public void DownloadResult_Success()
         {
             var result = new DownloadResult(
-                "https://cdn.example.com/update.zip",
+                null!,
                 "/tmp/update.zip",
                 50L * 1024 * 1024,
                 TimeSpan.FromSeconds(30),
@@ -236,7 +236,7 @@ namespace CoreTest.Configuration
         public void DownloadResult_FailureWithRetries()
         {
             var result = new DownloadResult(
-                "https://cdn.example.com/update.zip",
+                null!,
                 null,
                 0,
                 TimeSpan.FromSeconds(15),

--- a/tests/CoreTest/Download/OrchestratorOptionsBehaviourTests.cs
+++ b/tests/CoreTest/Download/OrchestratorOptionsBehaviourTests.cs
@@ -263,8 +263,9 @@ public class OrchestratorOptionsBehaviourTests
 
         try
         {
+            var asset = new DownloadAsset("file.bin", "http://example.com/file.bin", 0, null, "1.0.0");
             var result = await executor.ExecuteAsync(
-                "http://example.com/file.bin", destPath, token: CancellationToken.None);
+                asset, destPath, token: CancellationToken.None);
             Assert.True(result.Success, $"Download should succeed, error: {result.ErrorMessage}");
             Assert.True(File.Exists(destPath));
         }
@@ -308,8 +309,9 @@ public class OrchestratorOptionsBehaviourTests
 
         try
         {
+            var asset = new DownloadAsset("file.bin", "http://example.com/file.bin", 0, null, "1.0.0");
             var result = await executor.ExecuteAsync(
-                "http://example.com/file.bin", destPath, token: CancellationToken.None);
+                asset, destPath, token: CancellationToken.None);
             Assert.True(result.Success);
             // Partial content (30 bytes) appended to existing (20 bytes) = 50 total
             var fileInfo = new FileInfo(destPath);


### PR DESCRIPTION
## Summary
- Removed empty \GeneralUpdate.ClientCore\ directory (bin/obj artifacts only)
- \DownloadResult.Url\ replaced with \DownloadResult.Asset\ (full \DownloadAsset\)
- \IDownloadExecutor.ExecuteAsync\ now accepts \DownloadAsset\ instead of \string url\

Closes #411