### PR TITLE
fix: address Copilot review suggestions from merged PRs

### DIFF
--- a/src/c#/GeneralUpdate.Core/Download/Executors/HttpDownloadExecutor.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Executors/HttpDownloadExecutor.cs
@@ -79,7 +79,7 @@ public class HttpDownloadExecutor : IDownloadExecutor
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
-            return new DownloadResult(asset, null, existingBytes, sw.Elapsed, retries, false, ex.Message);
+            return new DownloadResult(asset, destPath, existingBytes, sw.Elapsed, retries, false, ex.Message);
         }
     }
 

--- a/src/c#/GeneralUpdate.Core/Download/Executors/OssDownloadExecutor.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Executors/OssDownloadExecutor.cs
@@ -42,7 +42,7 @@ public class OssDownloadExecutor : IDownloadExecutor
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
-            return new DownloadResult(asset, null, 0, sw.Elapsed, 0, false, ex.Message);
+            return new DownloadResult(asset, destPath, 0, sw.Elapsed, 0, false, ex.Message);
         }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Download/Models/DownloadProgress.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Models/DownloadProgress.cs
@@ -16,7 +16,7 @@ public record DownloadProgress(
 
 public record DownloadResult(
     DownloadAsset Asset,
-    string? LocalPath,
+    string LocalPath,
     long DownloadedBytes,
     TimeSpan Duration,
     int RetryCount,

--- a/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
@@ -122,7 +122,7 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
 
         // Dispatch all-completed event ONCE after all assets finish (only failed results)
         var failedDetails = results.Where(r => !r.Success)
-            .Select(r => ((object)r.Asset.Url, r.ErrorMessage ?? "failed")).ToList();
+            .Select(r => ((object)r.Asset, r.ErrorMessage ?? "failed")).ToList();
         DownloadProgressReporter.DispatchAllCompleted(
             this,
             results.All(r => r.Success),

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -74,7 +74,7 @@ public class OSSUpdateStrategy : IStrategy
 
         if (!string.IsNullOrEmpty(_configInfo.UpdateUrl))
         {
-            DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath);
+            await DownloadVersionConfig(_configInfo.UpdateUrl, versionsFilePath).ConfigureAwait(false);
         }
 
         if (!File.Exists(versionsFilePath))
@@ -210,7 +210,7 @@ public class OSSUpdateStrategy : IStrategy
 
     #region Helpers
 
-    private static void DownloadVersionConfig(string url, string path)
+    private static async Task DownloadVersionConfig(string url, string path)
     {
         if (File.Exists(path))
         {
@@ -218,7 +218,7 @@ public class OSSUpdateStrategy : IStrategy
             File.Delete(path);
         }
         using var httpClient = new HttpClient();
-        var bytes = httpClient.GetByteArrayAsync(url).GetAwaiter().GetResult();
+        var bytes = await httpClient.GetByteArrayAsync(url).ConfigureAwait(false);
         File.WriteAllBytes(path, bytes);
     }
 


### PR DESCRIPTION
Fixes for Copilot suggestions on #414, #416, #417:

- OSSUpdateStrategy: make DownloadVersionConfig truly async (remove .GetAwaiter().GetResult())
- DefaultDownloadOrchestrator: pass full DownloadAsset in failedDetails instead of just URL
- DownloadResult.LocalPath: change from string? to string
- Executors: return destPath instead of null for LocalPath on failure