### PR TITLE
Fix encoding corruption from #420 and cross-project BlackListManager references

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/Environments.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/Environments.cs
@@ -9,10 +9,11 @@ namespace GeneralUpdate.Core.Configuration;
 /// <summary>
 /// Secure IPC environment variable provider.
 /// AES-encrypted temp files in a dedicated subdirectory, auto-deleted after read.
-/// Encryption is delegated to <see cref="IpcEncryption"/>.
 /// </summary>
 public static class Environments
 {
+    // Fixed key/IV derived from a constant — not crypto-grade, but sufficient for
+    // ephemeral IPC where the file lives < 1 second and is in a per-user directory.
     private static readonly byte[] _aesKey = SHA256.Create()
         .ComputeHash(Encoding.UTF8.GetBytes("GeneralUpdate.IPC.EnvironmentProvider.v1"));
     private static readonly byte[] _aesIV = new byte[16] { 0x47, 0x55, 0x50, 0x44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
+++ b/src/c#/GeneralUpdate.Core/GeneralUpdate.Core.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <Title>GeneralUpdate.Core</Title>
         <Authors>JusterZhu</Authors>
-        <Description>GeneralUpdate unified core �?client and upgrade bootstrap, download, pipeline, strategies, utilities.</Description>
+        <Description>GeneralUpdate unified core — client and upgrade bootstrap, download, pipeline, strategies, utilities.</Description>
         <Copyright>Copyright 2020-2026 JusterZhu</Copyright>
         <PackageProjectUrl>https://github.com/GeneralLibrary/GeneralUpdate</PackageProjectUrl>
         <RepositoryUrl>https://github.com/GeneralLibrary/GeneralUpdate</RepositoryUrl>
@@ -30,7 +30,6 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     </ItemGroup>
 
-    <!-- net10.0: IHttpClientFactory built-in; add Http package for ServiceCollection -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     </ItemGroup>

--- a/src/c#/GeneralUpdate.Core/Ipc/IProcessInfoProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Ipc/IProcessInfoProvider.cs
@@ -20,7 +20,6 @@ public interface IProcessInfoProvider
 /// <summary>
 /// AES-encrypted temporary file IPC — simplest, most reliable cross-platform approach.
 /// File lives in %TEMP%/GeneralUpdate/ipc/ with a random name, auto-deleted after read.
-/// Encryption is delegated to <see cref="IpcEncryption"/>.
 /// </summary>
 public class EncryptedFileProcessInfoProvider : IProcessInfoProvider
 {

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -23,7 +23,7 @@ using GeneralUpdate.Core.Strategy;
 namespace GeneralUpdate.Core.Silent;
 
 /// <summary>
-/// Silent update poll orchestrator �?periodically checks for updates,
+/// Silent update poll orchestrator — periodically checks for updates,
 /// downloads them in the background, and optionally auto-installs.
 /// Replaces the legacy <c>SilentUpdateMode</c> class.
 /// </summary>
@@ -126,7 +126,7 @@ public class SilentPollOrchestrator : IDisposable
             return;
         }
 
-        // ══�?Hooks: allow cancellation before starting update ══�?
+        // ══— Hooks: allow cancellation before starting update ══— 
         var updateCtx = new UpdateContext(
             _configInfo.MainAppName ?? _configInfo.AppName,
             _configInfo.InstallPath,
@@ -173,7 +173,7 @@ public class SilentPollOrchestrator : IDisposable
             _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
         _configInfo.ProcessInfo = JsonSerializer.Serialize(_preparedProcessInfo, ProcessInfoJsonContext.Default.ProcessInfo);
 
-        // ══�?Reporter: update started ══�?
+        // ══— Reporter: update started ══— 
         var startTime = DateTimeOffset.UtcNow;
         if (_reporter != null)
         {
@@ -203,7 +203,7 @@ public class SilentPollOrchestrator : IDisposable
             downloadElapsed = report.TotalDuration;
             GeneralTracer.Info($"SilentPollOrchestrator: download complete. Success={downloadSuccessCount}, Failed={downloadFailedCount}");
 
-            // ══�?Hooks + Reporter: download completed ══�?
+            // ══— Hooks + Reporter: download completed ══— 
             if (_hooks != null)
             {
                 try
@@ -268,7 +268,7 @@ public class SilentPollOrchestrator : IDisposable
             GeneralTracer.Info("SilentPollOrchestrator: update prepared.");
             Interlocked.Exchange(ref _prepared, 1);
 
-            // ══�?Hooks + Reporter: update applied ══�?
+            // ══— Hooks + Reporter: update applied ══— 
             if (_hooks != null)
             {
                 try { await _hooks.OnAfterUpdateAsync(updateCtx).ConfigureAwait(false); }
@@ -318,7 +318,7 @@ public class SilentPollOrchestrator : IDisposable
         {
             var updaterPath = Path.Combine(_configInfo.InstallPath, _configInfo.AppName);
 
-            // Start the upgrade process first �?it will call ReceiveAsync in its constructor.
+            // Start the upgrade process first — it will call ReceiveAsync in its constructor.
             // We then call SendAsync which creates the NamedPipe server; the upgrade's
             // client connects to it. Auto-fallback (SharedMemory > EncryptedFile) handles
             // timing gaps where the named pipe handshake doesn't complete in time.

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
@@ -89,7 +89,7 @@ public class ClientUpdateStrategy : IStrategy
 
     private async Task ExecuteWorkflowAsync()
     {
-        // Standard mode �?silent mode is handled by GeneralUpdateBootstrap.LaunchSilentAsync().
+        // Standard mode — silent mode is handled by GeneralUpdateBootstrap.LaunchSilentAsync().
         // Runtime options (Encoding, Format, DownloadTimeOut, etc.) are already
         // populated on _configInfo by Bootstrap.ApplyRuntimeOptions().
         await ExecuteStandardWorkflowAsync();
@@ -185,7 +185,7 @@ public class ClientUpdateStrategy : IStrategy
         new EncryptedFileProcessInfoProvider().Send(processInfo);
         GeneralTracer.Info("ClientUpdateStrategy: ProcessInfo sent via encrypted file IPC.");
 
-        // Backup �?conditionally skipped when BackupEnabled is false
+        // Backup — conditionally skipped when BackupEnabled is false
         if (_configInfo.BackupEnabled != false)
         {
             Backup();
@@ -197,7 +197,7 @@ public class ClientUpdateStrategy : IStrategy
 
         _osStrategy!.Create(_configInfo);
 
-        // Download via orchestrator �?wired with options from GlobalConfigInfo
+        // Download via orchestrator — wired with options from GlobalConfigInfo
         var orchOptions = Download.Models.DownloadOrchestratorOptions.From(_configInfo);
         GeneralTracer.Info($"ClientUpdateStrategy: downloading {downloadPlan.Assets.Count} asset(s).");
         if (_orchestrator != null)

--- a/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OSSUpdateStrategy.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Compress;
 using GeneralUpdate.Core.Configuration;
@@ -17,11 +16,11 @@ using GeneralUpdate.Core.Download.Orchestrators;
 namespace GeneralUpdate.Core.Strategy;
 
 /// <summary>
-/// OSS (Object Storage Service) update strategy �?client/upgrade split via AppType.
+/// OSS (Object Storage Service) update strategy — client/upgrade split via AppType.
 /// <list type="bullet">
-///   <item><see cref="AppType.OSSClient"/> �?downloads version config, checks for updates,
+///   <item><see cref="AppType.OSSClient"/> — downloads version config, checks for updates,
 ///        starts the upgrade process, and exits.</item>
-///   <item><see cref="AppType.OSSUpgrade"/> �?reads version config, downloads packages from OSS,
+///   <item><see cref="AppType.OSSUpgrade"/> — reads version config, downloads packages from OSS,
 ///        decompresses them, starts the main app, and exits.</item>
 /// </list>
 /// </summary>
@@ -52,7 +51,7 @@ public class OSSUpdateStrategy : IStrategy
         if (_configInfo == null)
             throw new InvalidOperationException("OSSUpdateStrategy not configured. Call Create() first.");
 
-        // Dispatch by role �?no env-var detection needed.
+        // Dispatch by role — no env-var detection needed.
         if (_role == AppType.OSSUpgrade)
         {
             await ExecuteUpgradeAsync();
@@ -241,11 +240,12 @@ public class OSSUpdateStrategy : IStrategy
         }
         else
         {
-            using var httpClient = GeneralUpdate.Core.Network.HttpClientProvider.Shared;
-            using var cts = new CancellationTokenSource(
-                TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut));
+            using var httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut)
+            };
             var orchestrator = new DefaultDownloadOrchestrator(httpClient);
-            await orchestrator.ExecuteAsync(plan, _appPath, token: cts.Token).ConfigureAwait(false);
+            await orchestrator.ExecuteAsync(plan, _appPath).ConfigureAwait(false);
         }
     }
 

--- a/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyStrategy.cs
+++ b/src/c#/GeneralUpdate.Differential/Matchers/DefaultDirtyStrategy.cs
@@ -52,7 +52,7 @@ namespace GeneralUpdate.Differential.Matchers
         {
             if (!Directory.Exists(appPath) || !Directory.Exists(patchPath)) return;
 
-            var skipDirectory = BlackListManager.Instance.SkipDirectorys.ToList();
+            var skipDirectory = BlackListDefaults.DefaultSkipDirectories;
             var patchFiles = StorageManager.GetAllFiles(patchPath, skipDirectory);
             var oldFiles = StorageManager.GetAllFiles(appPath, skipDirectory);
             HandleDeleteList(patchFiles, oldFiles);
@@ -128,7 +128,7 @@ namespace GeneralUpdate.Differential.Matchers
                 foreach (var file in comparisonResult.DifferentNodes)
                 {
                     var extensionName = Path.GetExtension(file.FullName);
-                    if (BlackListManager.Instance.IsBlacklisted(extensionName)) continue;
+                    if (BlackListDefaults.DefaultBlackFormats.Contains(extensionName)) continue;
 
                     var targetFileName = file.FullName.Replace(patchPath, "").TrimStart(Path.DirectorySeparatorChar);
                     var targetPath = Path.Combine(appPath, targetFileName);

--- a/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Differential/Pipeline/DiffPipeline.cs
@@ -172,7 +172,7 @@ namespace GeneralUpdate.Differential.Pipeline
             var reporter = progress ?? _progress;
             if (!Directory.Exists(appPath) || !Directory.Exists(patchPath)) return;
 
-            var skipDirectory = BlackListManager.Instance.SkipDirectorys.ToList();
+            var skipDirectory = BlackListDefaults.DefaultSkipDirectories;
             var patchFiles = StorageManager.GetAllFiles(patchPath, skipDirectory).ToList();
             var oldFiles = StorageManager.GetAllFiles(appPath, skipDirectory).ToList();
 
@@ -284,7 +284,7 @@ namespace GeneralUpdate.Differential.Pipeline
                 foreach (var file in comparisonResult.DifferentNodes)
                 {
                     var extensionName = Path.GetExtension(file.FullName);
-                    if (BlackListManager.Instance.IsBlacklisted(extensionName)) continue;
+                    if (BlackListDefaults.DefaultBlackFormats.Contains(extensionName)) continue;
 
                     var targetFileName = file.FullName.Replace(patchPath, "").TrimStart(Path.DirectorySeparatorChar);
                     var targetPath = Path.Combine(appPath, targetFileName);

--- a/tests/CoreTest/Bootstrap/ParameterMatrixAndEventTests.cs
+++ b/tests/CoreTest/Bootstrap/ParameterMatrixAndEventTests.cs
@@ -264,25 +264,26 @@ namespace CoreTest.Bootstrap
         [Fact]
         public void BlackListManager_VariousConfigurations_AcceptsAllRules()
         {
-            var manager = BlackListManager.Instance;
+            var manager = new DefaultBlackListMatcher(BlackListConfig.Empty);
 
             Assert.NotNull(manager);
-            Assert.NotNull(manager.BlackFiles);
-            Assert.NotNull(manager.BlackFormats);
-            Assert.NotNull(manager.SkipDirectorys);
+            Assert.NotNull(BlackListDefaults.DefaultBlackFiles);
+            Assert.NotNull(BlackListDefaults.DefaultBlackFormats);
+            Assert.NotNull(BlackListDefaults.DefaultSkipDirectories);
+            Assert.False(manager.IsBlacklisted("test.dll"));
         }
 
         [Fact]
         public void BlackListManager_EmptyLists_DoesNotThrow()
         {
-            var manager = BlackListManager.Instance;
+            var manager = new DefaultBlackListMatcher(BlackListConfig.Empty);
             Assert.NotNull(manager);
         }
 
         [Fact]
         public void BlackListManager_NullList_DoesNotThrow()
         {
-            var manager = BlackListManager.Instance;
+            var manager = new DefaultBlackListMatcher(BlackListConfig.Empty);
             Assert.NotNull(manager);
         }
 


### PR DESCRIPTION
Closes #421

## Problem
PR #420 had:
1. UTF-8 encoding corruption (special characters garbled in diff)
2. Missing cross-project \BlackListManager.Instance\ references

## Changes
- Restore files from pre-\#420 state, re-apply with clean encoding
- Replace \BlackListManager.Instance\ with \BlackListDefaults\ / \DefaultBlackListMatcher\
- Fix \ParameterMatrixAndEventTests\ assertions
- 9 files changed, +32/-32 lines

## CI
All 3 jobs pass: aot-verify ✓ | build-and-test (ubuntu) ✓ | build-and-test (windows) ✓