### PR TITLE
refactor: change PipelineBuilder from LIFO (ImmutableStack) to FIFO (…

### DIFF
--- a/src/c#/GeneralUpdate.Core/Pipeline/PipelineBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/PipelineBuilder.cs
@@ -5,19 +5,16 @@ using System.Threading.Tasks;
 namespace GeneralUpdate.Core.Pipeline
 {
     /// <summary>
-    /// Pipeline builder.
+    /// Pipeline builder â€” middleware execute in FIFO (registration) order.
     /// </summary>
     public sealed class PipelineBuilder(PipelineContext context)
     {
-        /// <summary>
-        /// LIFO£¬Last In First Out.
-        /// </summary>
-        private ImmutableStack<IMiddleware> _middlewareStack = ImmutableStack<IMiddleware>.Empty;
+        private ImmutableQueue<IMiddleware> _middlewareQueue = ImmutableQueue<IMiddleware>.Empty;
 
         public PipelineBuilder UseMiddleware<TMiddleware>() where TMiddleware : IMiddleware, new()
         {
             var middleware = new TMiddleware();
-            _middlewareStack = _middlewareStack.Push(middleware);
+            _middlewareQueue = _middlewareQueue.Enqueue(middleware);
             return this;
         }
 
@@ -28,13 +25,13 @@ namespace GeneralUpdate.Core.Pipeline
                 return this;
             
             var middleware = new TMiddleware();
-            _middlewareStack = _middlewareStack.Push(middleware);
+            _middlewareQueue = _middlewareQueue.Enqueue(middleware);
             return this;
         }
 
         public async Task Build()
         {
-            foreach (var middleware in _middlewareStack)
+            foreach (var middleware in _middlewareQueue)
             {
                 await middleware.InvokeAsync(context);
             }

--- a/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
@@ -20,9 +20,9 @@ public class LinuxStrategy : AbstractStrategy
     {
         GeneralTracer.Info($"GeneralUpdate.Core.LinuxStrategy.BuildPipeline: assembling middleware pipeline. PatchEnabled={_configinfo.PatchEnabled}");
         var builder = new PipelineBuilder(context)
-            .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled)
+            .UseMiddleware<HashMiddleware>()
             .UseMiddleware<CompressMiddleware>()
-            .UseMiddleware<HashMiddleware>();
+            .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled);
         return builder;
     }
 

--- a/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
@@ -52,9 +52,9 @@ public class MacStrategy : AbstractStrategy
     {
         GeneralTracer.Info($"MacStrategy.BuildPipeline: assembling middleware pipeline. PatchEnabled={_configinfo.PatchEnabled}");
         var builder = new PipelineBuilder(context)
-            .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled)
+            .UseMiddleware<HashMiddleware>()
             .UseMiddleware<CompressMiddleware>()
-            .UseMiddleware<HashMiddleware>();
+            .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled);
         return builder;
     }
 }

--- a/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
@@ -27,9 +27,9 @@ namespace GeneralUpdate.Core.Strategy
         {
             GeneralTracer.Info($"GeneralUpdate.Core.WindowsStrategy.BuildPipeline: assembling middleware pipeline. PatchEnabled={_configinfo.PatchEnabled}");
             var builder = new PipelineBuilder(context)
-                .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled)
+                .UseMiddleware<HashMiddleware>()
                 .UseMiddleware<CompressMiddleware>()
-                .UseMiddleware<HashMiddleware>();
+                .UseMiddlewareIf<PatchMiddleware>(_configinfo.PatchEnabled);
             return builder;
         }
 


### PR DESCRIPTION
…ImmutableQueue)

The LIFO stack caused middleware execution order to be the reverse of registration order, which was the root cause of the MacStrategy pipeline bug. With FIFO (ImmutableQueue), registration order equals execution order, making the API intuitive for future maintainers.

All three OS strategies updated to register: Hash → Compress → Patch
FIFO execution: Hash → Compress → Patch

Closes #437