### PR TITLE
feat: wire up unused AbstractBootstrap extension points

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -15,6 +15,7 @@ using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.JsonContext;
 using GeneralUpdate.Core.Strategy;
 using GeneralUpdate.Core.Network;
+using GeneralUpdate.Core.Security;
 using GeneralUpdate.Core.Hooks;
 using GeneralUpdate.Core.Ipc;
 using GeneralUpdate.Core.Download.Reporting;
@@ -98,12 +99,37 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             var reporter = ResolveExtension<Download.Reporting.IUpdateReporter>() ??
                            new Download.Reporting.NoOpUpdateReporter();
 
+            // ── Network-level extensions (global, applied before any HTTP call) ──
+            var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
+            if (sslPolicy != null) Network.VersionService.SetSslValidationPolicy(sslPolicy);
+            var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
+            if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
+
             // ── Phase 1: inject all dependencies before Create ──
             roleStrategy.Hooks = hooks;
             roleStrategy.Reporter = reporter;
 
             var binaryDiffer = ResolveExtension<IBinaryDiffer>();
             var dirtyStrategy = ResolveExtension<IDirtyStrategy>();
+            var downloadOrchestrator = ResolveExtension<Download.Abstractions.IDownloadOrchestrator>();
+            var downloadPolicy = ResolveExtension<Download.Abstractions.IDownloadPolicy>();
+            var downloadExecutor = ResolveExtension<Download.Abstractions.IDownloadExecutor>();
+
+            // Build download pipeline factory from registered extension type.
+            // Tries a string constructor first (for passing the expected hash, à la DefaultDownloadPipeline),
+            // falls back to parameterless constructor otherwise.
+            Func<string?, Download.Abstractions.IDownloadPipeline>? downloadPipelineFactory = null;
+            var downloadPipeline = ResolveExtension<Download.Abstractions.IDownloadPipeline>();
+            if (downloadPipeline != null)
+            {
+                var pipelineType = downloadPipeline.GetType();
+                var stringCtor = pipelineType.GetConstructor([typeof(string)]);
+                if (stringCtor != null)
+                    downloadPipelineFactory = hash => (Download.Abstractions.IDownloadPipeline)stringCtor.Invoke([hash]);
+                else
+                    downloadPipelineFactory = _ => (Download.Abstractions.IDownloadPipeline)Activator.CreateInstance(pipelineType);
+            }
+
             var diffPipeline = BuildDiffPipeline();
 
             switch (roleStrategy)
@@ -119,13 +145,34 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
                     if (binaryDiffer != null) cs.SetBinaryDiffer(binaryDiffer);
                     if (dirtyStrategy != null) cs.SetDirtyStrategy(dirtyStrategy);
                     cs.SetDiffPipeline(diffPipeline);
+                    if (downloadOrchestrator != null) cs.SetOrchestrator(downloadOrchestrator);
+                    if (downloadPolicy != null) cs.SetDownloadPolicy(downloadPolicy);
+                    if (downloadExecutor != null) cs.SetDownloadExecutor(downloadExecutor);
+                    if (downloadPipelineFactory != null) cs.SetDownloadPipelineFactory(downloadPipelineFactory);
                     break;
 
                 case UpgradeUpdateStrategy us:
-                    if (binaryDiffer != null) us.SetBinaryDiffer(binaryDiffer);
-                    if (dirtyStrategy != null) us.SetDirtyStrategy(dirtyStrategy);
+                    if (binaryDiffer != null)
+                        us.SetBinaryDiffer(binaryDiffer);
+                    if (dirtyStrategy != null)
+                        us.SetDirtyStrategy(dirtyStrategy);
                     us.SetDiffPipeline(diffPipeline);
                     break;
+            }
+
+            // Inject custom OS-level strategy if registered via Strategy<T>()
+            var customOsStrategy = ResolveExtension<IStrategy>();
+            if (customOsStrategy != null)
+            {
+                switch (roleStrategy)
+                {
+                    case ClientUpdateStrategy cs:
+                        cs.SetOsStrategy(customOsStrategy);
+                        break;
+                    case UpgradeUpdateStrategy us:
+                        us.SetOsStrategy(customOsStrategy);
+                        break;
+                }
             }
 
             roleStrategy.Create(_configInfo);
@@ -316,9 +363,15 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         var reporter = ResolveExtension<Download.Reporting.IUpdateReporter>() ??
                        new Download.Reporting.NoOpUpdateReporter();
 
+        var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
+        if (sslPolicy != null) Network.VersionService.SetSslValidationPolicy(sslPolicy);
+        var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
+        if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
+
         var orchestrator = new Silent.SilentPollOrchestrator(_configInfo, silentOptions)
             .WithHooks(hooks)
-            .WithReporter(reporter);
+            .WithReporter(reporter)
+            .WithOsStrategy(ResolveExtension<IStrategy>());
 
         await orchestrator.StartAsync().ConfigureAwait(false);
         GeneralTracer.Info("GeneralUpdateBootstrap: silent update mode started, returning to caller.");

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -66,18 +66,22 @@ namespace GeneralUpdate.Core.Configuration
             return (TBootstrap)this;
         }
         
-        public TBootstrap PipelineFactory<T>() where T : Pipeline.IUpdatePipelineFactory, new()
-        {
-            _extensions[typeof(Pipeline.IUpdatePipelineFactory)] = typeof(T);
-            return (TBootstrap)this;
-        }
-
+        /// <summary>
+        /// Registers a custom retry/timeout policy for download operations.
+        /// Only effective when using the default download orchestrator.
+        /// If <see cref="DownloadOrchestrator{T}"/> is also set, this is ignored.
+        /// </summary>
         public TBootstrap DownloadPolicy<T>() where T : Download.Abstractions.IDownloadPolicy, new()
         {
             _extensions[typeof(Download.Abstractions.IDownloadPolicy)] = typeof(T);
             return (TBootstrap)this;
         }
 
+        /// <summary>
+        /// Registers a custom single-file download executor (e.g. for non-HTTP protocols).
+        /// Only effective when using the default download orchestrator.
+        /// If <see cref="DownloadOrchestrator{T}"/> is also set, this is ignored.
+        /// </summary>
         public TBootstrap DownloadExecutor<T>() where T : Download.Abstractions.IDownloadExecutor, new()
         {
             _extensions[typeof(Download.Abstractions.IDownloadExecutor)] = typeof(T);
@@ -90,6 +94,11 @@ namespace GeneralUpdate.Core.Configuration
             return (TBootstrap)this;
         }
 
+        /// <summary>
+        /// Registers a custom post-download processing pipeline (hash verification, decryption, virus scan).
+        /// Only effective when using the default download orchestrator.
+        /// If <see cref="DownloadOrchestrator{T}"/> is also set, this is ignored.
+        /// </summary>
         public TBootstrap DownloadPipeline<T>() where T : Download.Abstractions.IDownloadPipeline, new()
         {
             _extensions[typeof(Download.Abstractions.IDownloadPipeline)] = typeof(T);
@@ -108,15 +117,15 @@ namespace GeneralUpdate.Core.Configuration
             return (TBootstrap)this;
         }
 
+        /// <summary>
+        /// Registers a custom download orchestrator that handles batch downloads end-to-end.
+        /// This is the top-level download abstraction. When set, <see cref="DownloadPolicy{T}"/>,
+        /// <see cref="DownloadExecutor{T}"/>, and <see cref="DownloadPipeline{T}"/> are ignored
+        /// — the custom orchestrator owns the entire download pipeline.
+        /// </summary>
         public TBootstrap DownloadOrchestrator<T>() where T : Download.Abstractions.IDownloadOrchestrator, new()
         {
             _extensions[typeof(Download.Abstractions.IDownloadOrchestrator)] = typeof(T);
-            return (TBootstrap)this;
-        }
-
-        public TBootstrap CleanStrategy<T>() where T : Differential.ICleanStrategy, new()
-        {
-            _extensions[typeof(Differential.ICleanStrategy)] = typeof(T);
             return (TBootstrap)this;
         }
 

--- a/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
@@ -28,12 +28,21 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
     private readonly HttpClient _httpClient;
     private readonly IDownloadPolicy _policy;
     private readonly DownloadOrchestratorOptions _options;
+    private readonly IDownloadExecutor? _customExecutor;
+    private readonly Func<string?, IDownloadPipeline>? _pipelineFactory;
 
-    public DefaultDownloadOrchestrator(HttpClient httpClient, DownloadOrchestratorOptions? options = null, IDownloadPolicy? policy = null)
+    public DefaultDownloadOrchestrator(
+        HttpClient httpClient,
+        DownloadOrchestratorOptions? options = null,
+        IDownloadPolicy? policy = null,
+        IDownloadExecutor? executor = null,
+        Func<string?, IDownloadPipeline>? pipelineFactory = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _options = options ?? new DownloadOrchestratorOptions();
         _policy = policy ?? new DefaultRetryPolicy(_options.RetryCount, _options.RetryInterval);
+        _customExecutor = executor;
+        _pipelineFactory = pipelineFactory;
     }
 
     /// <summary>Execute downloads for all assets in the plan.</summary>
@@ -82,8 +91,8 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
                 var fileName = GetFileName(asset);
                 var destPath = Path.Combine(destDir, fileName);
 
-                var executor = new HttpDownloadExecutor(_httpClient, _options.DownloadTimeout, _options.EnableResume);
-                var pipeline = new DefaultDownloadPipeline(asset.SHA256);
+                var executor = _customExecutor ?? new HttpDownloadExecutor(_httpClient, _options.DownloadTimeout, _options.EnableResume);
+                var pipeline = _pipelineFactory?.Invoke(asset.SHA256) ?? new DefaultDownloadPipeline(asset.SHA256);
 
                 var result = await _policy.ExecuteAsync(async ct =>
                 {

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -19,6 +19,7 @@ namespace GeneralUpdate.Core.Network
     {
         private static readonly HttpClient _sharedClient;
         private static ISslValidationPolicy _globalSslPolicy = new StrictSslValidationPolicy();
+        private static IHttpAuthProvider? _globalAuthProvider;
 
         private readonly IHttpAuthProvider _auth;
         private readonly TimeSpan _timeout;
@@ -34,6 +35,9 @@ namespace GeneralUpdate.Core.Network
         public static void SetSslValidationPolicy(ISslValidationPolicy policy)
             => _globalSslPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
 
+        public static void SetDefaultAuthProvider(IHttpAuthProvider? provider)
+            => _globalAuthProvider = provider;
+
         private static bool SharedCertValidation(HttpRequestMessage m, X509Certificate2? c,
             X509Chain? ch, SslPolicyErrors e)
             => _globalSslPolicy.ValidateCertificate(c, ch, e);
@@ -48,7 +52,7 @@ namespace GeneralUpdate.Core.Network
         public static Task Report(string url, int recordId, int status, int? type,
             string scheme = null, string token = null, CancellationToken ct = default)
         {
-            var a = HttpAuthProviderFactory.Create(scheme, token, null);
+            var a = _globalAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, null);
             return new VersionService(a).ReportAsync(url, recordId, status, type, ct);
         }
 
@@ -57,7 +61,7 @@ namespace GeneralUpdate.Core.Network
             AppType appType, string appKey, PlatformType platform, string productId,
             string scheme = null, string token = null, CancellationToken ct = default)
         {
-            var a = HttpAuthProviderFactory.Create(scheme, token, appKey);
+            var a = _globalAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, appKey);
             return new VersionService(a).ValidateAsync(url, version, (int)appType, appKey, (int)platform, productId, ct);
         }
 

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -39,6 +39,7 @@ public class SilentPollOrchestrator : IDisposable
     private int _updaterStarted;
     private IUpdateHooks? _hooks;
     private IUpdateReporter? _reporter;
+    private IStrategy? _customOsStrategy;
     private Configuration.ProcessInfo? _preparedProcessInfo;
     private List<VersionInfo> _clientVersions = new();
 
@@ -50,6 +51,7 @@ public class SilentPollOrchestrator : IDisposable
 
     public SilentPollOrchestrator WithHooks(IUpdateHooks? hooks) { _hooks = hooks; return this; }
     public SilentPollOrchestrator WithReporter(IUpdateReporter? reporter) { _reporter = reporter; return this; }
+    public SilentPollOrchestrator WithOsStrategy(IStrategy? strategy) { _customOsStrategy = strategy; return this; }
 
     public Task StartAsync()
     {
@@ -335,8 +337,9 @@ public class SilentPollOrchestrator : IDisposable
         StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
     }
 
-    private static IStrategy CreateStrategy()
+    private IStrategy CreateStrategy()
     {
+        if (_customOsStrategy != null) return _customOsStrategy;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return new WindowsStrategy();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return new LinuxStrategy();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return new MacStrategy();

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientUpdateStrategy.cs
@@ -34,8 +34,12 @@ public class ClientUpdateStrategy : IStrategy
 {
     private GlobalConfigInfo? _configInfo;
     private IStrategy? _osStrategy;
+    private IStrategy? _customOsStrategy;
     private Func<UpdateInfoEventArgs, bool>? _updatePrecheck;
-    private readonly Download.Abstractions.IDownloadOrchestrator? _orchestrator;
+    private Download.Abstractions.IDownloadOrchestrator? _orchestrator;
+    private Download.Abstractions.IDownloadPolicy? _customDownloadPolicy;
+    private Download.Abstractions.IDownloadExecutor? _customDownloadExecutor;
+    private Func<string?, Download.Abstractions.IDownloadPipeline>? _customDownloadPipelineFactory;
     private int _mainRecordId;
 
     /// <summary>Which side(s) need updating, determined by server validation.</summary>
@@ -49,12 +53,30 @@ public class ClientUpdateStrategy : IStrategy
 
     /// <summary>Lifecycle hooks injected by the bootstrap.</summary>
     public Hooks.IUpdateHooks Hooks { get; set; } = new Hooks.NoOpUpdateHooks();
+
     /// <summary>Update status reporter injected by the bootstrap.</summary>
     public Download.Reporting.IUpdateReporter Reporter { get; set; } = new Download.Reporting.NoOpUpdateReporter();
+
     /// <summary>Download source (e.g., HTTP, SignalR Hub). Injected by bootstrap via HubConfig or extension registry (<c>.DownloadSource&lt;T&gt;()</c>).</summary>
     public Download.Abstractions.IDownloadSource? DownloadSource { get; set; }
 
-    public ClientUpdateStrategy(Download.Abstractions.IDownloadOrchestrator? orchestrator = null) { _orchestrator = orchestrator; }
+    public ClientUpdateStrategy() { }
+
+    /// <summary>Sets a custom OS-level strategy (injected via <c>.Strategy&lt;T&gt;()</c>).
+    /// When set, this replaces the automatic platform detection in <see cref="ResolveOsStrategy"/>.</summary>
+    public void SetOsStrategy(IStrategy? strategy) => _customOsStrategy = strategy;
+
+    /// <summary>Sets a custom download orchestrator (injected via <c>.DownloadOrchestrator&lt;T&gt;()</c>).</summary>
+    public void SetOrchestrator(Download.Abstractions.IDownloadOrchestrator? orchestrator) => _orchestrator = orchestrator;
+
+    /// <summary>Sets a custom download retry policy (injected via <c>.DownloadPolicy&lt;T&gt;()</c>).</summary>
+    public void SetDownloadPolicy(Download.Abstractions.IDownloadPolicy? policy) => _customDownloadPolicy = policy;
+
+    /// <summary>Sets a custom download executor (injected via <c>.DownloadExecutor&lt;T&gt;()</c>).</summary>
+    public void SetDownloadExecutor(Download.Abstractions.IDownloadExecutor? executor) => _customDownloadExecutor = executor;
+
+    /// <summary>Sets a custom download pipeline factory (injected via <c>.DownloadPipeline&lt;T&gt;()</c>).</summary>
+    public void SetDownloadPipelineFactory(Func<string?, Download.Abstractions.IDownloadPipeline>? factory) => _customDownloadPipelineFactory = factory;
 
     public void Create(GlobalConfigInfo parameter)
     {
@@ -145,7 +167,8 @@ public class ClientUpdateStrategy : IStrategy
 
     private async Task ExecuteStandardWorkflowAsync()
     {
-        GeneralTracer.Info($"ClientUpdateStrategy: validating client={_configInfo!.ClientVersion}, upgrade={_configInfo.UpgradeClientVersion}");
+        GeneralTracer.Info(
+            $"ClientUpdateStrategy: validating client={_configInfo!.ClientVersion}, upgrade={_configInfo.UpgradeClientVersion}");
 
         // Use injected DownloadSource (Hub/HTTP), or default to HttpDownloadSource
         var downloadSource = DownloadSource ?? new Download.Sources.HttpDownloadSource(
@@ -172,9 +195,9 @@ public class ClientUpdateStrategy : IStrategy
         var scenario = (_configInfo.IsMainUpdate, _configInfo.IsUpgradeUpdate) switch
         {
             (false, false) => UpdateScenario.None,
-            (false, true)  => UpdateScenario.UpgradeOnly,
-            (true, false)  => UpdateScenario.MainOnly,
-            (true, true)   => UpdateScenario.Both,
+            (false, true) => UpdateScenario.UpgradeOnly,
+            (true, false) => UpdateScenario.MainOnly,
+            (true, true) => UpdateScenario.Both,
         };
         GeneralTracer.Info($"ClientUpdateStrategy: Scenario={scenario}, AssetCount={downloadPlan.Assets.Count}");
 
@@ -194,14 +217,14 @@ public class ClientUpdateStrategy : IStrategy
             IsCrossVersion = a.IsCrossVersion,
             FromVersion = a.FromVersion
         }).ToList();
-        
+
         var versionResp = new VersionRespDTO
         {
             Code = versionInfos.Count > 0 ? 200 : 404,
             Body = versionInfos,
             Message = versionInfos.Count > 0 ? $"Found {versionInfos.Count} update(s)." : "No updates available."
         };
-        
+
         var updateInfoArgs = new UpdateInfoEventArgs(versionResp);
 
         // Capture the first RecordId for status reporting to GeneralSpacestation
@@ -241,7 +264,8 @@ public class ClientUpdateStrategy : IStrategy
         // Check failed version
         if (!string.IsNullOrEmpty(_configInfo.LastVersion) && CheckFail(_configInfo.LastVersion))
         {
-            GeneralTracer.Warn($"ClientUpdateStrategy: version {_configInfo.LastVersion} matches known-failed upgrade.");
+            GeneralTracer.Warn(
+                $"ClientUpdateStrategy: version {_configInfo.LastVersion} matches known-failed upgrade.");
             return;
         }
 
@@ -270,10 +294,14 @@ public class ClientUpdateStrategy : IStrategy
             var httpClient = GeneralUpdate.Core.Network.HttpClientProvider.Shared;
             try
             {
-                var orchestrator = new Download.Orchestrators.DefaultDownloadOrchestrator(httpClient, orchOptions);
+                var orchestrator = new Download.Orchestrators.DefaultDownloadOrchestrator(
+                    httpClient, orchOptions, _customDownloadPolicy,
+                    _customDownloadExecutor, _customDownloadPipelineFactory);
                 await orchestrator.ExecuteAsync(downloadPlan, _configInfo.TempPath).ConfigureAwait(false);
             }
-            finally { }
+            finally
+            {
+            }
         }
 
         await SafeReportDownloadCompletedAsync(hooksCtx).ConfigureAwait(false);
@@ -292,7 +320,8 @@ public class ClientUpdateStrategy : IStrategy
 
         var upgradeVersions = downloadVersions.Where(v => v.AppType == (int)AppType.Upgrade).ToList();
         var clientVersions = downloadVersions.Where(v => v.AppType == (int)AppType.Client).ToList();
-        GeneralTracer.Info($"ClientUpdateStrategy: Upgrade packages={upgradeVersions.Count}, MainApp packages={clientVersions.Count}");
+        GeneralTracer.Info(
+            $"ClientUpdateStrategy: Upgrade packages={upgradeVersions.Count}, MainApp packages={clientVersions.Count}");
 
         // ── Dispatch by scenario — one switch, four states, zero nested if-else ──
         switch (scenario)
@@ -356,7 +385,9 @@ public class ClientUpdateStrategy : IStrategy
             abs.LaunchBowl = false;
             abs.UseUpdatePath = !string.IsNullOrWhiteSpace(_configInfo.UpdatePath);
         }
-        GeneralTracer.Info($"ClientUpdateStrategy: launching upgrade process {_configInfo!.UpdateAppName} via OS strategy.");
+
+        GeneralTracer.Info(
+            $"ClientUpdateStrategy: launching upgrade process {_configInfo!.UpdateAppName} via OS strategy.");
         await _osStrategy!.StartAppAsync();
     }
 
@@ -364,8 +395,10 @@ public class ClientUpdateStrategy : IStrategy
 
     #region Helpers
 
-    private static IStrategy ResolveOsStrategy()
+    private IStrategy ResolveOsStrategy()
     {
+        if (_customOsStrategy != null)
+            return _customOsStrategy;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return new WindowsStrategy();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -380,14 +413,17 @@ public class ClientUpdateStrategy : IStrategy
         var effectiveConfig = new BlackListConfig(
             _configInfo!.BlackFiles?.Count > 0 ? _configInfo.BlackFiles : BlackListDefaults.DefaultBlackFiles,
             _configInfo.BlackFormats?.Count > 0 ? _configInfo.BlackFormats : BlackListDefaults.DefaultBlackFormats,
-            _configInfo.SkipDirectorys?.Count > 0 ? _configInfo.SkipDirectorys : BlackListDefaults.DefaultSkipDirectories
+            _configInfo.SkipDirectorys?.Count > 0
+                ? _configInfo.SkipDirectorys
+                : BlackListDefaults.DefaultSkipDirectories
         );
         StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
     }
 
     private void Backup()
     {
-        GeneralTracer.Info($"ClientUpdateStrategy: backing up {_configInfo!.InstallPath} -> {_configInfo.BackupDirectory}");
+        GeneralTracer.Info(
+            $"ClientUpdateStrategy: backing up {_configInfo!.InstallPath} -> {_configInfo.BackupDirectory}");
         StorageManager.Backup(_configInfo.InstallPath, _configInfo.BackupDirectory,
             _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
     }
@@ -450,26 +486,51 @@ public class ClientUpdateStrategy : IStrategy
 
     private async Task<bool> SafeOnBeforeUpdateAsync(Hooks.UpdateContext ctx)
     {
-        try { return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false); }
-        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}"); return true; }
+        try
+        {
+            return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}");
+            return true;
+        }
     }
 
     private async Task SafeOnBeforeStartAppAsync(Hooks.UpdateContext ctx)
     {
-        try { await Hooks.OnBeforeStartAppAsync(ctx).ConfigureAwait(false); }
-        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeStartAppAsync hook failed: {ex.Message}"); }
+        try
+        {
+            await Hooks.OnBeforeStartAppAsync(ctx).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"OnBeforeStartAppAsync hook failed: {ex.Message}");
+        }
     }
 
     private async Task SafeOnUpdateErrorAsync(Hooks.UpdateContext ctx, Exception error)
     {
-        try { await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false); }
-        catch (Exception ex) { GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}"); }
+        try
+        {
+            await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}");
+        }
     }
 
     private async Task SafeOnAfterUpdateAsync(Hooks.UpdateContext ctx)
     {
-        try { await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false); }
-        catch (Exception ex) { GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}"); }
+        try
+        {
+            await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}");
+        }
     }
 
     private async Task SafeOnDownloadCompletedAsync(Hooks.UpdateContext ctx)
@@ -482,43 +543,66 @@ public class ClientUpdateStrategy : IStrategy
                 0, TimeSpan.Zero, _configInfo?.TempPath, true);
             await Hooks.OnDownloadCompletedAsync(downloadCtx).ConfigureAwait(false);
         }
-        catch (Exception ex) { GeneralTracer.Warn($"OnDownloadCompletedAsync hook failed: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"OnDownloadCompletedAsync hook failed: {ex.Message}");
+        }
     }
 
     private async Task SafeReportUpdateStartedAsync(Hooks.UpdateContext ctx)
     {
         try
         {
-            await Reporter.ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId, (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
+            await Reporter
+                .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
+                    (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
         }
-        catch (Exception ex) { GeneralTracer.Warn($"Report UpdateStarted failed: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"Report UpdateStarted failed: {ex.Message}");
+        }
     }
 
     private async Task SafeReportDownloadCompletedAsync(Hooks.UpdateContext ctx)
     {
         try
         {
-            await Reporter.ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId, (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
+            await Reporter
+                .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
+                    (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
         }
-        catch (Exception ex) { GeneralTracer.Warn($"Report DownloadCompleted failed: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"Report DownloadCompleted failed: {ex.Message}");
+        }
     }
 
     private async Task SafeReportUpdateFailedAsync(Hooks.UpdateContext ctx, Exception error)
     {
         try
         {
-            await Reporter.ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId, (int)Download.Reporting.UpdateStatus.Failure, 1)).ConfigureAwait(false);
+            await Reporter
+                .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
+                    (int)Download.Reporting.UpdateStatus.Failure, 1)).ConfigureAwait(false);
         }
-        catch (Exception ex) { GeneralTracer.Warn($"Report UpdateFailed failed: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"Report UpdateFailed failed: {ex.Message}");
+        }
     }
 
     private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx)
     {
         try
         {
-            await Reporter.ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId, (int)Download.Reporting.UpdateStatus.Success, 1)).ConfigureAwait(false);
+            await Reporter
+                .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
+                    (int)Download.Reporting.UpdateStatus.Success, 1)).ConfigureAwait(false);
         }
-        catch (Exception ex) { GeneralTracer.Warn($"Report UpdateApplied failed: {ex.Message}"); }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn($"Report UpdateApplied failed: {ex.Message}");
+        }
     }
 
     #endregion

--- a/src/c#/GeneralUpdate.Core/Strategy/UpgradeUpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/UpgradeUpdateStrategy.cs
@@ -27,12 +27,17 @@ public class UpgradeUpdateStrategy : IStrategy
 {
     private GlobalConfigInfo? _configInfo;
     private IStrategy? _osStrategy;
+    private IStrategy? _customOsStrategy;
 
     /// <summary>Lifecycle hooks injected by the bootstrap.</summary>
     public Hooks.IUpdateHooks Hooks { get; set; } = new Hooks.NoOpUpdateHooks();
 
     /// <summary>Update status reporter injected by the bootstrap.</summary>
     public Download.Reporting.IUpdateReporter Reporter { get; set; } = new Download.Reporting.NoOpUpdateReporter();
+
+    /// <summary>Sets a custom OS-level strategy (injected via <c>.Strategy&lt;T&gt;()</c>).
+    /// When set, this replaces the automatic platform detection in <see cref="ResolveOsStrategy"/>.</summary>
+    public void SetOsStrategy(IStrategy? strategy) => _customOsStrategy = strategy;
 
     public void Create(GlobalConfigInfo parameter)
     {
@@ -151,8 +156,10 @@ public class UpgradeUpdateStrategy : IStrategy
 
     #region Helpers
 
-    private static IStrategy ResolveOsStrategy()
+    private IStrategy ResolveOsStrategy()
     {
+        if (_customOsStrategy != null)
+            return _customOsStrategy;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return new WindowsStrategy();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
+++ b/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
@@ -110,11 +110,6 @@ namespace CoreTest.Bootstrap
         }
 
 
-        private sealed class StubPipelineFactory : GeneralUpdate.Core.Pipeline.IUpdatePipelineFactory
-        {
-            public Task ExecutePipelineAsync(GeneralUpdate.Core.Pipeline.PipelineContext context, CancellationToken token = default) => Task.CompletedTask;
-        }
-
         private sealed class StubDownloadPolicy : GeneralUpdate.Core.Download.Abstractions.IDownloadPolicy
         {
             public Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken token = default) => action(token);
@@ -159,11 +154,6 @@ namespace CoreTest.Bootstrap
                 => Task.FromResult(new GeneralUpdate.Core.Download.Abstractions.DownloadReport(Array.Empty<GeneralUpdate.Core.Download.Models.DownloadResult>(), 0, TimeSpan.Zero, 0, 0));
         }
 
-        private sealed class StubCleanStrategy : GeneralUpdate.Core.Differential.ICleanStrategy
-        {
-            public Task ExecuteAsync(string sourcePath, string targetPath, string patchPath) => Task.CompletedTask;
-        }
-
         private sealed class StubDirtyStrategy : GeneralUpdate.Core.Differential.IDirtyStrategy
         {
             public Task ExecuteAsync(string appPath, string patchPath) => Task.CompletedTask;
@@ -173,14 +163,12 @@ namespace CoreTest.Bootstrap
         [Fact] public void Inject_Strategy() => Assert.NotNull(B().Strategy<StubStrategy>());
         [Fact] public void Inject_SslPolicy() => Assert.NotNull(B().SslPolicy<StubSslPolicy>());
         [Fact] public void Inject_DirtyStrategy() => Assert.NotNull(B().DirtyStrategy<StubDirtyStrategy>());
-        [Fact] public void Inject_PipelineFactory() => Assert.NotNull(B().PipelineFactory<StubPipelineFactory>());
         [Fact] public void Inject_DownloadPolicy() => Assert.NotNull(B().DownloadPolicy<StubDownloadPolicy>());
         [Fact] public void Inject_DownloadExecutor() => Assert.NotNull(B().DownloadExecutor<StubDownloadExecutor>());
         [Fact] public void Inject_DownloadSource() => Assert.NotNull(B().DownloadSource<StubDownloadSource>());
         [Fact] public void Inject_DownloadPipeline() => Assert.NotNull(B().DownloadPipeline<StubDownloadPipeline>());
         [Fact] public void Inject_UpdateReporter() => Assert.NotNull(B().UpdateReporter<StubUpdateReporter>());
         [Fact] public void Inject_DownloadOrchestrator() => Assert.NotNull(B().DownloadOrchestrator<StubDownloadOrchestrator>());
-        [Fact] public void Inject_CleanStrategy() => Assert.NotNull(B().CleanStrategy<StubCleanStrategy>());
 
         [Fact]
         public void Chain_AllExtensionsInjected()
@@ -194,11 +182,8 @@ namespace CoreTest.Bootstrap
                 .DownloadPipeline<StubDownloadPipeline>()
                 .DownloadOrchestrator<StubDownloadOrchestrator>()
                 .DirtyStrategy<StubDirtyStrategy>()
-                .CleanStrategy<StubCleanStrategy>()
-                .DirtyStrategy<StubDirtyStrategy>()
                 .SslPolicy<StubSslPolicy>()
                 .UpdateAuth<StubUpdateAuth>()
-                .PipelineFactory<StubPipelineFactory>()
                 .Strategy<StubStrategy>();
             Assert.NotNull(b);
         }


### PR DESCRIPTION
## Summary

Closes #455

8 extension points registered in `AbstractBootstrap` were stored in the registry but never resolved by any code path. This PR wires them into the update flow so user-injected implementations actually take effect.

### Changes

**Wired up (6 new wirings):**

| Extension | Where consumed |
|---|---|
| `Strategy<T>()` | `ClientUpdateStrategy`/`UpgradeUpdateStrategy` — custom OS-level strategy replaces auto-detected platform |
| `SslPolicy<T>()` | `VersionService.SetSslValidationPolicy()` — global SSL cert validation |
| `UpdateAuth<T>()` | `VersionService.SetDefaultAuthProvider()` — global HTTP auth provider |
| `DownloadOrchestrator<T>()` | `ClientUpdateStrategy.SetOrchestrator()` — replaces default batch download |
| `DownloadPolicy<T>()` | `DefaultDownloadOrchestrator` — custom retry/timeout policy |
| `DownloadExecutor<T>()` | `DefaultDownloadOrchestrator` — custom single-file download executor |
| `DownloadPipeline<T>()` | `DefaultDownloadOrchestrator` — factory-based per-asset pipeline (hash passed to constructor when supported) |

**Removed (2):**

- `CleanStrategy<T>()` — redundant with `ICleanMatcher` + `IBinaryDiffer` already injectable via `DiffPipelineBuilder`
- `PipelineFactory<T>()` — too coarse (replaces entire update pipeline), misleading name

**Documented:**

- XML docs on `DownloadOrchestrator`/`DownloadPolicy`/`DownloadExecutor`/`DownloadPipeline` clarifying priority: orchestrator overrides sub-components

### Files changed

- `AbstractBootstrap.cs` — removed 2 methods, added XML docs for 4 download methods
- `GeneralUpdateBootstrap.cs` — resolve and inject all extension types
- `ClientUpdateStrategy.cs` — added setters for OS strategy + download components
- `UpgradeUpdateStrategy.cs` — added pending forwarding for OS strategy
- `DefaultDownloadOrchestrator.cs` — accept custom executor/pipeline factory
- `VersionService.cs` — added `SetDefaultAuthProvider()` static method
- `SilentPollOrchestrator.cs` — accept custom OS strategy
- `BootstrapFullParameterMatrixTests.cs` — removed tests for removed methods

## Test plan

- [x] Build: 0 errors
- [x] CoreTest Bootstrap: 120/120 passing
- [x] CoreTest full suite: 921/925 (4 pre-existing failures unrelated to this PR)
- [x] DifferentialTest: 94/94 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)