### PR TITLE
fix: AppType filtering, RecordId reporting, and MainOnly scenario report

### DIFF
--- a/src/c#/DifferentialTest/Pipeline/DiffPipelineIntegrationTests.cs
+++ b/src/c#/DifferentialTest/Pipeline/DiffPipelineIntegrationTests.cs
@@ -222,7 +222,7 @@ namespace DifferentialTest.Pipeline
             await pipeline.CleanAsync(sourceDir, targetDir, patchDir);
 
             // Assert
-            var deleteJson = Path.Combine(patchDir, "generalupdate_delete_files.json");
+            var deleteJson = Path.Combine(patchDir, "generalupdate.delete.json");
             Assert.True(File.Exists(deleteJson));
             var content = File.ReadAllText(deleteJson);
             Assert.NotEmpty(content);
@@ -423,7 +423,7 @@ namespace DifferentialTest.Pipeline
 
             // Phase 1: Clean generates delete JSON
             await pipeline.CleanAsync(sourceDir, targetDir, patchDir);
-            Assert.True(File.Exists(Path.Combine(patchDir, "generalupdate_delete_files.json")));
+            Assert.True(File.Exists(Path.Combine(patchDir, "generalupdate.delete.json")));
 
             // Phase 2: app dir has both files
             File.WriteAllBytes(Path.Combine(appDir, "keep.bin"), keepData);

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -177,6 +177,7 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
                 case UpdateStrategy us:
                     us.SetDiffPipeline(diffPipeline);
+                    us.SetReportType(_configInfo.ReportType);
                     break;
             }
 
@@ -369,6 +370,7 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             DriverDirectory = processInfo.DriverDirectory,
             UpdatePath = processInfo.UpdatePath,
             LaunchClientAfterUpdate = processInfo.LaunchClientAfterUpdate,
+            ReportType = processInfo.ReportType,
             BlackFiles = processInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
             BlackFormats = processInfo.BlackFileFormats ?? BlackListDefaults.DefaultBlackFormats,
             SkipDirectorys = processInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories

--- a/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
@@ -170,14 +170,15 @@ namespace GeneralUpdate.Core.Configuration
             List<VersionInfo> updateVersions,
             List<string> blackFileFormats,
             List<string> blackFiles,
-            List<string> skipDirectories)
+            List<string> skipDirectories,
+            int reportType = 1)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source), "GlobalConfigInfo source cannot be null");
 
             // 在单一位置创建 ProcessInfo，包含所有必需参数
             // 集中管理 ProcessInfo 的参数映射逻辑
-            return new ProcessInfo(
+            var processInfo = new ProcessInfo(
                 appName: source.MainAppName,                    // MainAppName 映射到 ProcessInfo.UpdateAppName
                 installPath: source.InstallPath,
                 currentVersion: source.ClientVersion,           // ClientVersion 映射到 ProcessInfo.CurrentVersion
@@ -201,6 +202,8 @@ namespace GeneralUpdate.Core.Configuration
                 upgradePath: source.UpdatePath,                  // 自定义升级目录
                 launchClient: source.LaunchClientAfterUpdate
             );
+            processInfo.ReportType = reportType;
+            return processInfo;
         }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Configuration/GlobalConfigInfo.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/GlobalConfigInfo.cs
@@ -100,6 +100,12 @@ public class GlobalConfigInfo : BaseConfigInfo
     public bool LaunchClientAfterUpdate { get; set; } = true;
 
     /// <summary>
+    ///     The report type for status reporting: 1 = Upgrade (active poll), 2 = Push (SignalR push).
+    ///     Passed from ClientStrategy through ProcessInfo to UpdateStrategy.
+    /// </summary>
+    public int ReportType { get; set; } = 1;
+
+    /// <summary>
     ///     The list of version information objects to be updated.
     ///     Populated from the update server response based on <see cref="IsUpgradeUpdate" /> and <see cref="IsMainUpdate" />.
     /// </summary>

--- a/src/c#/GeneralUpdate.Core/Configuration/ProcessInfo.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ProcessInfo.cs
@@ -373,5 +373,12 @@ namespace GeneralUpdate.Core.Configuration
         /// </summary>
         [JsonPropertyName("LaunchClientAfterUpdate")]
         public bool LaunchClientAfterUpdate { get; set; } = true;
+
+        /// <summary>
+        ///     The report type for status reporting: 1 = Upgrade (active poll), 2 = Push (SignalR push).
+        ///     Passed from ClientStrategy to UpdateStrategy so it uses the same type when reporting.
+        /// </summary>
+        [JsonPropertyName("ReportType")]
+        public int ReportType { get; set; } = 1;
     }
 }

--- a/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
@@ -118,8 +118,11 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
             _appSecretKey, _platform, _productId,
             _scheme, _token, token);
 
-        var hasMainUpdate = mainResp?.Body?.Count > 0;
-        var hasUpgradeUpdate = upgradeResp?.Body?.Count > 0;
+        // Check that returned VersionInfo items' AppType matches the requested type,
+        // rather than just checking Count > 0. The server may return items whose
+        // AppType doesn't match the request, which would mis-identify the scenario.
+        var hasMainUpdate = mainResp?.Body?.Any(v => v.AppType == (int)AppType.Client) == true;
+        var hasUpgradeUpdate = upgradeResp?.Body?.Any(v => v.AppType == (int)AppType.Upgrade) == true;
 
         var assets = new List<DownloadAsset>();
 

--- a/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
@@ -76,7 +76,7 @@ public class DiffPipeline
     private readonly IProgress<DiffProgress>? _progress;
 
     private const string PatchExtension = ".patch";
-    private const string DeleteListFileName = "generalupdate_delete_files.json";
+    private const string DeleteListFileName = "generalupdate.delete.json";
 
     /// <summary>
     /// Initializes a new pipeline instance with default options, default binary differ

--- a/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
@@ -62,7 +62,7 @@ namespace GeneralUpdate.Core.Pipeline;
 /// <list type="bullet">
 ///   <item><description>Changed files: Generate/apply binary patches.</description></item>
 ///   <item><description>New files: Copy directly.</description></item>
-///   <item><description>Deleted files: Recorded in <c>generalupdate_delete_files.json</c>; removed during dirty mode execution.</description></item>
+///   <item><description>Deleted files: Recorded in <c>generalupdate.delete.json</c>; removed during dirty mode execution.</description></item>
 ///   <item><description>Unchanged files: Skipped.</description></item>
 /// </list>
 /// </para>
@@ -188,7 +188,7 @@ public class DiffPipeline
     ///   <item><description>For each changed file: computes the relative path, creates a temporary directory,
     ///         and uses <see cref="IBinaryDiffer.CleanAsync"/> to generate a .patch file.</description></item>
     ///   <item><description>For each new file: copies it directly to the corresponding location in the patch output directory.</description></item>
-    ///   <item><description>Generates a <c>generalupdate_delete_files.json</c> manifest recording files that have been
+    ///   <item><description>Generates a <c>generalupdate.delete.json</c> manifest recording files that have been
     ///         deleted from the new version (no longer present in the old version).</description></item>
     /// </list>
     /// </para>
@@ -291,7 +291,7 @@ public class DiffPipeline
     /// <list type="number">
     ///   <item><description>If <paramref name="appPath"/> or <paramref name="patchPath"/> does not exist, returns immediately.</description></item>
     ///   <item><description>Scans all files in the patch directory (skipping blacklisted directories), finds the
-    ///         <c>generalupdate_delete_files.json</c> file, and performs file deletion.</description></item>
+    ///         <c>generalupdate.delete.json</c> file, and performs file deletion.</description></item>
     ///   <item><description>Uses <see cref="IDirtyMatcher.Match"/> to pair patch files with their corresponding old version files.</description></item>
     ///   <item><description>For each matched file pair, safely applies the patch using a temporary file strategy:
     ///         first writes the patch result to a temporary file, then on success deletes the original file and
@@ -302,7 +302,7 @@ public class DiffPipeline
     /// </para>
     /// <para>
     /// Deletion manifest handling details:
-    /// If the patch directory contains a <c>generalupdate_delete_files.json</c> file, this file records the
+    /// If the patch directory contains a <c>generalupdate.delete.json</c> file, this file records the
     /// SHA256 hash values of files that have been deleted in the new version. The system identifies and removes
     /// these files by comparing the recorded hash values with the SHA256 hash of each current file.
     /// </para>
@@ -429,13 +429,13 @@ public class DiffPipeline
     }
 
     /// <summary>
-    /// Processes the deletion manifest (generalupdate_delete_files.json) and removes obsolete files from the application directory.
+    /// Processes the deletion manifest (generalupdate.delete.json) and removes obsolete files from the application directory.
     /// </summary>
     /// <param name="patchFiles">The list of files in the patch directory.</param>
     /// <param name="oldFiles">The list of files in the application directory.</param>
     /// <remarks>
     /// <para>
-    /// This method locates the <c>generalupdate_delete_files.json</c> file in the patch directory,
+    /// This method locates the <c>generalupdate.delete.json</c> file in the patch directory,
     /// which contains a list of SHA256 hash values for files that have been deleted in the new version.
     /// It then scans each file in the application directory, computes its SHA256 hash, and compares it
     /// against the values in the manifest. Matching files are deleted.

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -442,6 +442,10 @@ public class ClientStrategy : IStrategy
         // Capture RecordIds per AppType for status reporting.
         // Client packages are reported by UpdateStrategy (Bowl) via IPC; Upgrade packages
         // are applied in-place and reported by ClientStrategy.
+        //
+        // Note: _mainRecordId treats null AppType as Client (matching the fallback in
+        // downloadVersions at line ~530). _upgradeRecordId requires an explicit Upgrade
+        // match — assets with omitted AppType are never treated as Upgrade packages.
         _mainRecordId = downloadPlan.Assets
             .FirstOrDefault(a => (a.AppType ?? (int)AppType.Client) == (int)AppType.Client)?.RecordId ?? 0;
         _upgradeRecordId = downloadPlan.Assets
@@ -563,7 +567,7 @@ public class ClientStrategy : IStrategy
                 break;
             case UpdateScenario.None:
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new InvalidOperationException($"Unhandled update scenario: {scenario}");
         }
     }
 

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -72,6 +72,8 @@ public class ClientStrategy : IStrategy
     private Download.Abstractions.IDownloadExecutor? _customDownloadExecutor;
     private Func<string?, Download.Abstractions.IDownloadPipeline>? _customDownloadPipelineFactory;
     private int _mainRecordId;
+    private int _upgradeRecordId;
+    private int _reportType = 1; // 1=Upgrade(active poll), 2=Push(SignalR push)
 
     /// <summary>
     /// Update scenario determined by the server validation result, indicating which update targets are needed.
@@ -159,6 +161,16 @@ public class ClientStrategy : IStrategy
     /// and <see cref="SetDownloadPipelineFactory"/> are ignored.
     /// </remarks>
     public void SetOrchestrator(Download.Abstractions.IDownloadOrchestrator? orchestrator) => _orchestrator = orchestrator;
+
+    /// <summary>
+    /// Sets the report type for status reporting. Injected by the bootstrap for push-triggered updates.
+    /// </summary>
+    /// <param name="reportType">1 = Upgrade (active poll), 2 = Push (SignalR push). Default is 1.</param>
+    /// <remarks>
+    /// When a push notification triggers the update (via SignalR hub), the caller should set this to 2
+    /// so the server can distinguish push-triggered updates from active poll updates.
+    /// </remarks>
+    public void SetReportType(int reportType) => _reportType = reportType;
 
     /// <summary>
     /// Sets a custom download retry policy. Registered and injected by the bootstrap via <c>.DownloadPolicy&lt;T&gt;()</c>.
@@ -427,8 +439,13 @@ public class ClientStrategy : IStrategy
 
         var updateInfoArgs = new UpdateInfoEventArgs(versionResp);
 
-        // Capture the first RecordId for status reporting to GeneralSpacestation
-        _mainRecordId = downloadPlan.Assets.FirstOrDefault().RecordId;
+        // Capture RecordIds per AppType for status reporting.
+        // Client packages are reported by UpdateStrategy (Bowl) via IPC; Upgrade packages
+        // are applied in-place and reported by ClientStrategy.
+        _mainRecordId = downloadPlan.Assets
+            .FirstOrDefault(a => (a.AppType ?? (int)AppType.Client) == (int)AppType.Client)?.RecordId ?? 0;
+        _upgradeRecordId = downloadPlan.Assets
+            .FirstOrDefault(a => a.AppType == (int)AppType.Upgrade)?.RecordId ?? 0;
         EventManager.Instance.Dispatch(this, updateInfoArgs);
 
         var isForcibly = downloadPlan.IsForcibly;
@@ -504,6 +521,7 @@ public class ClientStrategy : IStrategy
         // Build VersionInfo list with AppType preserved from server response.
         var downloadVersions = downloadPlan.Assets.Select(a => new VersionInfo
         {
+            RecordId = a.RecordId,
             Name = a.Name,
             Hash = a.SHA256,
             Url = a.Url,
@@ -523,12 +541,14 @@ public class ClientStrategy : IStrategy
             case UpdateScenario.UpgradeOnly:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
-                await SafeReportUpdateAppliedAsync(hooksCtx).ConfigureAwait(false);
+                await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 GeneralTracer.Info("ClientStrategy: Upgrade-only update applied, client continues running.");
                 break;
 
             case UpdateScenario.MainOnly:
                 SendProcessIpc(clientVersions);
+                await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
+                await SafeReportUpdateAppliedAsync(hooksCtx, _mainRecordId).ConfigureAwait(false);
                 await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
                 await LaunchUpgradeProcessAsync().ConfigureAwait(false);
                 break;
@@ -536,11 +556,14 @@ public class ClientStrategy : IStrategy
             case UpdateScenario.Both:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
-                await SafeReportUpdateAppliedAsync(hooksCtx).ConfigureAwait(false);
+                await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 SendProcessIpc(clientVersions);
                 await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
                 await LaunchUpgradeProcessAsync().ConfigureAwait(false);
                 break;
+            case UpdateScenario.None:
+            default:
+                throw new ArgumentOutOfRangeException();
         }
     }
 
@@ -584,7 +607,8 @@ public class ClientStrategy : IStrategy
             _configInfo!, clientVersions,
             _configInfo!.BlackFormats ?? BlackListDefaults.DefaultBlackFormats,
             _configInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
-            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
+            _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories,
+            _reportType);
 
         _configInfo.ProcessInfo = JsonSerializer.Serialize(processInfo,
             ProcessInfoJsonContext.Default.ProcessInfo);
@@ -883,7 +907,7 @@ public class ClientStrategy : IStrategy
         {
             await Reporter
                 .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
-                    (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
+                    (int)Download.Reporting.UpdateStatus.Updating, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -901,7 +925,7 @@ public class ClientStrategy : IStrategy
         {
             await Reporter
                 .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
-                    (int)Download.Reporting.UpdateStatus.Updating, 1)).ConfigureAwait(false);
+                    (int)Download.Reporting.UpdateStatus.Updating, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -920,7 +944,7 @@ public class ClientStrategy : IStrategy
         {
             await Reporter
                 .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
-                    (int)Download.Reporting.UpdateStatus.Failure, 1)).ConfigureAwait(false);
+                    (int)Download.Reporting.UpdateStatus.Failure, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -932,13 +956,13 @@ public class ClientStrategy : IStrategy
     /// Safely reports the update applied success status. If the report fails, logs a warning.
     /// </summary>
     /// <param name="ctx">The update context.</param>
-    private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx)
+    private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx, int recordId)
     {
         try
         {
             await Reporter
-                .ReportAsync(new Download.Reporting.UpdateReport(_mainRecordId,
-                    (int)Download.Reporting.UpdateStatus.Success, 1)).ConfigureAwait(false);
+                .ReportAsync(new Download.Reporting.UpdateReport(recordId,
+                    (int)Download.Reporting.UpdateStatus.Success, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
@@ -45,6 +46,7 @@ public class UpdateStrategy : IStrategy
     private GlobalConfigInfo? _configInfo;
     private IStrategy? _osStrategy;
     private IStrategy? _customOsStrategy;
+    private int _reportType = 1; // 1=Upgrade(active poll), 2=Push(SignalR push)
 
     /// <summary>
     /// Gets or sets the lifecycle hooks. Injected by the bootstrap to execute custom logic at key points in the update flow.
@@ -63,12 +65,18 @@ public class UpdateStrategy : IStrategy
     public void SetOsStrategy(IStrategy? strategy) => _customOsStrategy = strategy;
 
     /// <summary>
+    /// Sets the report type for status reporting. The caller (ClientStrategy) should pass the same
+    /// report type it used, so the server can distinguish push-triggered updates from active polls.
+    /// </summary>
+    /// <param name="reportType">1 = Upgrade (active poll), 2 = Push (SignalR push). Default is 1.</param>
+    public void SetReportType(int reportType) => _reportType = reportType;
+
+    /// <summary>
     /// Initializes the upgrade-side strategy. Receives the global configuration information passed from the client
     /// and resolves the strategy instance for the current operating system.
     /// </summary>
     /// <param name="parameter">Global configuration information containing update package paths, hash values, version information, etc.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is null.</exception>
-    /// <exception cref="PlatformNotSupportedException">Thrown by <see cref="ResolveOsStrategy"/> when the current OS is not supported.</exception>
     public void Create(GlobalConfigInfo parameter)
     {
         _configInfo = parameter ?? throw new ArgumentNullException(nameof(parameter));
@@ -83,32 +91,6 @@ public class UpdateStrategy : IStrategy
     /// Executes the upgrade-side update flow. Follows the lifecycle order: pre-update hook, OS update pipeline,
     /// post-update hook, pre-start-app hook, and main application launch.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <b>Detailed Execution Flow:</b>
-    /// <list type="number">
-    ///   <item><description><b>OnBeforeUpdate Hook:</b> Calls <see cref="Hooks.IUpdateHooks.OnBeforeUpdateAsync"/>.
-    ///   If it returns <c>false</c>, the update is cancelled.</description></item>
-    ///   <item><description><b>OS Update Pipeline:</b> Passes <c>_configInfo.UpdateVersions</c> to
-    ///   <see cref="IStrategy.ExecuteAsync"/>, where the OS strategy processes each version's update package
-    ///   (<c>Hash</c> verification → <c>Decompress</c> extraction → <c>Patch</c> application).</description></item>
-    ///   <item><description><b>OnAfterUpdate Hook:</b> Calls <see cref="Hooks.IUpdateHooks.OnAfterUpdateAsync"/>
-    ///   to notify the caller that all updates have been applied.</description></item>
-    ///   <item><description><b>Report Success:</b> Reports the update success status via
-    ///   <see cref="Download.Reporting.IUpdateReporter"/>.</description></item>
-    ///   <item><description><b>OnBeforeStartApp Hook:</b> Calls <see cref="Hooks.IUpdateHooks.OnBeforeStartAppAsync"/>,
-    ///   allowing the caller to perform additional operations before launching the application
-    ///   (such as setting executable permissions).</description></item>
-    ///   <item><description><b>Launch Application:</b> When <c>LaunchClientAfterUpdate</c> is <c>true</c>,
-    ///   launches the main application (<c>MainAppName</c>) and the Bowl helper process via the OS strategy.</description></item>
-    /// </list>
-    /// </para>
-    /// <para>
-    /// <b>Exception Handling:</b> Any exception in the entire flow is caught by the <c>try-catch</c> block,
-    /// which sequentially triggers <see cref="Hooks.IUpdateHooks.OnUpdateErrorAsync"/>, reports the update failure status,
-    /// logs the error, and dispatches the exception event via <see cref="EventManager"/>.
-    /// </para>
-    /// </remarks>
     public async Task ExecuteAsync()
     {
         if (_configInfo == null) throw new InvalidOperationException("UpdateStrategy not configured.");
@@ -142,7 +124,7 @@ public class UpdateStrategy : IStrategy
             // Hooks: after all updates applied
             await SafeOnAfterUpdateAsync(ctx).ConfigureAwait(false);
 
-            // Report: update applied successfully
+            // Report: update applied successfully — uses the first Client package's RecordId
             await SafeReportUpdateAppliedAsync(ctx).ConfigureAwait(false);
 
             // Hooks: before starting main app (e.g. chmod +x on Linux/macOS)
@@ -180,10 +162,6 @@ public class UpdateStrategy : IStrategy
     /// Sets the differential patch pipeline on the underlying OS-level strategy for parallel patch application.
     /// </summary>
     /// <param name="diffPipeline">The differential pipeline instance. If <c>null</c>, clears the pending pipeline.</param>
-    /// <remarks>
-    /// If the OS strategy is not yet initialized, the pipeline is stored in a pending field
-    /// and passed to the OS strategy's <c>DiffPipeline</c> property when <see cref="Create"/> is called.
-    /// </remarks>
     public void SetDiffPipeline(DiffPipeline? diffPipeline)
     {
         if (_osStrategy is AbstractStrategy abs)
@@ -195,9 +173,6 @@ public class UpdateStrategy : IStrategy
     /// <summary>
     /// Starts the main application. Delegates to the underlying OS strategy for platform-specific application launch logic.
     /// </summary>
-    /// <remarks>
-    /// This method is called externally (e.g., by the Bowl process) to start the main application after the upgrade completes.
-    /// </remarks>
     public async Task StartAppAsync()
     {
         if (_osStrategy != null)
@@ -219,10 +194,6 @@ public class UpdateStrategy : IStrategy
         throw new PlatformNotSupportedException("The current operating system is not supported!");
     }
 
-    // ════════════════════════════════════════════════════════════════
-    // Hooks & Reporter safe wrappers
-    // ════════════════════════════════════════════════════════════════
-
     private Hooks.UpdateContext BuildUpdateContext()
     {
         return new Hooks.UpdateContext(
@@ -236,60 +207,36 @@ public class UpdateStrategy : IStrategy
 
     private async Task<bool> SafeOnBeforeUpdateAsync(Hooks.UpdateContext ctx)
     {
-        try
-        {
-            return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}");
-            return true;
-        }
+        try { return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}"); return true; }
     }
 
     private async Task SafeOnAfterUpdateAsync(Hooks.UpdateContext ctx)
     {
-        try
-        {
-            await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}");
-        }
+        try { await Hooks.OnAfterUpdateAsync(ctx).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnAfterUpdateAsync hook failed: {ex.Message}"); }
     }
 
     private async Task SafeOnBeforeStartAppAsync(Hooks.UpdateContext ctx)
     {
-        try
-        {
-            await Hooks.OnBeforeStartAppAsync(ctx).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Warn($"OnBeforeStartAppAsync hook failed: {ex.Message}");
-        }
+        try { await Hooks.OnBeforeStartAppAsync(ctx).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeStartAppAsync hook failed: {ex.Message}"); }
     }
 
     private async Task SafeOnUpdateErrorAsync(Hooks.UpdateContext ctx, Exception error)
     {
-        try
-        {
-            await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}");
-        }
+        try { await Hooks.OnUpdateErrorAsync(ctx, error).ConfigureAwait(false); }
+        catch (Exception ex) { GeneralTracer.Warn($"OnUpdateErrorAsync hook failed: {ex.Message}"); }
     }
 
     private async Task SafeReportUpdateAppliedAsync(Hooks.UpdateContext ctx)
     {
         try
         {
+            var recordId = _configInfo?.UpdateVersions?.FirstOrDefault()?.RecordId ?? 0;
             await Reporter
-                .ReportAsync(new Download.Reporting.UpdateReport(0, (int)Download.Reporting.UpdateStatus.Success,
-                    1)).ConfigureAwait(false);
+                .ReportAsync(new Download.Reporting.UpdateReport(recordId,
+                    (int)Download.Reporting.UpdateStatus.Success, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -301,10 +248,10 @@ public class UpdateStrategy : IStrategy
     {
         try
         {
+            var recordId = _configInfo?.UpdateVersions?.FirstOrDefault()?.RecordId ?? 0;
             await Reporter
-                .ReportAsync(
-                    new Download.Reporting.UpdateReport(0, (int)Download.Reporting.UpdateStatus.Failure, 1))
-                .ConfigureAwait(false);
+                .ReportAsync(new Download.Reporting.UpdateReport(recordId,
+                    (int)Download.Reporting.UpdateStatus.Failure, _reportType)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/tests/DifferentialTest/ComprehensiveDifferentialTests.cs
+++ b/tests/DifferentialTest/ComprehensiveDifferentialTests.cs
@@ -657,7 +657,7 @@ public class ComprehensiveDifferentialTests : IDisposable
         await pipeline.CleanAsync(src, tgt, patchDir);
 
         // Verify delete list exists
-        Assert.True(File.Exists(Path.Combine(patchDir, "generalupdate_delete_files.json")));
+        Assert.True(File.Exists(Path.Combine(patchDir, "generalupdate.delete.json")));
 
         // Apply patches
         await pipeline.DirtyAsync(app, patchDir);


### PR DESCRIPTION
- HttpDownloadSource: filter response by AppType for HasMainUpdate/HasUpgradeUpdate instead of only checking Body.Count > 0, preventing Both scenario misjudgment
- ClientStrategy: capture _mainRecordId and _upgradeRecordId separately per AppType, copy RecordId into downloadVersions for IPC, add SafeReportUpdateAppliedAsync in MainOnly scenario, use explicit recordId in UpgradeOnly/Both reports
- UpdateStrategy: read RecordId from UpdateVersions instead of hardcoded 0, add _reportType/SetReportType for poll(1) vs push(2) distinction
- Add ReportType to ProcessInfo, GlobalConfigInfo, ConfigurationMapper for IPC
- Bootstrap: wire ReportType from ProcessInfo to UpdateStrategy.SetReportType()
- DiffPipeline: rename DeleteListFileName to generalupdate.delete.json