### PR TITLE
feat: write back latest version to generalupdate.manifest.json after successful update

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/ManifestInfo.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ManifestInfo.cs
@@ -83,4 +83,46 @@ public class ManifestInfo
             AppType = Enum.TryParse<AppType>(AppType, out var at) ? at : null
         };
     }
+
+    /// <summary>
+    ///     Serialize this manifest back to the JSON file at the specified path, or
+    ///     <see cref="AppDomain.CurrentDomain.BaseDirectory"/>/<c>generalupdate.manifest.json</c>
+    ///     when <paramref name="path"/> is <c>null</c>.
+    /// </summary>
+    public void Save(string? path = null)
+    {
+        var filePath = path ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, FileName);
+        var json = JsonSerializer.Serialize(this, HttpParameterJsonContext.Default.ManifestInfo);
+        File.WriteAllText(filePath, json);
+    }
+
+    /// <summary>
+    ///     Load the manifest from <paramref name="baseDirectory"/>, update the specified version
+    ///     fields, and save it back. Does nothing silently when the manifest file does not exist.
+    /// </summary>
+    /// <param name="baseDirectory">
+    ///     The directory containing <c>generalupdate.manifest.json</c>.
+    /// </param>
+    /// <param name="clientVersion">
+    ///     If non-null, overwrites <see cref="ClientVersion"/> with this value.
+    /// </param>
+    /// <param name="upgradeClientVersion">
+    ///     If non-null, overwrites <see cref="UpgradeClientVersion"/> with this value.
+    /// </param>
+    public static void TryUpdateVersion(
+        string baseDirectory,
+        string? clientVersion = null,
+        string? upgradeClientVersion = null)
+    {
+        var manifestPath = Path.Combine(baseDirectory, FileName);
+        var manifest = Load(manifestPath);
+        if (manifest == null) return;
+
+        if (clientVersion != null)
+            manifest.ClientVersion = clientVersion;
+        if (upgradeClientVersion != null)
+            manifest.UpgradeClientVersion = upgradeClientVersion;
+
+        manifest.Save(manifestPath);
+    }
 }

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -355,6 +355,11 @@ public class SilentPollOrchestrator : IDisposable
                 strategy.Create(_configInfo);
                 await strategy.ExecuteAsync().ConfigureAwait(false);
                 GeneralTracer.Info("SilentPollOrchestrator: Upgrade packages applied.");
+
+                // Only advance the manifest version when every package was applied
+                // successfully — the same gating used by ClientStrategy.
+                if ((strategy as AbstractStrategy)?.AllPackagesSucceeded == true)
+                    WriteBackUpgradeVersion(upgradeVersions);
             }
             catch (Exception ex)
             {
@@ -523,6 +528,35 @@ public class SilentPollOrchestrator : IDisposable
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformType.Linux;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return PlatformType.MacOS;
         return PlatformType.Unknown;
+    }
+
+    /// <summary>
+    /// After upgrade packages have been applied in-place, writes the latest upgrade version
+    /// back to <c>generalupdate.manifest.json</c> so the next poll cycle starts from the
+    /// correct <c>UpgradeClientVersion</c>.
+    /// </summary>
+    /// <param name="upgradeVersions">
+    /// The upgrade version list that was just applied. The last element carries the
+    /// highest target version.
+    /// </param>
+    private void WriteBackUpgradeVersion(List<VersionInfo> upgradeVersions)
+    {
+        var latestVersion = upgradeVersions.LastOrDefault()?.Version;
+        if (string.IsNullOrEmpty(latestVersion)) return;
+
+        try
+        {
+            ManifestInfo.TryUpdateVersion(
+                _configInfo.InstallPath,
+                upgradeClientVersion: latestVersion);
+            GeneralTracer.Info(
+                $"SilentPollOrchestrator: UpgradeClientVersion updated to {latestVersion} in manifest.");
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn(
+                $"SilentPollOrchestrator: failed to write back UpgradeClientVersion: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -86,6 +86,14 @@ namespace GeneralUpdate.Core.Strategy
         public bool UseUpdatePath { get; set; }
 
         /// <summary>
+        /// After <see cref="ExecuteAsync"/> completes, indicates whether every package in the
+        /// current batch was applied without error. A per-package failure does not prevent the
+        /// loop from continuing, so callers must inspect this flag before treating the batch
+        /// as fully successful (e.g. before writing updated version numbers to the manifest).
+        /// </summary>
+        public bool AllPackagesSucceeded { get; private set; }
+
+        /// <summary>
         /// Starts the main application. Virtual method, overridden by subclasses to provide platform-specific application launch implementations.
         /// </summary>
         /// <remarks>
@@ -132,6 +140,7 @@ namespace GeneralUpdate.Core.Strategy
         {
             try
             {
+                AllPackagesSucceeded = true;
                 var status = ReportType.None;
                 var patchPath = StorageManager.GetTempDirectory(Patchs);
                 foreach (var version in _configinfo.UpdateVersions)
@@ -146,6 +155,7 @@ namespace GeneralUpdate.Core.Strategy
                     catch (Exception e)
                     {
                         status = ReportType.Failure;
+                        AllPackagesSucceeded = false;
                         HandleExecuteException(e);
                         TryRollback();
                     }
@@ -170,6 +180,7 @@ namespace GeneralUpdate.Core.Strategy
             }
             catch (Exception e)
             {
+                AllPackagesSucceeded = false;
                 HandleExecuteException(e);
             }
         }

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -544,6 +544,7 @@ public class ClientStrategy : IStrategy
         {
             case UpdateScenario.UpgradeOnly:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
+                WriteBackUpgradeVersion(upgradeVersions);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 GeneralTracer.Info("ClientStrategy: Upgrade-only update applied, client continues running.");
@@ -559,6 +560,7 @@ public class ClientStrategy : IStrategy
 
             case UpdateScenario.Both:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
+                WriteBackUpgradeVersion(upgradeVersions);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 SendProcessIpc(clientVersions);
@@ -763,6 +765,35 @@ public class ClientStrategy : IStrategy
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformType.Linux;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return PlatformType.MacOS;
         return PlatformType.Unknown;
+    }
+
+    /// <summary>
+    /// After upgrade packages have been applied in-place, writes the latest upgrade version
+    /// back to <c>generalupdate.manifest.json</c> so the next poll cycle starts from the
+    /// correct <c>UpgradeClientVersion</c>.
+    /// </summary>
+    /// <param name="upgradeVersions">
+    /// The upgrade version list that was just applied. The last element carries the
+    /// highest target version.
+    /// </param>
+    private static void WriteBackUpgradeVersion(List<VersionInfo> upgradeVersions)
+    {
+        var latestVersion = upgradeVersions.LastOrDefault()?.Version;
+        if (string.IsNullOrEmpty(latestVersion)) return;
+
+        try
+        {
+            ManifestInfo.TryUpdateVersion(
+                AppDomain.CurrentDomain.BaseDirectory,
+                upgradeClientVersion: latestVersion);
+            GeneralTracer.Info(
+                $"ClientStrategy: UpgradeClientVersion updated to {latestVersion} in manifest.");
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn(
+                $"ClientStrategy: failed to write back UpgradeClientVersion: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -544,7 +544,6 @@ public class ClientStrategy : IStrategy
         {
             case UpdateScenario.UpgradeOnly:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
-                WriteBackUpgradeVersion(upgradeVersions);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 GeneralTracer.Info("ClientStrategy: Upgrade-only update applied, client continues running.");
@@ -560,7 +559,6 @@ public class ClientStrategy : IStrategy
 
             case UpdateScenario.Both:
                 await ApplyUpgradePackagesAsync(upgradeVersions).ConfigureAwait(false);
-                WriteBackUpgradeVersion(upgradeVersions);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 SendProcessIpc(clientVersions);
@@ -593,6 +591,13 @@ public class ClientStrategy : IStrategy
         _configInfo!.UpdateVersions = upgradeVersions;
         _osStrategy!.Create(_configInfo);
         await _osStrategy.ExecuteAsync().ConfigureAwait(false);
+
+        // Only advance the manifest version when every package was applied
+        // successfully. AbstractStrategy catches per-package failures and
+        // continues the loop, so ExecuteAsync() completing is not a
+        // reliable success signal on its own.
+        if ((_osStrategy as AbstractStrategy)?.AllPackagesSucceeded == true)
+            WriteBackUpgradeVersion(upgradeVersions);
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
@@ -115,6 +115,10 @@ public class UpdateStrategy : IStrategy
                 GeneralTracer.Info("UpdateStrategy: applying " + _configInfo.UpdateVersions.Count +
                                    " MainApp update(s).");
                 await _osStrategy.ExecuteAsync();
+
+                // Write the new ClientVersion back to generalupdate.manifest.json so the
+                // next poll cycle starts from the correct version.
+                WriteBackClientVersion();
             }
             else
             {
@@ -256,6 +260,34 @@ public class UpdateStrategy : IStrategy
         catch (Exception ex)
         {
             GeneralTracer.Warn($"Report UpdateFailed failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// After the main-app update pipeline completes, writes the new <c>ClientVersion</c>
+    /// back to <c>generalupdate.manifest.json</c> in the client's install directory so the
+    /// next poll cycle starts from the correct version.
+    /// </summary>
+    private void WriteBackClientVersion()
+    {
+        // Use the latest version from the applied update list; fall back to LastVersion
+        // (which covers the single-package / full-update case).
+        var latestVersion = _configInfo?.UpdateVersions?.LastOrDefault()?.Version
+                            ?? _configInfo?.LastVersion;
+        if (string.IsNullOrEmpty(latestVersion)) return;
+
+        try
+        {
+            ManifestInfo.TryUpdateVersion(
+                _configInfo!.InstallPath,
+                clientVersion: latestVersion);
+            GeneralTracer.Info(
+                $"UpdateStrategy: ClientVersion updated to {latestVersion} in manifest.");
+        }
+        catch (Exception ex)
+        {
+            GeneralTracer.Warn(
+                $"UpdateStrategy: failed to write back ClientVersion: {ex.Message}");
         }
     }
 

--- a/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
@@ -116,9 +116,12 @@ public class UpdateStrategy : IStrategy
                                    " MainApp update(s).");
                 await _osStrategy.ExecuteAsync();
 
-                // Write the new ClientVersion back to generalupdate.manifest.json so the
-                // next poll cycle starts from the correct version.
-                WriteBackClientVersion();
+                // Only advance the manifest version when every package was applied
+                // successfully. AbstractStrategy catches per-package failures and
+                // continues the loop, so ExecuteAsync() completing is not a
+                // reliable success signal on its own.
+                if ((_osStrategy as AbstractStrategy)?.AllPackagesSucceeded == true)
+                    WriteBackClientVersion();
             }
             else
             {


### PR DESCRIPTION
## Summary

Closes #467

After a successful update, write the new version number back to `generalupdate.manifest.json` so the next poll cycle starts from the correct current version.

## Changes

### 1. [ManifestInfo.cs](src/c#/GeneralUpdate.Core/Configuration/ManifestInfo.cs)

- **`Save(string? path = null)`** — serializes the manifest back to JSON file (defaults to `BaseDirectory/generalupdate.manifest.json`)
- **`TryUpdateVersion(string baseDirectory, string? clientVersion, string? upgradeClientVersion)`** — loads manifest from a directory, selectively updates version fields, and saves. Silently no-ops when the file doesn't exist.

### 2. [ClientStrategy.cs](src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs)

- New `WriteBackUpgradeVersion()` helper called after `ApplyUpgradePackagesAsync` succeeds in both `UpgradeOnly` and `Both` scenarios
- Writes the latest upgrade version to `upgradeClientVersion` in manifest

### 3. [UpdateStrategy.cs](src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs)

- New `WriteBackClientVersion()` helper called after the main-app update pipeline completes
- Writes the latest client version to `clientVersion` in manifest, using `_configInfo.InstallPath` (the client's install directory, received via IPC)

## Update Scenario Coverage

| Scenario | Who updates whom | Field written | Strategy |
|----------|-----------------|--------------|----------|
| **UpgradeOnly** | Client → Updater (in-place) | `upgradeClientVersion` | ClientStrategy |
| **MainOnly** | Updater → Client | `clientVersion` | UpdateStrategy |
| **Both** | Client → Updater, then Updater → Client | Both | Both |

## Error Handling

All write-back calls are wrapped in try-catch with warning-level logging — a failed manifest write never blocks the update flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)