### PR TITLE
fix: 重构 SilentPollOrchestrator，委托 ClientStrategy 复用标准更新流程

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -135,76 +135,10 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
             if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
 
-            // Resolve hooks from extensions
-            var hooks = ResolveExtension<Hooks.IUpdateHooks>() ?? new Hooks.NoOpUpdateHooks();
-            roleStrategy.Hooks = hooks;
+            ConfigureStrategy(roleStrategy);
 
-            // Resolve reporter from extensions; default to HttpUpdateReporter.
-            // When ReportUrl is not configured, HttpUpdateReporter is effectively a no-op.
-            var reporter = ResolveExtension<Download.Reporting.IUpdateReporter>() ??
-                           new Download.Reporting.HttpUpdateReporter();
-
-            if (reporter is Download.Reporting.HttpUpdateReporter httpReporter)
-                httpReporter.ReportUrl = _configInfo.ReportUrl;
-
-            roleStrategy.Reporter = reporter;
-
-            // ── Download components ──
-            var downloadOrchestrator = ResolveExtension<Download.Abstractions.IDownloadOrchestrator>();
-            var downloadPolicy = ResolveExtension<Download.Abstractions.IDownloadPolicy>();
-            var downloadExecutor = ResolveExtension<Download.Abstractions.IDownloadExecutor>();
-
-            // Build download pipeline factory from registered extension type
-            Func<string?, Download.Abstractions.IDownloadPipeline>? downloadPipelineFactory = null;
-            var pipelineType = ResolveExtensionType<Download.Abstractions.IDownloadPipeline>();
-            if (pipelineType != null)
-            {
-                var stringCtor = pipelineType.GetConstructor([typeof(string)]);
-                if (stringCtor != null)
-                    downloadPipelineFactory = hash => (Download.Abstractions.IDownloadPipeline)stringCtor.Invoke([hash]);
-                else
-                    downloadPipelineFactory = _ => (Download.Abstractions.IDownloadPipeline)Activator.CreateInstance(pipelineType);
-            }
-
-            var diffPipeline = BuildDiffPipeline();
-
-            switch (roleStrategy)
-            {
-                case ClientStrategy cs:
-                    cs.DownloadSource = ResolveExtension<Download.Abstractions.IDownloadSource>();
-
-                    if (_updatePrecheck != null)
-                        cs.UseUpdatePrecheck(_updatePrecheck);
-
-                    await CallSmallBowlHomeAsync(_configInfo.Bowl).ConfigureAwait(false);
-
-                    cs.SetDiffPipeline(diffPipeline);
-                    if (downloadOrchestrator != null) cs.SetOrchestrator(downloadOrchestrator);
-                    if (downloadPolicy != null) cs.SetDownloadPolicy(downloadPolicy);
-                    if (downloadExecutor != null) cs.SetDownloadExecutor(downloadExecutor);
-                    if (downloadPipelineFactory != null) cs.SetDownloadPipelineFactory(downloadPipelineFactory);
-                    break;
-
-                case UpdateStrategy us:
-                    us.SetDiffPipeline(diffPipeline);
-                    us.SetReportType(_configInfo.ReportType);
-                    break;
-            }
-
-            // Inject custom OS-level strategy if registered via Strategy<T>()
-            var customOsStrategy = ResolveExtension<IStrategy>();
-            if (customOsStrategy != null)
-            {
-                switch (roleStrategy)
-                {
-                    case ClientStrategy cs:
-                        cs.SetOsStrategy(customOsStrategy);
-                        break;
-                    case UpdateStrategy us:
-                        us.SetOsStrategy(customOsStrategy);
-                        break;
-                }
-            }
+            if (roleStrategy is ClientStrategy cs)
+                await CallSmallBowlHomeAsync(_configInfo.Bowl).ConfigureAwait(false);
 
             roleStrategy.Create(_configInfo);
 
@@ -420,34 +354,103 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
     /// <summary>
     /// Silent update mode — starts a background poll loop and returns immediately.
-    /// The orchestrator checks for updates periodically and prepares them.
-    /// When the host process exits, the prepared update is applied.
+    /// Uses the same fully-configured <see cref="ClientStrategy"/> as the standard flow;
+    /// the orchestrator only adds polling and deferred-upgrade-on-exit on top.
     /// </summary>
-    private async Task LaunchSilentAsync()
+    private async Task<GeneralUpdateBootstrap> LaunchSilentAsync()
     {
         GeneralTracer.Info("GeneralUpdateBootstrap: starting silent update mode.");
-        var pollMinutes = GetOption(UpdateOptions.SilentPollIntervalMinutes);
-        var silentOptions = new Silent.SilentOptions
-        {
-            PollInterval = TimeSpan.FromMinutes(pollMinutes)
-        };
-        var hooks = ResolveExtension<Hooks.IUpdateHooks>() ?? new Hooks.NoOpUpdateHooks();
-        var reporter = ResolveExtension<Download.Reporting.IUpdateReporter>() ??
-                       new Download.Reporting.HttpUpdateReporter();
-        if (reporter is Download.Reporting.HttpUpdateReporter httpRep)
-            httpRep.ReportUrl = _configInfo.ReportUrl;
+
+        ApplyRuntimeOptions();
+
+        // Network-level extensions (global, applied before any HTTP call)
         var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
         if (sslPolicy != null) Network.VersionService.SetSslValidationPolicy(sslPolicy);
         var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
         if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
 
-        var orchestrator = new Silent.SilentPollOrchestrator(_configInfo, silentOptions)
-            .WithHooks(hooks)
-            .WithReporter(reporter)
-            .WithOsStrategy(ResolveExtension<IStrategy>());
+        var strategy = new ClientStrategy();
+        ConfigureStrategy(strategy);
 
+        strategy.LaunchAfterPrepare = false;
+
+        var pollMinutes = GetOption(UpdateOptions.SilentPollIntervalMinutes);
+        var launchClient = GetOption(UpdateOptions.LaunchClientAfterUpdate);
+        var silentOptions = new Silent.SilentOptions
+        {
+            PollInterval = TimeSpan.FromMinutes(pollMinutes),
+            LaunchClientAfterUpdate = launchClient
+        };
+
+        var orchestrator = new Silent.SilentPollOrchestrator(strategy, _configInfo, silentOptions);
         await orchestrator.StartAsync().ConfigureAwait(false);
         GeneralTracer.Info("GeneralUpdateBootstrap: silent update mode started, returning to caller.");
+
+        return this;
+    }
+
+    /// <summary>
+    /// Applies all registered extensions (hooks, reporter, download components,
+    /// DiffPipeline, custom OS strategy) to a role strategy. Shared by the standard
+    /// and silent boot paths so they are always configured identically.
+    /// </summary>
+    private void ConfigureStrategy(IStrategy roleStrategy)
+    {
+        var hooks = ResolveExtension<Hooks.IUpdateHooks>() ?? new Hooks.NoOpUpdateHooks();
+        roleStrategy.Hooks = hooks;
+
+        var reporter = ResolveExtension<Download.Reporting.IUpdateReporter>() ??
+                       new Download.Reporting.HttpUpdateReporter();
+        if (reporter is Download.Reporting.HttpUpdateReporter httpReporter)
+            httpReporter.ReportUrl = _configInfo.ReportUrl;
+        roleStrategy.Reporter = reporter;
+
+        var diffPipeline = BuildDiffPipeline();
+
+        // Download components
+        var downloadOrchestrator = ResolveExtension<Download.Abstractions.IDownloadOrchestrator>();
+        var downloadPolicy = ResolveExtension<Download.Abstractions.IDownloadPolicy>();
+        var downloadExecutor = ResolveExtension<Download.Abstractions.IDownloadExecutor>();
+
+        Func<string?, Download.Abstractions.IDownloadPipeline>? downloadPipelineFactory = null;
+        var pipelineType = ResolveExtensionType<Download.Abstractions.IDownloadPipeline>();
+        if (pipelineType != null)
+        {
+            var stringCtor = pipelineType.GetConstructor([typeof(string)]);
+            if (stringCtor != null)
+                downloadPipelineFactory = hash => (Download.Abstractions.IDownloadPipeline)stringCtor.Invoke([hash]);
+            else
+                downloadPipelineFactory = _ => (Download.Abstractions.IDownloadPipeline)Activator.CreateInstance(pipelineType);
+        }
+
+        switch (roleStrategy)
+        {
+            case ClientStrategy cs:
+                cs.DownloadSource = ResolveExtension<Download.Abstractions.IDownloadSource>();
+                cs.SetDiffPipeline(diffPipeline);
+                if (downloadOrchestrator != null) cs.SetOrchestrator(downloadOrchestrator);
+                if (downloadPolicy != null) cs.SetDownloadPolicy(downloadPolicy);
+                if (downloadExecutor != null) cs.SetDownloadExecutor(downloadExecutor);
+                if (downloadPipelineFactory != null) cs.SetDownloadPipelineFactory(downloadPipelineFactory);
+                if (_updatePrecheck != null) cs.UseUpdatePrecheck(_updatePrecheck);
+                break;
+
+            case UpdateStrategy us:
+                us.SetDiffPipeline(diffPipeline);
+                us.SetReportType(_configInfo.ReportType);
+                break;
+        }
+
+        // Custom OS-level strategy (registered via Strategy<T>())
+        var customOsStrategy = ResolveExtension<IStrategy>();
+        if (customOsStrategy != null)
+        {
+            switch (roleStrategy)
+            {
+                case ClientStrategy cs: cs.SetOsStrategy(customOsStrategy); break;
+                case UpdateStrategy us: us.SetOsStrategy(customOsStrategy); break;
+            }
+        }
     }
 
     private DiffPipeline BuildDiffPipeline()

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateOptions.cs
@@ -113,6 +113,12 @@ namespace GeneralUpdate.Core.Configuration
         /// </summary>
         public static UpdateOption<int> SilentPollIntervalMinutes { get; } = UpdateOption.ValueOf<int>("SILENTPOLLINTERVALMINUTES", 60);
 
+        /// <summary>
+        ///     Whether to automatically launch the client application after the upgrade process completes in silent mode.
+        ///     Defaults to <c>true</c>.
+        /// </summary>
+        public static UpdateOption<bool> LaunchClientAfterUpdate { get; } = UpdateOption.ValueOf<bool>("LAUNCHCLIENTAFTERUPDATE", true);
+
         // ════════════════════════════════════════
         //  Concurrency and Resume Options
         // ════════════════════════════════════════

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
@@ -142,7 +140,9 @@ public class SilentPollOrchestrator : IDisposable
     /// </summary>
     /// <remarks>
     /// The encrypted IPC file was already written by <see cref="ClientStrategy.SendProcessIpc"/>
-    /// during the last successful poll cycle. This handler only starts the upgrade executable.
+    /// during the last successful poll cycle. This handler delegates the actual process
+    /// launch to <see cref="ClientStrategy.LaunchUpgradeProcessSync"/>, which reuses the
+    /// configured OS strategy for path resolution and runs the pre-launch lifecycle hook.
     /// </remarks>
     private void OnProcessExit(object? sender, EventArgs e)
     {
@@ -159,21 +159,8 @@ public class SilentPollOrchestrator : IDisposable
                 return;
             }
 
-            var updaterDir = !string.IsNullOrWhiteSpace(_configInfo.UpdatePath)
-                ? (Path.IsPathRooted(_configInfo.UpdatePath)
-                    ? _configInfo.UpdatePath
-                    : Path.Combine(_configInfo.InstallPath, _configInfo.UpdatePath))
-                : _configInfo.InstallPath;
-            var updaterPath = Path.Combine(updaterDir, _configInfo.UpdateAppName);
-
-            if (!File.Exists(updaterPath))
-            {
-                GeneralTracer.Warn($"SilentPollOrchestrator: updater not found at {updaterPath}, cannot launch.");
-                return;
-            }
-
-            Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = updaterPath });
-            GeneralTracer.Info($"SilentPollOrchestrator: launched updater {updaterPath}");
+            _strategy.LaunchUpgradeProcessSync();
+            GeneralTracer.Info("SilentPollOrchestrator: upgrade process launched via ClientStrategy.");
         }
         catch (Exception ex)
         {

--- a/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Silent/SilentPollOrchestrator.cs
@@ -1,127 +1,83 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
-using GeneralUpdate.Core.Download;
-using GeneralUpdate.Core.Download.Reporting;
-using GeneralUpdate.Core.Download.Sources;
-using GeneralUpdate.Core.FileSystem;
-using GeneralUpdate.Core.Hooks;
-using GeneralUpdate.Core.JsonContext;
-using GeneralUpdate.Core.Ipc;
 using GeneralUpdate.Core.Strategy;
 
 namespace GeneralUpdate.Core.Silent;
 
 /// <summary>
-/// Silent update polling orchestrator -- periodically checks for updates,
-/// silently downloads update packages in the background, and defers application
-/// update execution until the process exits.
+/// Silent update polling orchestrator — periodically invokes a fully-configured
+/// <see cref="ClientStrategy"/> on a background interval, and defers the upgrade-process
+/// launch to <see cref="AppDomain.ProcessExit"/> so the running application is undisturbed.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Follows the same AppType dispatch pattern as <see cref="ClientStrategy"/>:
+/// This orchestrator is a thin scheduling layer. It does NOT re-implement any update logic.
+/// All update work (version check, download, backup, Upgrade-package application,
+/// Client-package IPC staging) is performed by the injected <see cref="ClientStrategy"/>.
 /// </para>
-/// <list type="bullet">
-///   <item><description><b>Upgrade (AppType=2)</b>: Update packages are applied in-place
-///   during the polling cycle. They operate on <c>UpdatePath</c> rather than
-///   the running application's <c>InstallPath</c>.</description></item>
-///   <item><description><b>Client (AppType=1)</b>: Update packages are deferred -- stored in
-///   <c>ProcessInfo</c> and handed off to the Upgrade process via IPC when the
-///   current process exits.</description></item>
-/// </list>
 /// <para>
 /// Core workflow:
+/// </para>
 /// <list type="number">
-///   <item><description>Starts a background polling loop that checks the server for new versions
-///   at intervals specified by <see cref="SilentOptions.PollInterval"/>.</description></item>
-///   <item><description>When a new version is found, silently downloads all update packages
-///   in the background.</description></item>
-///   <item><description>Upgrade packages are applied immediately; Client packages are staged
-///   into <c>ProcessInfo</c>.</description></item>
-///   <item><description>Listens to the <see cref="AppDomain.ProcessExit"/> event and launches the
-///   upgrade program when the process exits.</description></item>
+///   <item><description>Registers the <see cref="AppDomain.CurrentDomain.ProcessExit"/> event handler.</description></item>
+///   <item><description>Starts a background polling loop at the configured interval.</description></item>
+///   <item><description>Each cycle calls <c>ClientStrategy.ExecuteAsync()</c> to perform a full check-and-prepare.</description></item>
+///   <item><description>When the strategy reports <c>HasPreparedClientUpdate == true</c>, the loop exits.</description></item>
+///   <item><description>On process exit, the upgrade process is launched — IPC was already sent by <c>ClientStrategy.SendProcessIpc()</c>.</description></item>
 /// </list>
+/// <para>
+/// The difference from the standard (immediate) flow is purely timing:
+/// <br/>
+/// • Standard: download → IPC → launch upgrade → exit<br/>
+/// • Silent: download → IPC → (user keeps working) → process exit → launch upgrade → exit
 /// </para>
 /// </remarks>
 public class SilentPollOrchestrator : IDisposable
 {
+    private readonly ClientStrategy _strategy;
     private readonly GlobalConfigInfo _configInfo;
     private readonly SilentOptions _options;
     private CancellationTokenSource? _cts;
     private Task? _pollingTask;
     private int _prepared;
     private int _updaterStarted;
-    private IUpdateHooks? _hooks;
-    private IUpdateReporter? _reporter;
-    private IStrategy? _customOsStrategy;
-    private Configuration.ProcessInfo? _preparedProcessInfo;
-    private List<VersionInfo> _clientVersions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SilentPollOrchestrator"/> class.
     /// </summary>
-    /// <param name="configInfo">The global configuration information, including update URL,
-    /// version numbers, product information, etc.</param>
-    /// <param name="options">The silent update options, including polling interval and
-    /// client launch behavior.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configInfo"/>
-    /// or <paramref name="options"/> is <c>null</c>.</exception>
-    public SilentPollOrchestrator(GlobalConfigInfo configInfo, SilentOptions options)
+    /// <param name="strategy">
+    /// A fully-configured <see cref="ClientStrategy"/>. Callers should set
+    /// <c>strategy.LaunchAfterPrepare = false</c> before passing it in so that
+    /// the upgrade process is NOT started at the end of each poll cycle.
+    /// </param>
+    /// <param name="configInfo">The global configuration.</param>
+    /// <param name="options">Polling interval and restart behaviour.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any parameter is <c>null</c>.</exception>
+    public SilentPollOrchestrator(ClientStrategy strategy, GlobalConfigInfo configInfo, SilentOptions options)
     {
+        _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
         _configInfo = configInfo ?? throw new ArgumentNullException(nameof(configInfo));
         _options = options ?? throw new ArgumentNullException(nameof(options));
     }
 
     /// <summary>
-    /// Sets the update lifecycle hooks (fluent method).
+    /// Starts the silent polling orchestrator. Registers the <see cref="AppDomain.ProcessExit"/>
+    /// handler and launches the background polling loop. Returns immediately.
     /// </summary>
-    /// <param name="hooks">An <see cref="IUpdateHooks"/> implementation for injecting
-    /// custom logic at various update stages.</param>
-    /// <returns>The current <see cref="SilentPollOrchestrator"/> instance, enabling fluent chaining.</returns>
-    public SilentPollOrchestrator WithHooks(IUpdateHooks? hooks) { _hooks = hooks; return this; }
-
-    /// <summary>
-    /// Sets the update progress reporter (fluent method).
-    /// </summary>
-    /// <param name="reporter">An <see cref="IUpdateReporter"/> implementation for reporting
-    /// update status.</param>
-    /// <returns>The current <see cref="SilentPollOrchestrator"/> instance, enabling fluent chaining.</returns>
-    public SilentPollOrchestrator WithReporter(IUpdateReporter? reporter) { _reporter = reporter; return this; }
-
-    /// <summary>
-    /// Sets a custom operating system strategy (fluent method), overriding the default
-    /// platform-specific update strategy (Windows/Linux/macOS).
-    /// </summary>
-    /// <param name="strategy">A custom <see cref="IStrategy"/> implementation.</param>
-    /// <returns>The current <see cref="SilentPollOrchestrator"/> instance, enabling fluent chaining.</returns>
-    public SilentPollOrchestrator WithOsStrategy(IStrategy? strategy) { _customOsStrategy = strategy; return this; }
-
-    /// <summary>
-    /// Starts the silent polling orchestrator, beginning background update checks.
-    /// </summary>
-    /// <returns>A task representing the start operation. Note: this task completes as soon as
-    /// the polling loop is launched, not when the polling loop ends.</returns>
-    /// <remarks>
-    /// <para>
-    /// Start flow:
-    /// <list type="number">
-    ///   <item><description>Registers the <see cref="AppDomain.CurrentDomain.ProcessExit"/> event handler.</description></item>
-    ///   <item><description>Creates a <see cref="CancellationTokenSource"/>.</description></item>
-    ///   <item><description>Launches the polling loop <see cref="PollLoopAsync"/> in a background task.</description></item>
-    ///   <item><description>Attaches an exception handler to the polling task to log unhandled exceptions.</description></item>
-    /// </list>
-    /// </para>
-    /// </remarks>
+    /// <returns>A task representing the start operation.</returns>
     public Task StartAsync()
     {
         GeneralTracer.Info($"SilentPollOrchestrator: starting. PollInterval={_options.PollInterval.TotalMinutes}min");
+
+        _strategy.Create(_configInfo);
+
+        // Must be set before the first poll cycle so that when ClientStrategy calls
+        // SendProcessIpc(), the correct value flows into ProcessInfo / IPC.
+        _configInfo.LaunchClientAfterUpdate = _options.LaunchClientAfterUpdate;
 
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
         _cts = new CancellationTokenSource();
@@ -137,17 +93,9 @@ public class SilentPollOrchestrator : IDisposable
     }
 
     /// <summary>
-    /// Stops the silent polling orchestrator, cancelling in-progress polling and download operations.
+    /// Stops the polling orchestrator. Cancels the background loop and unregisters
+    /// the <see cref="AppDomain.ProcessExit"/> handler.
     /// </summary>
-    /// <remarks>
-    /// Calling this method will:
-    /// <list type="bullet">
-    ///   <item><description>Cancel the background polling loop.</description></item>
-    ///   <item><description>Unregister the <see cref="AppDomain.CurrentDomain.ProcessExit"/> event handler.</description></item>
-    /// </list>
-    /// Note: This method does not cancel downloads that are already in progress,
-    /// but it prevents new polling cycles from starting.
-    /// </remarks>
     public void Stop()
     {
         _cts?.Cancel();
@@ -155,24 +103,11 @@ public class SilentPollOrchestrator : IDisposable
     }
 
     /// <summary>
-    /// Background polling loop that periodically checks for updates and performs
-    /// update preparation at the configured interval.
+    /// Background polling loop. Calls <see cref="ClientStrategy.ExecuteAsync"/> on each cycle.
+    /// Exits when client packages have been prepared (<c>HasPreparedClientUpdate == true</c>)
+    /// or cancellation is requested.
     /// </summary>
-    /// <param name="token">A cancellation token for stopping the polling loop.</param>
-    /// <returns>A task representing the polling loop. Ends when preparation is complete
-    /// or cancellation is requested.</returns>
-    /// <remarks>
-    /// <para>
-    /// Loop logic:
-    /// <list type="number">
-    ///   <item><description>Calls <see cref="PrepareUpdateIfNeededAsync"/> to check for and prepare updates.</description></item>
-    ///   <item><description>If preparation is complete (<c>_prepared == 1</c>), exits the loop.</description></item>
-    ///   <item><description>Otherwise, waits for <see cref="SilentOptions.PollInterval"/> before checking again.</description></item>
-    /// </list>
-    /// Individual exceptions within the loop do not terminate the entire loop;
-    /// errors are logged and polling continues on the next cycle.
-    /// </para>
-    /// </remarks>
+    /// <param name="token">A cancellation token for stopping the loop.</param>
     private async Task PollLoopAsync(CancellationToken token)
     {
         GeneralTracer.Info("SilentPollOrchestrator: polling loop started.");
@@ -180,7 +115,14 @@ public class SilentPollOrchestrator : IDisposable
         {
             try
             {
-                await PrepareUpdateIfNeededAsync(token).ConfigureAwait(false);
+                GeneralTracer.Info("SilentPollOrchestrator: running update check cycle.");
+                await _strategy.ExecuteAsync().ConfigureAwait(false);
+
+                if (_strategy.HasPreparedClientUpdate)
+                {
+                    Interlocked.Exchange(ref _prepared, 1);
+                    GeneralTracer.Info("SilentPollOrchestrator: client update prepared, waiting for process exit.");
+                }
             }
             catch (Exception ex)
             {
@@ -195,244 +137,28 @@ public class SilentPollOrchestrator : IDisposable
     }
 
     /// <summary>
-    /// Checks for available updates and, if found, performs the full update preparation
-    /// workflow including download, backup, Upgrade package application, and ProcessInfo staging.
+    /// Process exit event handler. When client packages were prepared, launches
+    /// the upgrade process so it can apply them.
     /// </summary>
-    /// <param name="token">A cancellation token.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>
-    /// <para>
-    /// This is the core method of the silent update flow, executing the complete workflow:
-    /// </para>
-    /// <list type="number">
-    ///   <item><description>Queries the server for available updates via <see cref="HttpDownloadSource"/>.</description></item>
-    ///   <item><description>Builds a download plan using <see cref="DownloadPlanBuilder"/>.</description></item>
-    ///   <item><description>Checks version failure records to skip known-failed versions.</description></item>
-    ///   <item><description>Calls hooks' <c>OnBeforeUpdateAsync</c> to allow external cancellation of the update.</description></item>
-    ///   <item><description>Initializes the blacklist, creates a temp directory, and performs backup.</description></item>
-    ///   <item><description>Downloads all update packages using
-    ///   <see cref="Download.Orchestrators.DefaultDownloadOrchestrator"/>.</description></item>
-    ///   <item><description>Dispatches by AppType: Upgrade packages are executed immediately via the
-    ///   platform strategy; Client packages are staged in ProcessInfo.</description></item>
-    ///   <item><description>Calls hooks' <c>OnAfterUpdateAsync</c> to notify that the update is complete.</description></item>
-    /// </list>
-    /// </remarks>
-    private async Task PrepareUpdateIfNeededAsync(CancellationToken token)
-    {
-        GeneralTracer.Info($"SilentPollOrchestrator: checking for updates. Url={_configInfo.UpdateUrl}");
-
-        var downloadSource = new HttpDownloadSource(
-            _configInfo.UpdateUrl,
-            _configInfo.ClientVersion,
-            _configInfo.UpgradeClientVersion,
-            _configInfo.AppSecretKey,
-            GetPlatform(),
-            _configInfo.ProductId,
-            _configInfo.Scheme,
-            _configInfo.Token);
-
-        var sourceResult = await downloadSource.ListAsync(token).ConfigureAwait(false);
-        var plan = DownloadPlanBuilder.Build(sourceResult.Assets, _configInfo.ClientVersion);
-
-        if (!plan.HasAssets)
-        {
-            GeneralTracer.Info("SilentPollOrchestrator: no update available.");
-            return;
-        }
-
-        var latestVersion = plan.Assets.LastOrDefault()?.Version;
-        if (CheckFail(latestVersion))
-        {
-            GeneralTracer.Warn($"SilentPollOrchestrator: version {latestVersion} is a known-failed upgrade, skipping.");
-            return;
-        }
-
-        // Hooks: allow cancellation before starting update
-        var updateCtx = new UpdateContext(
-            _configInfo.MainAppName ?? _configInfo.UpdateAppName,
-            _configInfo.InstallPath,
-            _configInfo.ClientVersion,
-            latestVersion,
-            AppType.Client);
-
-        if (_hooks != null)
-        {
-            try
-            {
-                if (!await _hooks.OnBeforeUpdateAsync(updateCtx).ConfigureAwait(false))
-                {
-                    GeneralTracer.Info("SilentPollOrchestrator: update cancelled by hooks.");
-                    return;
-                }
-            }
-            catch (Exception ex) { GeneralTracer.Warn($"Hook OnBeforeUpdateAsync failed: {ex.Message}"); }
-        }
-
-        InitBlackList();
-
-        _configInfo.LastVersion = latestVersion;
-        _configInfo.TempPath = StorageManager.GetTempDirectory("silent_temp");
-        _configInfo.BackupDirectory = Path.Combine(_configInfo.InstallPath,
-            $"{StorageManager.DirectoryName}{_configInfo.ClientVersion}");
-
-        // Backup
-        if (_configInfo.BackupEnabled != false)
-        {
-            StorageManager.Backup(_configInfo.InstallPath, _configInfo.BackupDirectory,
-                _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
-        }
-
-        // Reporter: update started
-        if (_reporter != null)
-        {
-            try { await _reporter.ReportAsync(new UpdateReport(0, (int)UpdateStatus.Updating, 1), token).ConfigureAwait(false); }
-            catch (Exception ex) { GeneralTracer.Warn($"Reporter UpdateStarted failed: {ex.Message}"); }
-        }
-
-        // Download all packages in background
-        GeneralTracer.Info($"SilentPollOrchestrator: downloading {plan.Assets.Count} asset(s).");
-        var httpClient = GeneralUpdate.Core.Network.HttpClientProvider.Shared;
-        try
-        {
-            var orchestrator = new Download.Orchestrators.DefaultDownloadOrchestrator(httpClient);
-            var report = await orchestrator.ExecuteAsync(plan, _configInfo.TempPath, token: token).ConfigureAwait(false);
-            GeneralTracer.Info($"SilentPollOrchestrator: download complete. Success={report.SuccessCount}, Failed={report.FailedCount}");
-
-            if (report.FailedCount > 0)
-            {
-                GeneralTracer.Error($"SilentPollOrchestrator: download had {report.FailedCount} failures, aborting update.");
-                return;
-            }
-
-            if (_hooks != null)
-            {
-                try
-                {
-                    var downloadCtx = new DownloadContext(
-                        plan.Assets.FirstOrDefault()?.Name ?? "update", latestVersion ?? "",
-                        report.TotalBytes, report.TotalDuration,
-                        _configInfo.TempPath, report.FailedCount == 0);
-                    await _hooks.OnDownloadCompletedAsync(downloadCtx).ConfigureAwait(false);
-                }
-                catch (Exception ex) { GeneralTracer.Warn($"Hook OnDownloadCompletedAsync failed: {ex.Message}"); }
-            }
-            if (_reporter != null)
-            {
-                try { await _reporter.ReportAsync(new UpdateReport(0, (int)UpdateStatus.Updating, 1), token).ConfigureAwait(false); }
-                catch (Exception ex) { GeneralTracer.Warn($"Reporter DownloadCompleted failed: {ex.Message}"); }
-            }
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Error("SilentPollOrchestrator: download failed.", ex);
-            TryReportError(updateCtx, ex);
-            return;
-        }
-
-        // Split packages by AppType -- mirrors ClientStrategy
-        var downloadVersions = plan.Assets.Select(a => new VersionInfo
-        {
-            Name = a.Name,
-            Hash = a.SHA256,
-            Url = a.Url,
-            Version = a.Version,
-            Format = _configInfo.Format.ToExtension(),
-            AppType = a.AppType ?? (int)AppType.Client
-        }).ToList();
-
-        var upgradeVersions = downloadVersions.Where(v => v.AppType == (int)AppType.Upgrade).ToList();
-        _clientVersions = downloadVersions.Where(v => v.AppType == (int)AppType.Client).ToList();
-        GeneralTracer.Info($"SilentPollOrchestrator: Upgrade packages={upgradeVersions.Count}, Client packages={_clientVersions.Count}");
-
-        // Apply Upgrade packages in place -- safe because they target UpdatePath
-        if (upgradeVersions.Count > 0)
-        {
-            GeneralTracer.Info("SilentPollOrchestrator: applying Upgrade packages.");
-            try
-            {
-                _configInfo.UpdateVersions = upgradeVersions;
-                var strategy = CreateStrategy();
-                strategy.Create(_configInfo);
-                await strategy.ExecuteAsync().ConfigureAwait(false);
-                GeneralTracer.Info("SilentPollOrchestrator: Upgrade packages applied.");
-
-                // Only advance the manifest version when every package was applied
-                // successfully — the same gating used by ClientStrategy.
-                if ((strategy as AbstractStrategy)?.AllPackagesSucceeded == true)
-                    WriteBackUpgradeVersion(upgradeVersions);
-            }
-            catch (Exception ex)
-            {
-                GeneralTracer.Error("SilentPollOrchestrator: Upgrade package application failed.", ex);
-                TryReportError(updateCtx, ex);
-                return;
-            }
-        }
-
-        // Build ProcessInfo with Client packages for IPC delivery on process exit
-        if (_clientVersions.Count > 0)
-        {
-            _configInfo.LaunchClientAfterUpdate = _options.LaunchClientAfterUpdate;
-            _preparedProcessInfo = ConfigurationMapper.MapToProcessInfo(
-                _configInfo, _clientVersions,
-                _configInfo.BlackFormats ?? BlackListDefaults.DefaultBlackFormats,
-                _configInfo.BlackFiles ?? BlackListDefaults.DefaultBlackFiles,
-                _configInfo.SkipDirectorys ?? BlackListDefaults.DefaultSkipDirectories);
-            _configInfo.ProcessInfo = JsonSerializer.Serialize(_preparedProcessInfo, ProcessInfoJsonContext.Default.ProcessInfo);
-
-            Interlocked.Exchange(ref _prepared, 1);
-            GeneralTracer.Info("SilentPollOrchestrator: update prepared, waiting for process exit.");
-        }
-        else if (upgradeVersions.Count > 0)
-        {
-            // Upgrade-only: packages already applied, no handoff needed
-            Interlocked.Exchange(ref _prepared, 1);
-            GeneralTracer.Info("SilentPollOrchestrator: upgrade-only update applied, no client handoff needed.");
-        }
-
-        if (_hooks != null)
-        {
-            try { await _hooks.OnAfterUpdateAsync(updateCtx).ConfigureAwait(false); }
-            catch (Exception ex) { GeneralTracer.Warn($"Hook OnAfterUpdateAsync failed: {ex.Message}"); }
-        }
-        if (_reporter != null)
-        {
-            try { await _reporter.ReportAsync(new UpdateReport(0, (int)UpdateStatus.Success, 1), token).ConfigureAwait(false); }
-            catch (Exception ex) { GeneralTracer.Warn($"Reporter UpdateApplied failed: {ex.Message}"); }
-        }
-    }
-
-    /// <summary>
-    /// Process exit event handler -- when the process is about to exit, sends the prepared
-    /// Client package information to the upgrade program via IPC and launches the upgrade.
-    /// </summary>
-    /// <param name="sender">The event sender.</param>
-    /// <param name="e">The event arguments.</param>
-    /// <remarks>
-    /// <para>
-    /// This method is invoked when the <see cref="AppDomain.CurrentDomain.ProcessExit"/>
-    /// event fires. It only executes when an update has been prepared (<c>_prepared == 1</c>)
-    /// and the upgrade program has not yet been started.
-    /// </para>
-    /// <para>
-    /// Execution flow:
-    /// <list type="number">
-    ///   <item><description>Uses <c>Interlocked.Exchange</c> to ensure the upgrade program is only
-    ///   started once.</description></item>
-    ///   <item><description>Resolves the upgrade program path (prefers UpdatePath, falls back to InstallPath).</description></item>
-    ///   <item><description>If Client packages exist, sends the encrypted ProcessInfo via
-    ///   <see cref="EncryptedFileProcessInfoProvider"/>.</description></item>
-    ///   <item><description>Starts the upgrade process (uses ShellExecute for privilege elevation).</description></item>
-    /// </list>
-    /// </para>
+    /// The encrypted IPC file was already written by <see cref="ClientStrategy.SendProcessIpc"/>
+    /// during the last successful poll cycle. This handler only starts the upgrade executable.
     /// </remarks>
     private void OnProcessExit(object? sender, EventArgs e)
     {
-        if (Volatile.Read(ref _prepared) != 1 || Interlocked.Exchange(ref _updaterStarted, 1) == 1) return;
+        if (Volatile.Read(ref _prepared) != 1 || Interlocked.Exchange(ref _updaterStarted, 1) == 1)
+            return;
 
         try
         {
-            // Resolve updater location -- prefers UpdatePath, falls back to InstallPath
+            // Only launch the upgrade process if there are client packages staged.
+            // Upgrade-only updates are already applied in-place; no further action needed.
+            if (!_strategy.HasPreparedClientUpdate)
+            {
+                GeneralTracer.Info("SilentPollOrchestrator: no client packages staged, skipping upgrade launch.");
+                return;
+            }
+
             var updaterDir = !string.IsNullOrWhiteSpace(_configInfo.UpdatePath)
                 ? (Path.IsPathRooted(_configInfo.UpdatePath)
                     ? _configInfo.UpdatePath
@@ -446,13 +172,6 @@ public class SilentPollOrchestrator : IDisposable
                 return;
             }
 
-            // Send ProcessInfo with Client packages via encrypted file IPC BEFORE starting Upgrade
-            if (_preparedProcessInfo != null && _clientVersions.Count > 0)
-            {
-                new EncryptedFileProcessInfoProvider().Send(_preparedProcessInfo);
-                GeneralTracer.Info($"SilentPollOrchestrator: ProcessInfo sent with {_clientVersions.Count} Client package(s).");
-            }
-
             Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = updaterPath });
             GeneralTracer.Info($"SilentPollOrchestrator: launched updater {updaterPath}");
         }
@@ -463,129 +182,8 @@ public class SilentPollOrchestrator : IDisposable
     }
 
     /// <summary>
-    /// Attempts to report an update error through hooks and the reporter.
-    /// </summary>
-    /// <param name="ctx">The update context containing application information.</param>
-    /// <param name="ex">The exception that occurred.</param>
-    /// <remarks>
-    /// This method makes a best-effort attempt to call <c>_hooks.OnUpdateErrorAsync</c> and
-    /// <c>_reporter.ReportAsync</c>. Even if these calls themselves throw exceptions,
-    /// the exceptions are not propagated (only a warning is logged), ensuring that a
-    /// failure in error reporting does not mask the original error.
-    /// </remarks>
-    private void TryReportError(UpdateContext ctx, Exception ex)
-    {
-        if (_hooks != null)
-        {
-            try { _hooks.OnUpdateErrorAsync(ctx, ex).GetAwaiter().GetResult(); }
-            catch (Exception hookEx) { GeneralTracer.Warn($"Hook OnUpdateErrorAsync failed: {hookEx.Message}"); }
-        }
-        if (_reporter != null)
-        {
-            try { _reporter.ReportAsync(new UpdateReport(0, (int)UpdateStatus.Failure, 1)).GetAwaiter().GetResult(); }
-            catch (Exception reporterEx) { GeneralTracer.Warn($"Reporter UpdateFailed failed: {reporterEx.Message}"); }
-        }
-    }
-
-    /// <summary>
-    /// Initializes the <see cref="StorageManager.BlackListMatcher"/> using the configured
-    /// blacklist information. Falls back to <see cref="BlackListDefaults"/> if the
-    /// configured lists are empty.
-    /// </summary>
-    private void InitBlackList()
-    {
-        var effectiveConfig = new BlackListConfig(
-            _configInfo.BlackFiles?.Count > 0 ? _configInfo.BlackFiles : BlackListDefaults.DefaultBlackFiles,
-            _configInfo.BlackFormats?.Count > 0 ? _configInfo.BlackFormats : BlackListDefaults.DefaultBlackFormats,
-            _configInfo.SkipDirectorys?.Count > 0 ? _configInfo.SkipDirectorys : BlackListDefaults.DefaultSkipDirectories
-        );
-        StorageManager.BlackListMatcher = new DefaultBlackListMatcher(effectiveConfig);
-    }
-
-    /// <summary>
-    /// Creates the appropriate update strategy instance based on the current operating system.
-    /// Uses the custom strategy (<c>_customOsStrategy</c>) if one has been set.
-    /// </summary>
-    /// <returns>An <see cref="IStrategy"/> implementation matching the current platform.</returns>
-    /// <exception cref="PlatformNotSupportedException">Thrown when the operating system is
-    /// not Windows, Linux, or macOS.</exception>
-    private IStrategy CreateStrategy()
-    {
-        if (_customOsStrategy != null) return _customOsStrategy;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return new WindowsStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return new LinuxStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return new MacStrategy();
-        throw new PlatformNotSupportedException();
-    }
-
-    /// <summary>
-    /// Detects the current operating system platform.
-    /// </summary>
-    /// <returns>A <see cref="PlatformType"/> enum value representing the current operating system.</returns>
-    private static PlatformType GetPlatform()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return PlatformType.Windows;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformType.Linux;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return PlatformType.MacOS;
-        return PlatformType.Unknown;
-    }
-
-    /// <summary>
-    /// After upgrade packages have been applied in-place, writes the latest upgrade version
-    /// back to <c>generalupdate.manifest.json</c> so the next poll cycle starts from the
-    /// correct <c>UpgradeClientVersion</c>.
-    /// </summary>
-    /// <param name="upgradeVersions">
-    /// The upgrade version list that was just applied. The last element carries the
-    /// highest target version.
-    /// </param>
-    private void WriteBackUpgradeVersion(List<VersionInfo> upgradeVersions)
-    {
-        var latestVersion = upgradeVersions.LastOrDefault()?.Version;
-        if (string.IsNullOrEmpty(latestVersion)) return;
-
-        try
-        {
-            ManifestInfo.TryUpdateVersion(
-                _configInfo.InstallPath,
-                upgradeClientVersion: latestVersion);
-            GeneralTracer.Info(
-                $"SilentPollOrchestrator: UpgradeClientVersion updated to {latestVersion} in manifest.");
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Warn(
-                $"SilentPollOrchestrator: failed to write back UpgradeClientVersion: {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Checks whether the specified version is a known failed version (recorded in the
-    /// <c>UpgradeFail</c> environment variable).
-    /// </summary>
-    /// <param name="version">The version string to check.</param>
-    /// <returns><c>true</c> if the version is not null and is less than or equal to the
-    /// failed version recorded in the environment variable.</returns>
-    /// <remarks>
-    /// This feature prevents repeatedly attempting known-failed version updates.
-    /// The <c>UpgradeFail</c> environment variable stores a previously failed version number;
-    /// if the candidate version is less than or equal to that value, it is skipped.
-    /// </remarks>
-    private static bool CheckFail(string? version)
-    {
-        if (string.IsNullOrEmpty(version)) return false;
-        var fail = Environments.GetEnvironmentVariable("UpgradeFail");
-        if (string.IsNullOrEmpty(fail)) return false;
-        return new Version(fail) >= new Version(version);
-    }
-
-    /// <summary>
     /// Releases all resources used by the <see cref="SilentPollOrchestrator"/>.
     /// </summary>
-    /// <remarks>
-    /// Calls <see cref="Stop"/> to halt polling, then disposes the
-    /// <see cref="CancellationTokenSource"/>.
-    /// </remarks>
     public void Dispose()
     {
         Stop();
@@ -596,27 +194,20 @@ public class SilentPollOrchestrator : IDisposable
 /// <summary>
 /// Configuration options for silent updates.
 /// </summary>
-/// <remarks>
-/// <see cref="SilentOptions"/> controls the polling behavior and client restart policy
-/// for silent updates.
-/// </remarks>
 public sealed class SilentOptions
 {
     /// <summary>
     /// Gets or sets the polling interval. The default is 1 hour.
     /// </summary>
-    /// <value>The time interval between update checks. The recommended minimum is
-    /// 5 minutes to avoid excessive network requests.</value>
     public TimeSpan PollInterval { get; set; } = TimeSpan.FromHours(1);
 
     /// <summary>
     /// Gets or sets a value indicating whether the client application should be
-    /// automatically launched after an update completes.
+    /// automatically launched after the upgrade process completes.
     /// </summary>
     /// <value>
     /// <c>true</c> (default): Automatically start the client after the upgrade completes;
-    /// <c>false</c>: The caller controls restart timing manually (suitable for maintenance
-    /// windows, orchestrated deployments, etc.).
+    /// <c>false</c>: The caller controls restart timing manually.
     /// </value>
     public bool LaunchClientAfterUpdate { get; set; } = true;
 }

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -320,6 +321,23 @@ namespace GeneralUpdate.Core.Strategy
             }
 
             return CheckPath(_configinfo.InstallPath, name);
+        }
+
+        /// <summary>
+        /// Resolves and starts the target executable using the strategy's platform-specific
+        /// path resolution logic. Does not perform any additional work (no hooks, no shutdown).
+        /// For use by callers that only need process launch, e.g. <see cref="Silent.SilentPollOrchestrator"/>.
+        /// </summary>
+        /// <param name="appName">The name of the executable to launch.</param>
+        /// <param name="preferUpdatePath">When <c>true</c>, checks <c>UpdatePath</c> first.</param>
+        /// <exception cref="FileNotFoundException">Thrown when the executable cannot be resolved.</exception>
+        internal void StartProcess(string appName, bool preferUpdatePath = false)
+        {
+            var appPath = ResolveAppPath(appName, preferUpdatePath);
+            if (string.IsNullOrEmpty(appPath))
+                throw new FileNotFoundException($"Can't find the app {appName}!");
+            GeneralTracer.Info($"AbstractStrategy.StartProcess: launching {appPath}");
+            Process.Start(appPath);
         }
 
         /// <summary>

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -674,6 +674,52 @@ public class ClientStrategy : IStrategy
         await _osStrategy!.StartAppAsync();
     }
 
+    /// <summary>
+    /// Synchronously launches the upgrade process via the configured OS strategy
+    /// after running the pre-launch lifecycle hook. Designed for
+    /// <see cref="Silent.SilentPollOrchestrator"/> to call from
+    /// <see cref="AppDomain.ProcessExit"/>, where the process is already shutting
+    /// down and only path resolution + hook + process start are needed.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="LaunchUpgradeProcessAsync"/>, this method does NOT call
+    /// <see cref="AbstractStrategy.StartAppAsync"/> — it only resolves the path
+    /// via the strategy's <see cref="AbstractStrategy.ResolveAppPath"/> and starts
+    /// the process, without the extra shutdown / Bowl / tracer-dispose work that
+    /// is only appropriate when the current process is about to exit voluntarily.
+    /// </remarks>
+    internal void LaunchUpgradeProcessSync()
+    {
+        // Run the pre-launch lifecycle hook (e.g. UnixPermissionHooks for chmod +x).
+        // In the standard flow this runs inside ExecuteStandardWorkflowAsync; in
+        // silent mode it was deferred and must run now, before the process starts.
+        var ctx = BuildUpdateContext();
+        SafeOnBeforeStartAppAsync(ctx).GetAwaiter().GetResult();
+
+        if (_osStrategy is AbstractStrategy abs)
+        {
+            abs.LaunchAppName = _configInfo!.UpdateAppName;
+            abs.LaunchBowl = false;
+            abs.UseUpdatePath = !string.IsNullOrWhiteSpace(_configInfo.UpdatePath);
+            abs.StartProcess(abs.LaunchAppName!, abs.UseUpdatePath);
+            return;
+        }
+
+        // Fallback: custom IStrategy (non-AbstractStrategy).
+        // For a custom strategy we can't use the platform path resolution, so we
+        // fall back to a simple InstallPath + UpdateAppName lookup.
+        var updaterDir = !string.IsNullOrWhiteSpace(_configInfo!.UpdatePath)
+            ? (Path.IsPathRooted(_configInfo.UpdatePath)
+                ? _configInfo.UpdatePath
+                : Path.Combine(_configInfo.InstallPath, _configInfo.UpdatePath))
+            : _configInfo.InstallPath;
+        var appPath = Path.Combine(updaterDir, _configInfo.UpdateAppName);
+        if (!File.Exists(appPath))
+            throw new FileNotFoundException($"Upgrade application not found: {appPath}");
+        GeneralTracer.Info($"ClientStrategy: launching upgrade process {appPath}");
+        Process.Start(appPath);
+    }
+
     #endregion
 
     #region Helpers

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -76,6 +76,19 @@ public class ClientStrategy : IStrategy
     private int _reportType = 1; // 1=Upgrade(active poll), 2=Push(SignalR push)
 
     /// <summary>
+    /// When <c>false</c>, skips <see cref="LaunchUpgradeProcessAsync"/> in MainOnly / Both scenarios.
+    /// The caller (e.g. <see cref="Silent.SilentPollOrchestrator"/>) is responsible for launching the
+    /// upgrade process at a later point. Default is <c>true</c> — standard immediate-launch behaviour.
+    /// </summary>
+    public bool LaunchAfterPrepare { get; set; } = true;
+
+    /// <summary>
+    /// After <see cref="ExecuteAsync"/> completes, <c>true</c> indicates that client packages were
+    /// staged via <see cref="SendProcessIpc"/> and the upgrade process should be launched to apply them.
+    /// </summary>
+    public bool HasPreparedClientUpdate { get; private set; }
+
+    /// <summary>
     /// Update scenario determined by the server validation result, indicating which update targets are needed.
     /// </summary>
     private enum UpdateScenario
@@ -244,6 +257,8 @@ public class ClientStrategy : IStrategy
     public async Task ExecuteAsync()
     {
         if (_configInfo == null) throw new InvalidOperationException("ClientStrategy not configured.");
+
+        HasPreparedClientUpdate = false;
 
         try
         {
@@ -554,8 +569,11 @@ public class ClientStrategy : IStrategy
                 SendProcessIpc(clientVersions);
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _mainRecordId).ConfigureAwait(false);
-                await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
-                await LaunchUpgradeProcessAsync().ConfigureAwait(false);
+                if (LaunchAfterPrepare)
+                {
+                    await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
+                    await LaunchUpgradeProcessAsync().ConfigureAwait(false);
+                }
                 break;
 
             case UpdateScenario.Both:
@@ -563,8 +581,11 @@ public class ClientStrategy : IStrategy
                 await SafeOnAfterUpdateAsync(hooksCtx).ConfigureAwait(false);
                 await SafeReportUpdateAppliedAsync(hooksCtx, _upgradeRecordId).ConfigureAwait(false);
                 SendProcessIpc(clientVersions);
-                await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
-                await LaunchUpgradeProcessAsync().ConfigureAwait(false);
+                if (LaunchAfterPrepare)
+                {
+                    await SafeOnBeforeStartAppAsync(hooksCtx).ConfigureAwait(false);
+                    await LaunchUpgradeProcessAsync().ConfigureAwait(false);
+                }
                 break;
             case UpdateScenario.None:
             default:
@@ -625,6 +646,7 @@ public class ClientStrategy : IStrategy
         _configInfo.ProcessInfo = JsonSerializer.Serialize(processInfo,
             ProcessInfoJsonContext.Default.ProcessInfo);
         new EncryptedFileProcessInfoProvider().Send(processInfo);
+        HasPreparedClientUpdate = true;
         GeneralTracer.Info("ClientStrategy: ProcessInfo sent with MainApp versions only.");
     }
 

--- a/tests/CoreTest/Silent/SilentPollOrchestratorTests.cs
+++ b/tests/CoreTest/Silent/SilentPollOrchestratorTests.cs
@@ -1,13 +1,14 @@
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Silent;
+using GeneralUpdate.Core.Strategy;
 
 namespace CoreTest.Silent;
 
 public class SilentPollOrchestratorTests
 {
-    private GlobalConfigInfo CreateValidConfig()
+    private static GlobalConfigInfo CreateValidConfig()
     {
-        return new GeneralUpdate.Core.Configuration.GlobalConfigInfo
+        return new GlobalConfigInfo
         {
             UpdateUrl = "https://api.example.com/update",
             ClientVersion = "1.0.0",
@@ -18,56 +19,38 @@ public class SilentPollOrchestratorTests
         };
     }
 
+    private static ClientStrategy CreateValidStrategy()
+    {
+        return new ClientStrategy { LaunchAfterPrepare = false };
+    }
+
+    [Fact]
+    public void Ctor_StrategyNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SilentPollOrchestrator(null!, CreateValidConfig(), new SilentOptions()));
+    }
+
     [Fact]
     public void Ctor_ConfigInfoNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new SilentPollOrchestrator(null, new SilentOptions()));
+            new SilentPollOrchestrator(CreateValidStrategy(), null!, new SilentOptions()));
     }
 
     [Fact]
     public void Ctor_OptionsNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new SilentPollOrchestrator(CreateValidConfig(), null));
+            new SilentPollOrchestrator(CreateValidStrategy(), CreateValidConfig(), null!));
     }
 
     [Fact]
     public void Ctor_ValidParameters_CreatesInstance()
     {
         var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
+            CreateValidStrategy(), CreateValidConfig(), new SilentOptions());
         Assert.NotNull(orchestrator);
-        orchestrator.Dispose();
-    }
-
-    [Fact]
-    public void WithHooks_ReturnsSameInstance()
-    {
-        var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
-        var result = orchestrator.WithHooks(new GeneralUpdate.Core.Hooks.NoOpUpdateHooks());
-        Assert.Same(orchestrator, result);
-        orchestrator.Dispose();
-    }
-
-    [Fact]
-    public void WithReporter_ReturnsSameInstance()
-    {
-        var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
-        var result = orchestrator.WithReporter(new GeneralUpdate.Core.Download.Reporting.HttpUpdateReporter());
-        Assert.Same(orchestrator, result);
-        orchestrator.Dispose();
-    }
-
-    [Fact]
-    public void WithHooks_Null_Accepted()
-    {
-        var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
-        var result = orchestrator.WithHooks(null);
-        Assert.Same(orchestrator, result);
         orchestrator.Dispose();
     }
 
@@ -75,7 +58,7 @@ public class SilentPollOrchestratorTests
     public void Stop_WithoutStart_DoesNotThrow()
     {
         var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
+            CreateValidStrategy(), CreateValidConfig(), new SilentOptions());
         var ex = Record.Exception(() => orchestrator.Stop());
         Assert.Null(ex);
         orchestrator.Dispose();
@@ -85,7 +68,7 @@ public class SilentPollOrchestratorTests
     public void Dispose_ReleasesResources()
     {
         var orchestrator = new SilentPollOrchestrator(
-            CreateValidConfig(), new SilentOptions());
+            CreateValidStrategy(), CreateValidConfig(), new SilentOptions());
         var ex = Record.Exception(() => orchestrator.Dispose());
         Assert.Null(ex);
     }
@@ -95,6 +78,13 @@ public class SilentPollOrchestratorTests
     {
         var options = new SilentOptions();
         Assert.Equal(TimeSpan.FromHours(1), options.PollInterval);
+    }
+
+    [Fact]
+    public void SilentOptions_DefaultLaunchClientAfterUpdate_IsTrue()
+    {
+        var options = new SilentOptions();
+        Assert.True(options.LaunchClientAfterUpdate);
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

静默更新模式的核心差异只是「ProcessExit 时才启动 Upgrade」，而不是「重新实现一套更新逻辑」。本次重构将 `SilentPollOrchestrator` 从独立实现者转变为调度层，所有更新工作委托给完全配置的 `ClientStrategy`。

## 改动

| 文件 | 变更 |
|---|---|
| `ClientStrategy.cs` | + `LaunchAfterPrepare` 标志（默认 true）、+ `HasPreparedClientUpdate` 状态 |
| `GeneralUpdateBootstrap.cs` | 抽取 `ConfigureStrategy()`（标准/静默路径共享）；精简 `LaunchWithStrategy` 和 `LaunchSilentAsync` |
| `SilentPollOrchestrator.cs` | 从 ~600 行缩减到 ~175 行；构造参数改为 `ClientStrategy` + `GlobalConfigInfo`；轮询循环委托给 strategy |
| `UpdateOptions.cs` | + `LaunchClientAfterUpdate` 配置项 |
| `SilentPollOrchestratorTests.cs` | 适配新 API |

## 修复的 Bug

- **#1**: DiffPipeline 未注入 → PatchMiddleware 无限抛异常 → **静默模式可用**
- **#2**: Upgrade-only 时多余启动 Upgrade 进程 → **条件守卫**
- **#3**: 下载行为忽略 Options → **完全复用标准配置**

## 效果

```
标准模式: 触发 → 下载 → 应用Upgrade → IPC → 立即启动Upgrade → 退出
静默模式: 触发 → 下载 → 应用Upgrade → IPC → 等待退出 → 启动Upgrade → 退出
                                                ↑ 唯一差异
```

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)