### PR TITLE
fix: ManifestInfo.Load receives directory path — manifest read always fails in ClientStrategy

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/ManifestInfo.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ManifestInfo.cs
@@ -34,7 +34,7 @@ public class ManifestInfo
     [JsonPropertyName("updatePath")]
     public string UpdatePath { get; set; }
 
-    private const string FileName = "generalupdate.manifest.json";
+    public const string FileName = "generalupdate.manifest.json";
 
     /// <summary>
     ///     Load manifest from <see cref="AppDomain.CurrentDomain.BaseDirectory"/>.
@@ -47,21 +47,33 @@ public class ManifestInfo
     }
 
     /// <summary>
-    ///     Load manifest from a specific path. Returns <c>null</c> when the file does not exist.
+    ///     Load manifest from a specific file path. Returns <c>null</c> when the file does
+    ///     not exist or cannot be deserialized.
     /// </summary>
-    public static ManifestInfo? Load(string path)
+    /// <param name="filePath">
+    ///     Full path to <c>generalupdate.manifest.json</c>. When passing a directory,
+    ///     use <c>Path.Combine(dir, ManifestInfo.FileName)</c> instead.
+    /// </param>
+    public static ManifestInfo? Load(string filePath)
     {
-        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+        {
+            if (!string.IsNullOrWhiteSpace(filePath))
+                GeneralTracer.Warn($"Manifest file not found: {filePath}");
             return null;
+        }
 
         try
         {
-            var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize(json, HttpParameterJsonContext.Default.ManifestInfo);
+            var json = File.ReadAllText(filePath);
+            var manifest = JsonSerializer.Deserialize(json, HttpParameterJsonContext.Default.ManifestInfo);
+            if (manifest == null)
+                GeneralTracer.Warn($"Manifest deserialization returned null for: {filePath}");
+            return manifest;
         }
-        catch
+        catch (Exception ex)
         {
-            // Malformed JSON, permission denied, etc. — treat as missing.
+            GeneralTracer.Warn($"Failed to load manifest from {filePath}: {ex.Message}");
             return null;
         }
     }

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -418,7 +418,7 @@ public class ClientStrategy : IStrategy
         // and could pick up a stale manifest when InstallPath is customized.
         // Caller's explicit value takes precedence; manifest is a fallback.
         var installPath = _configInfo!.InstallPath;
-        var manifest = ManifestInfo.Load(installPath);
+        var manifest = ManifestInfo.Load(Path.Combine(installPath, ManifestInfo.FileName));
         var localClientVersion = _configInfo.ClientVersion ?? manifest?.ClientVersion;
         var localUpgradeVersion = _configInfo.UpgradeClientVersion ?? manifest?.UpgradeClientVersion;
 


### PR DESCRIPTION
## Summary

Fixes #477 — `ClientStrategy` was passing a **directory** to `ManifestInfo.Load(string)`, which expects a **file path**. In .NET, `File.Exists()` returns `false` for directories, so the manifest was never found and the version fallback logic was silently dead.

## Changes

### ManifestInfo.cs
| Change | Reason |
|--------|--------|
| `FileName`: `private const` → `public const` | Callers can correctly construct `Path.Combine(dir, FileName)` |
| Parameter `path` → `filePath` + XML doc | Eliminates ambiguity — doc shows `Path.Combine(dir, ManifestInfo.FileName)` |
| Added `GeneralTracer.Warn` for 3 failure paths | No more silent failure — file-not-found, null-deserialize, and exceptions all logged |

### ClientStrategy.cs
| Change | Reason |
|--------|--------|
| `Load(installPath)` → `Load(Path.Combine(installPath, ManifestInfo.FileName))` | **Bug fix**: directory → proper file path |

## Before / After

```csharp
// Before (broken)
var manifest = ManifestInfo.Load(installPath);  
// installPath = "C:\Program Files\MyApp" → File.Exists returns false → always null

// After (fixed)
var manifest = ManifestInfo.Load(Path.Combine(installPath, ManifestInfo.FileName));
// Path = "C:\Program Files\MyApp\generalupdate.manifest.json" → found and parsed correctly
```

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)