### PR TITLE
fix: SSL policy not covering file downloads + HttpClient lifecycle issues

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -153,7 +153,11 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
             // ── Network-level extensions (global, applied before any HTTP call) ──
             var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
-            if (sslPolicy != null) Network.VersionService.SetSslValidationPolicy(sslPolicy);
+            if (sslPolicy != null)
+            {
+                Network.VersionService.SetSslValidationPolicy(sslPolicy);
+                Network.HttpClientProvider.SetSslValidationPolicy(sslPolicy);
+            }
             var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
             if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
 
@@ -403,7 +407,11 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
         // Network-level extensions (global, applied before any HTTP call)
         var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
-        if (sslPolicy != null) Network.VersionService.SetSslValidationPolicy(sslPolicy);
+        if (sslPolicy != null)
+        {
+            Network.VersionService.SetSslValidationPolicy(sslPolicy);
+            Network.HttpClientProvider.SetSslValidationPolicy(sslPolicy);
+        }
         var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
         if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
 

--- a/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
@@ -32,7 +32,14 @@ public static class HttpClientProvider
         var handler = new HttpClientHandler();
         handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) =>
             _sslPolicy.ValidateCertificate(cert, chain, errors);
-        _shared = new HttpClient(handler, disposeHandler: false);
+        _shared = new HttpClient(handler, disposeHandler: false)
+        {
+            // Let per-request CancellationTokenSource.CancelAfter (set by
+            // HttpDownloadExecutor & VersionService) control timeout — the
+            // global HttpClient.Timeout (default ~100s) would otherwise cap
+            // requests before a caller-configured longer DownloadTimeout.
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan
+        };
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
@@ -1,15 +1,58 @@
+using System;
 using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using GeneralUpdate.Core.Security;
 
 namespace GeneralUpdate.Core.Network;
 
 /// <summary>
-/// Provides a shared static <see cref="HttpClient"/> instance.
+/// Provides a shared static <see cref="HttpClient"/> instance with configurable SSL validation.
 /// Reusing a single HttpClient prevents socket exhaustion.
 /// Do NOT dispose clients obtained from here.
 /// </summary>
+/// <remarks>
+/// <para>
+/// SSL certificate validation behaviour is controlled by the
+/// <see cref="SetSslValidationPolicy"/> method. The default policy is
+/// <see cref="StrictSslValidationPolicy"/> (rejects any certificate with SSL errors).
+/// </para>
+/// <para>
+/// This class mirrors the SSL validation pattern used by <see cref="VersionService"/>,
+/// ensuring that both API calls and file downloads respect the same global SSL policy.
+/// </para>
+/// </remarks>
 public static class HttpClientProvider
 {
-    private static readonly HttpClient _shared = new();
+    private static ISslValidationPolicy _sslPolicy = new StrictSslValidationPolicy();
+    private static readonly HttpClient _shared;
+
+    static HttpClientProvider()
+    {
+        var handler = new HttpClientHandler();
+        handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) =>
+            _sslPolicy.ValidateCertificate(cert, chain, errors);
+        _shared = new HttpClient(handler, disposeHandler: false);
+    }
+
+    /// <summary>
+    /// Sets the global SSL certificate validation policy for all download requests.
+    /// </summary>
+    /// <param name="policy">The SSL validation policy instance. Must not be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="policy"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// This policy affects all HTTPS download requests made through
+    /// <see cref="HttpDownloadExecutor"/> and other components that use the shared
+    /// <see cref="HttpClient"/>. The default is <see cref="StrictSslValidationPolicy"/>.
+    /// </para>
+    /// <para>
+    /// The validation callback delegates to the stored policy instance, so the policy
+    /// can be changed at any time — new requests will use the updated policy.
+    /// </para>
+    /// </remarks>
+    public static void SetSslValidationPolicy(ISslValidationPolicy policy)
+        => _sslPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
 
     /// <summary>
     /// Gets the shared <see cref="HttpClient"/> instance. Do NOT dispose.

--- a/src/c#/GeneralUpdate.Core/Strategy/OssStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OssStrategy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -462,8 +461,7 @@ public class OssStrategy : IStrategy
             File.SetAttributes(path, FileAttributes.Normal);
             File.Delete(path);
         }
-        using var httpClient = GeneralUpdate.Core.Network.HttpClientProvider.Shared;
-        var bytes = await httpClient.GetByteArrayAsync(url).ConfigureAwait(false);
+        var bytes = await Network.HttpClientProvider.Shared.GetByteArrayAsync(url).ConfigureAwait(false);
         File.WriteAllBytes(path, bytes);
     }
 
@@ -506,11 +504,13 @@ public class OssStrategy : IStrategy
         }
         else
         {
-            using var httpClient = new HttpClient
+            var options = new DownloadOrchestratorOptions
             {
-                Timeout = TimeSpan.FromSeconds(_configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut)
+                DownloadTimeout = TimeSpan.FromSeconds(
+                    _configInfo?.DownloadTimeOut > 0 ? _configInfo!.DownloadTimeOut : DefaultTimeOut)
             };
-            var orchestrator = new DefaultDownloadOrchestrator(httpClient);
+            var orchestrator = new DefaultDownloadOrchestrator(
+                Network.HttpClientProvider.Shared, options);
             await orchestrator.ExecuteAsync(plan, targetPath).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
## Summary

Fixes #487 — three issues found during review of the GeneralUpdate.Core extension injection and consumption paths:

### 🔴 SSL validation policy did not cover file download requests

`HttpClientProvider.Shared` was using a bare `new HttpClient()` without SSL validation callback. When users registered a custom SSL policy via `.SslPolicy<T>()`, it only applied to `VersionService` API calls, not file downloads through `HttpDownloadExecutor`.

**Fix:** `HttpClientProvider` now uses `HttpClientHandler` with `ServerCertificateCustomValidationCallback` (same pattern as `VersionService`). `GeneralUpdateBootstrap` wires the SSL policy to both `VersionService` and `HttpClientProvider`.

### 🟡 OssStrategy disposes shared HttpClient

`DownloadVersionConfig` used `using var httpClient = HttpClientProvider.Shared`, disposing the singleton and causing `ObjectDisposedException` on all subsequent requests.

**Fix:** Removed `using` — directly calls `HttpClientProvider.Shared.GetByteArrayAsync(url)`.

### 🟢 OssStrategy creates new HttpClient per download call

`DownloadAssetsAsync` created `new HttpClient()` per call, risking socket exhaustion and not respecting global SSL policy.

**Fix:** Uses `HttpClientProvider.Shared` with `DownloadOrchestratorOptions` for timeout control.

## Changes

| File | Change |
|------|--------|
| `HttpClientProvider.cs` | Add SSL validation callback support via `HttpClientHandler` |
| `GeneralUpdateBootstrap.cs` | Wire SSL policy to `HttpClientProvider` in both launch paths |
| `OssStrategy.cs` | Remove `using` on shared `HttpClient`; use `HttpClientProvider.Shared` |

## Verification

- Build: 0 errors
- All warnings are pre-existing (JSON AOT, trimming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)