### PR TITLE
feat(Security): add BasicAuthProvider, AuthScheme enum, and refine auth system

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -260,6 +260,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
     /// <param name="reportUrl">Optional URL for reporting update status back to the server.</param>
     /// <param name="scheme">Optional URL scheme override (e.g. <c>"https"</c>).</param>
     /// <param name="token">Optional authentication token for API requests.</param>
+    /// <param name="authScheme">Explicitly selects the HTTP authentication method. Defaults to <see cref="Security.AuthScheme.Hmac"/>.</param>
+    /// <param name="basicUsername">Optional username for HTTP Basic Authentication.</param>
+    /// <param name="basicPassword">Optional password for HTTP Basic Authentication.</param>
     /// <param name="installPath">
     /// Optional override for the installation root directory. When <c>null</c>,
     /// defaults to <see cref="AppDomain.CurrentDomain.BaseDirectory"/>. Set this when
@@ -273,6 +276,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         string? reportUrl = null,
         string? scheme = null,
         string? token = null,
+        Security.AuthScheme authScheme = Security.AuthScheme.Hmac,
+        string? basicUsername = null,
+        string? basicPassword = null,
         string? installPath = null)
     {
         var config = new UpdateRequest
@@ -281,6 +287,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             AppSecretKey = appSecretKey,
             Token = token,
             Scheme = scheme,
+            AuthScheme = authScheme,
+            BasicUsername = basicUsername,
+            BasicPassword = basicPassword,
             ReportUrl = reportUrl
         };
         if (installPath != null)
@@ -353,6 +362,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             BackupDirectory = processInfo.BackupDirectory,
             Scheme = processInfo.Scheme,
             Token = processInfo.Token,
+            AuthScheme = processInfo.AuthScheme,
+            BasicUsername = processInfo.BasicUsername,
+            BasicPassword = processInfo.BasicPassword,
             DriverDirectory = processInfo.DriverDirectory,
             UpdatePath = processInfo.UpdatePath,
             LaunchClientAfterUpdate = processInfo.LaunchClientAfterUpdate,

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -261,7 +261,6 @@ namespace GeneralUpdate.Core.Configuration
         }
 
         /// <summary>
-        /// <summary>
         /// Registers an HTTP authentication provider for attaching authentication credentials
         /// to download requests.
         /// </summary>
@@ -280,6 +279,15 @@ namespace GeneralUpdate.Core.Configuration
             _extensions[typeof(Security.IHttpAuthProvider)] = typeof(T);
             return (TBootstrap)this;
         }
+
+        /// <summary>
+        /// [Obsolete] Use <see cref="HttpAuth{T}"/> instead.
+        /// </summary>
+        /// <typeparam name="T">The authentication provider implementation type.</typeparam>
+        /// <returns>The current <typeparamref name="TBootstrap"/> instance for chaining.</returns>
+        [Obsolete("Use HttpAuth<T>() instead.")]
+        public TBootstrap UpdateAuth<T>() where T : Security.IHttpAuthProvider, new()
+            => HttpAuth<T>();
 
         /// <summary>
         /// Registers a custom download orchestrator for end-to-end handling of batch

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -270,11 +270,12 @@ namespace GeneralUpdate.Core.Configuration
         /// <returns>The current <typeparamref name="TBootstrap"/> instance for chaining.</returns>
         /// <remarks>
         /// Can be used to support servers that require token authentication (Bearer Token),
-        /// basic authentication (Basic Auth), or custom authentication headers. This extension
+        /// basic authentication (Basic Auth), API key authentication, HMAC-SHA256 signature
+        /// authentication, or custom authentication headers. This extension
         /// point is read by <c>HttpClientProvider</c> and injected into request headers when
         /// creating HTTP download requests.
         /// </remarks>
-        public TBootstrap UpdateAuth<T>() where T : Security.IHttpAuthProvider, new()
+        public TBootstrap HttpAuth<T>() where T : Security.IHttpAuthProvider, new()
         {
             _extensions[typeof(Security.IHttpAuthProvider)] = typeof(T);
             return (TBootstrap)this;

--- a/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
@@ -94,6 +94,9 @@ namespace GeneralUpdate.Core.Configuration
             target.Bowl = source.Bowl;
             target.Scheme = source.Scheme;
             target.Token = source.Token;
+            target.AuthScheme = source.AuthScheme;
+            target.BasicUsername = source.BasicUsername;
+            target.BasicPassword = source.BasicPassword;
             target.DriverDirectory = source.DriverDirectory;
             target.AppType = source.AppType;
             target.UpdatePath = source.UpdatePath;
@@ -192,6 +195,9 @@ namespace GeneralUpdate.Core.Configuration
                 bowl: source.Bowl,
                 scheme: source.Scheme,
                 token: source.Token,
+                authScheme: source.AuthScheme,
+                basicUsername: source.BasicUsername,
+                basicPassword: source.BasicPassword,
                 driverDirectory: source.DriverDirectory,         // 驱动更新所需的目录
                 tempPath: source.TempPath,                       // 客户端的下载临时路径，供升级进程定位包文件
                 blackFileFormats: blackFileFormats,              // 来自 BlackListManager

--- a/src/c#/GeneralUpdate.Core/Configuration/ProcessContract.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ProcessContract.cs
@@ -135,6 +135,9 @@ namespace GeneralUpdate.Core.Configuration
         /// <param name="bowl">The process name to terminate before the update.</param>
         /// <param name="scheme">The URL scheme for update requests.</param>
         /// <param name="token">The authentication token.</param>
+        /// <param name="authScheme">Explicitly selects the HTTP authentication method.</param>
+        /// <param name="basicUsername">The username for HTTP Basic Authentication.</param>
+        /// <param name="basicPassword">The password for HTTP Basic Authentication.</param>
         /// <param name="driverDirectory">The directory path containing driver files.</param>
         /// <param name="tempPath">The temporary directory path where the client downloaded the update package.</param>
         /// <param name="blackFileFormats">The list of file format extensions to skip.</param>
@@ -168,6 +171,9 @@ namespace GeneralUpdate.Core.Configuration
             , string bowl
             , string scheme
             , string token
+            , Security.AuthScheme authScheme
+            , string basicUsername
+            , string basicPassword
             , string driverDirectory
             , string tempPath
             , List<string> blackFileFormats
@@ -206,6 +212,9 @@ namespace GeneralUpdate.Core.Configuration
             Bowl = bowl;
             Scheme = scheme;
             Token = token;
+            AuthScheme = authScheme;
+            BasicUsername = basicUsername;
+            BasicPassword = basicPassword;
             DriverDirectory = driverDirectory;
             TempPath = tempPath;
 
@@ -326,6 +335,24 @@ namespace GeneralUpdate.Core.Configuration
         /// </summary>
         [JsonPropertyName("Token")]
         public string Token { get; set; }
+
+        /// <summary>
+        ///     Explicitly selects the HTTP authentication method.
+        /// </summary>
+        [JsonPropertyName("AuthScheme")]
+        public Security.AuthScheme AuthScheme { get; set; } = Security.AuthScheme.Hmac;
+
+        /// <summary>
+        ///     The username for HTTP Basic Authentication.
+        /// </summary>
+        [JsonPropertyName("BasicUsername")]
+        public string BasicUsername { get; set; }
+
+        /// <summary>
+        ///     The password for HTTP Basic Authentication.
+        /// </summary>
+        [JsonPropertyName("BasicPassword")]
+        public string BasicPassword { get; set; }
 
         /// <summary>
         ///     The list of file format extensions to exclude from the update.

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
@@ -186,13 +186,13 @@ namespace GeneralUpdate.Core.Configuration
 
         /// <summary>
         ///     The username for HTTP Basic Authentication.
-        ///     Used together with <see cref="BasicPassword"/> when the authentication scheme is "basic".
+        ///     Used together with <see cref="BasicPassword"/> when <see cref="Security.AuthScheme.Basic"/> is selected.
         /// </summary>
         public string BasicUsername { get; set; }
 
         /// <summary>
         ///     The password for HTTP Basic Authentication.
-        ///     Used together with <see cref="BasicUsername"/> when the authentication scheme is "basic".
+        ///     Used together with <see cref="BasicUsername"/> when <see cref="Security.AuthScheme.Basic"/> is selected.
         /// </summary>
         public string BasicPassword { get; set; }
 

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
@@ -173,10 +173,28 @@ namespace GeneralUpdate.Core.Configuration
         public string Scheme { get; set; }
 
         /// <summary>
+        ///     Explicitly selects the HTTP authentication method.
+        ///     When set, this determines which credentials are used to authenticate update requests.
+        /// </summary>
+        public Security.AuthScheme AuthScheme { get; set; } = Security.AuthScheme.Hmac;
+
+        /// <summary>
         ///     The authentication token used for API requests.
         ///     This token is included in HTTP request headers when communicating with the update server.
         /// </summary>
         public string Token { get; set; }
+
+        /// <summary>
+        ///     The username for HTTP Basic Authentication.
+        ///     Used together with <see cref="BasicPassword"/> when the authentication scheme is "basic".
+        /// </summary>
+        public string BasicUsername { get; set; }
+
+        /// <summary>
+        ///     The password for HTTP Basic Authentication.
+        ///     Used together with <see cref="BasicUsername"/> when the authentication scheme is "basic".
+        /// </summary>
+        public string BasicPassword { get; set; }
 
         /// <summary>
         ///     The directory path containing driver files, used for driver-based update functionality.

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateRequestBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateRequestBuilder.cs
@@ -267,9 +267,9 @@ namespace GeneralUpdate.Core.Configuration
         /// </summary>
         /// <param name="scheme">The authentication scheme to use. Defaults to <see cref="Security.AuthScheme.Hmac"/>.</param>
         /// <returns>The current <see cref="UpdateRequestBuilder" /> instance for chaining.</returns>
-        public UpdateRequestBuilder SetAuthScheme(Security.AuthScheme scheme)
+        public UpdateRequestBuilder SetAuthScheme(Security.AuthScheme authScheme)
         {
-            _authScheme = scheme;
+            _authScheme = authScheme;
             return this;
         }
 

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateRequestBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateRequestBuilder.cs
@@ -46,6 +46,9 @@ namespace GeneralUpdate.Core.Configuration
         private string _updateUrl;
         private string _token;
         private string _scheme;
+        private Security.AuthScheme _authScheme = Security.AuthScheme.Hmac;
+        private string _basicUsername;
+        private string _basicPassword;
         private string _appName = "Update.exe";
         private string _mainAppName;
         private string _clientVersion;
@@ -155,6 +158,11 @@ namespace GeneralUpdate.Core.Configuration
                     builder.SetToken(config.Token);
                 if (!string.IsNullOrWhiteSpace(config.Scheme))
                     builder.SetScheme(config.Scheme);
+                builder.SetAuthScheme(config.AuthScheme);
+                if (!string.IsNullOrWhiteSpace(config.BasicUsername))
+                    builder.SetBasicUsername(config.BasicUsername);
+                if (!string.IsNullOrWhiteSpace(config.BasicPassword))
+                    builder.SetBasicPassword(config.BasicPassword);
                 if (!string.IsNullOrWhiteSpace(config.UpdateAppName))
                     builder.SetUpgradeAppName(config.UpdateAppName);
                 if (!string.IsNullOrWhiteSpace(config.MainAppName))
@@ -251,6 +259,39 @@ namespace GeneralUpdate.Core.Configuration
                 throw new ArgumentException("scheme cannot be null or empty.", nameof(scheme));
 
             _scheme = scheme;
+            return this;
+        }
+
+        /// <summary>
+        ///     Explicitly selects the HTTP authentication method.
+        /// </summary>
+        /// <param name="scheme">The authentication scheme to use. Defaults to <see cref="Security.AuthScheme.Hmac"/>.</param>
+        /// <returns>The current <see cref="UpdateRequestBuilder" /> instance for chaining.</returns>
+        public UpdateRequestBuilder SetAuthScheme(Security.AuthScheme scheme)
+        {
+            _authScheme = scheme;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the username for HTTP Basic Authentication.
+        /// </summary>
+        /// <param name="username">The username for Basic Authentication.</param>
+        /// <returns>The current <see cref="UpdateRequestBuilder" /> instance for chaining.</returns>
+        public UpdateRequestBuilder SetBasicUsername(string username)
+        {
+            _basicUsername = username;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the password for HTTP Basic Authentication.
+        /// </summary>
+        /// <param name="password">The password for Basic Authentication.</param>
+        /// <returns>The current <see cref="UpdateRequestBuilder" /> instance for chaining.</returns>
+        public UpdateRequestBuilder SetBasicPassword(string password)
+        {
+            _basicPassword = password;
             return this;
         }
 
@@ -474,6 +515,9 @@ namespace GeneralUpdate.Core.Configuration
                 UpdateUrl = _updateUrl,
                 Token = _token,
                 Scheme = _scheme,
+                AuthScheme = _authScheme,
+                BasicUsername = _basicUsername,
+                BasicPassword = _basicPassword,
                 UpdateAppName = _appName,
                 MainAppName = _mainAppName,
                 ClientVersion = _clientVersion,

--- a/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
@@ -45,6 +45,9 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
     private readonly string? _productId;
     private readonly string? _scheme;
     private readonly string? _token;
+    private readonly Security.AuthScheme _authScheme;
+    private readonly string? _basicUsername;
+    private readonly string? _basicPassword;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpDownloadSource"/> class
@@ -61,6 +64,9 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
     /// <param name="productId">An optional product identifier.</param>
     /// <param name="scheme">An optional authentication scheme.</param>
     /// <param name="token">An optional authentication token.</param>
+    /// <param name="authScheme">Explicitly selects the HTTP authentication method.</param>
+    /// <param name="basicUsername">An optional username for HTTP Basic Authentication.</param>
+    /// <param name="basicPassword">An optional password for HTTP Basic Authentication.</param>
     public HttpDownloadSource(
         string updateUrl,
         string clientVersion,
@@ -69,7 +75,10 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
         PlatformType platform,
         string? productId,
         string? scheme,
-        string? token)
+        string? token,
+        Security.AuthScheme authScheme,
+        string? basicUsername,
+        string? basicPassword)
     {
         _updateUrl = updateUrl;
         _clientVersion = clientVersion;
@@ -79,6 +88,9 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
         _productId = productId;
         _scheme = scheme;
         _token = token;
+        _authScheme = authScheme;
+        _basicUsername = basicUsername;
+        _basicPassword = basicPassword;
     }
 
     /// <summary>
@@ -111,12 +123,12 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
         var mainResp = await VersionService.Validate(
             _updateUrl, _clientVersion, AppType.Client,
             _appSecretKey, _platform, _productId,
-            _scheme, _token, token);
+            _scheme, _token, _authScheme, _basicUsername, _basicPassword, token);
 
         var upgradeResp = await VersionService.Validate(
             _updateUrl, _upgradeClientVersion ?? _clientVersion, AppType.Upgrade,
             _appSecretKey, _platform, _productId,
-            _scheme, _token, token);
+            _scheme, _token, _authScheme, _basicUsername, _basicPassword, token);
 
         // Check that returned VersionEntry items' AppType matches the requested type,
         // rather than just checking Count > 0. The server may return items whose

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -177,7 +177,7 @@ namespace GeneralUpdate.Core.Network
         /// <param name="token">The authentication token or key, used together with <paramref name="scheme"/>.</param>
         /// <param name="authScheme">Explicitly selects the HTTP authentication method. Defaults to <see cref="Security.AuthScheme.Hmac"/>.</param>
         /// <param name="basicUsername">The username for HTTP Basic Authentication. Used when <see cref="Security.AuthScheme.Basic"/> is selected.</param>
-        /// <param name="basicPassword">The password for HTTP Basic Authentication. Used when <paramref name="scheme"/> is "basic".</param>
+        /// <param name="basicPassword">The password for HTTP Basic Authentication. Used when <see cref="Security.AuthScheme.Basic"/> is selected.</param>
         /// <param name="ct">A <see cref="CancellationToken"/> for cancelling the operation.</param>
         /// <returns>A <see cref="VersionRespDTO"/> containing the version validation result
         /// (e.g., whether an update exists, download URL, etc.).</returns>

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -175,14 +175,17 @@ namespace GeneralUpdate.Core.Network
         /// <param name="productId">The product identifier.</param>
         /// <param name="scheme">The authentication scheme (e.g., "bearer", "apikey", "hmac"), used to create the auth provider. Ignored when a global auth provider is set.</param>
         /// <param name="token">The authentication token or key, used together with <paramref name="scheme"/>.</param>
+        /// <param name="authScheme">Explicitly selects the HTTP authentication method. Defaults to <see cref="Security.AuthScheme.Hmac"/>.</param>
+        /// <param name="basicUsername">The username for HTTP Basic Authentication. Used when <see cref="Security.AuthScheme.Basic"/> is selected.</param>
+        /// <param name="basicPassword">The password for HTTP Basic Authentication. Used when <paramref name="scheme"/> is "basic".</param>
         /// <param name="ct">A <see cref="CancellationToken"/> for cancelling the operation.</param>
         /// <returns>A <see cref="VersionRespDTO"/> containing the version validation result
         /// (e.g., whether an update exists, download URL, etc.).</returns>
         public static Task<VersionRespDTO> Validate(string url, string version,
             AppType appType, string appKey, PlatformType platform, string productId,
-            string scheme = null, string token = null, CancellationToken ct = default)
+            string scheme = null, string token = null, Security.AuthScheme authScheme = Security.AuthScheme.Hmac, string basicUsername = null, string basicPassword = null, CancellationToken ct = default)
         {
-            var auth = _globalAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, appKey);
+            var auth = _globalAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, appKey, authScheme, basicUsername, basicPassword);
             return new VersionService(auth).ValidateAsync(url, version, (int)appType, appKey, (int)platform, productId, ct);
         }
 
@@ -205,12 +208,15 @@ namespace GeneralUpdate.Core.Network
         /// <param name="productId">The product identifier.</param>
         /// <param name="scheme">The authentication scheme.</param>
         /// <param name="token">The authentication token or key.</param>
+        /// <param name="authScheme">Explicitly selects the HTTP authentication method.</param>
+        /// <param name="basicUsername">The username for HTTP Basic Authentication.</param>
+        /// <param name="basicPassword">The password for HTTP Basic Authentication.</param>
         /// <param name="ct">A <see cref="CancellationToken"/> for cancelling the operation.</param>
         /// <returns>A <see cref="VersionRespDTO"/> containing the version validation result.</returns>
         public static Task<VersionRespDTO> Validate(string url, string version,
             int appType, string appKey, int platform, string productId,
-            string scheme = null, string token = null, CancellationToken ct = default)
-            => Validate(url, version, (AppType)appType, appKey, (PlatformType)platform, productId, scheme, token, ct);
+            string scheme = null, string token = null, Security.AuthScheme authScheme = Security.AuthScheme.Hmac, string basicUsername = null, string basicPassword = null, CancellationToken ct = default)
+            => Validate(url, version, (AppType)appType, appKey, (PlatformType)platform, productId, scheme, token, authScheme, basicUsername, basicPassword, ct);
 
         /// <summary>
         /// Asynchronously validates the version by querying the server for available updates.

--- a/src/c#/GeneralUpdate.Core/Security/IHttpAuthProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Security/IHttpAuthProvider.cs
@@ -9,6 +9,34 @@ using System.Threading.Tasks;
 namespace GeneralUpdate.Core.Security;
 
 /// <summary>
+/// Explicitly selects the HTTP authentication method for update requests.
+/// </summary>
+/// <remarks>
+/// Use this enum to tell the framework which authentication scheme to use,
+/// then supply the corresponding credentials:
+/// <list type="bullet">
+///   <item><description><see cref="Hmac"/> — uses <c>AppSecretKey</c> (default).</description></item>
+///   <item><description><see cref="Bearer"/> — uses <c>Token</c>.</description></item>
+///   <item><description><see cref="ApiKey"/> — uses <c>Token</c>.</description></item>
+///   <item><description><see cref="Basic"/> — uses <c>BasicUsername</c> + <c>BasicPassword</c>.</description></item>
+/// </list>
+/// </remarks>
+public enum AuthScheme
+{
+    /// <summary>HMAC-SHA256 signature authentication (default). Requires <c>AppSecretKey</c>.</summary>
+    Hmac,
+
+    /// <summary>Bearer Token authentication. Requires <c>Token</c>.</summary>
+    Bearer,
+
+    /// <summary>API Key authentication via custom header. Requires <c>Token</c>.</summary>
+    ApiKey,
+
+    /// <summary>HTTP Basic Authentication (RFC 7617). Requires <c>BasicUsername</c> + <c>BasicPassword</c>.</summary>
+    Basic
+}
+
+/// <summary>
 /// Defines a strategy for applying HTTP authentication to outgoing requests.
 /// </summary>
 /// <remarks>
@@ -25,6 +53,7 @@ namespace GeneralUpdate.Core.Security;
 ///   <item><description><see cref="BearerTokenAuthProvider"/> — sets the <c>Authorization: Bearer</c> header.</description></item>
 ///   <item><description><see cref="ApiKeyAuthProvider"/> — sets a custom header with the API key value.</description></item>
 ///   <item><description><see cref="HmacAuthProvider"/> — computes an HMAC-SHA256 signature over the request body and timestamp.</description></item>
+///   <item><description><see cref="BasicAuthProvider"/> — sets the <c>Authorization: Basic</c> header with a Base64-encoded credential.</description></item>
 /// </list>
 /// </para>
 /// <para>
@@ -214,16 +243,85 @@ public sealed class HmacAuthProvider : IHttpAuthProvider
 }
 
 /// <summary>
+/// An authentication provider that uses the HTTP Basic Authentication scheme
+/// (<c>Authorization: Basic &lt;credential&gt;</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This provider sets the <c>Authorization</c> header to <c>Basic &lt;credential&gt;</c>
+/// where <c>credential</c> is the Base64-encoded string of <c>username:password</c>.
+/// Use <see cref="EncodeCredential"/> to generate the encoded value from a username and password pair.
+/// </para>
+/// <para>
+/// This scheme is defined in RFC 7617 and is widely used by enterprise artifact
+/// repositories (Nexus, JFrog Artifactory), internal file servers, and simple API gateways.
+/// </para>
+/// </remarks>
+public sealed class BasicAuthProvider : IHttpAuthProvider
+{
+    private readonly string _credential;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BasicAuthProvider"/> class.
+    /// </summary>
+    /// <param name="base64Credential">
+    /// The Base64-encoded credential string (i.e., the result of Base64-encoding <c>username:password</c>).
+    /// Must not be null. Use <see cref="EncodeCredential"/> to generate this value safely.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="base64Credential"/> is null.</exception>
+    public BasicAuthProvider(string base64Credential)
+        => _credential = base64Credential ?? throw new ArgumentNullException(nameof(base64Credential));
+
+    /// <summary>
+    /// Encodes a username and password pair into a Base64 credential string suitable for
+    /// use with the HTTP Basic Authentication scheme.
+    /// </summary>
+    /// <param name="username">The username. Must not be null or empty.</param>
+    /// <param name="password">The password. Must not be null or empty.</param>
+    /// <returns>The Base64-encoded credential string for use with <c>Authorization: Basic</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="username"/> or <paramref name="password"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="username"/> or <paramref name="password"/> is empty or whitespace.</exception>
+    public static string EncodeCredential(string username, string password)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+            throw new ArgumentException("Username must not be null or empty.", nameof(username));
+        if (string.IsNullOrWhiteSpace(password))
+            throw new ArgumentException("Password must not be null or empty.", nameof(password));
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+    }
+
+    /// <summary>
+    /// Applies the Basic authentication by setting the <c>Authorization</c> header.
+    /// </summary>
+    /// <param name="request">The HTTP request message to authenticate.</param>
+    /// <param name="token">A <see cref="CancellationToken"/> (ignored by this implementation).</param>
+    /// <returns>A completed task after setting the header.</returns>
+    public Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", _credential);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
 /// Factory class for creating <see cref="IHttpAuthProvider"/> instances based on a scheme string and token.
 /// </summary>
 /// <remarks>
 /// <para>
 /// This factory encapsulates the logic for selecting the appropriate authentication provider
-/// based on the authentication scheme name:
+/// based on the authentication scheme name. Explicit scheme+credentials take priority:
 /// <list type="bullet">
-///   <item><description>If <paramref name="secretKey"/> is provided, creates an <see cref="HmacAuthProvider"/>.</description></item>
-///   <item><description>If <paramref name="scheme"/> is <c>"apikey"</c>, creates an <see cref="ApiKeyAuthProvider"/>.</description></item>
-///   <item><description>If <paramref name="token"/> is provided (any other scheme), creates a <see cref="BearerTokenAuthProvider"/>.</description></item>
+///   <item><description>If <paramref name="scheme"/> is <c>"basic"</c> with <paramref name="basicUsername"/>/<paramref name="basicPassword"/>,
+///   creates a <see cref="BasicAuthProvider"/> (auto-encodes credentials).</description></item>
+///   <item><description>If <paramref name="scheme"/> is <c>"basic"</c> with <paramref name="token"/>,
+///   creates a <see cref="BasicAuthProvider"/> (pre-encoded credential).</description></item>
+///   <item><description>If <paramref name="scheme"/> is <c>"apikey"</c> with <paramref name="token"/>,
+///   creates an <see cref="ApiKeyAuthProvider"/>.</description></item>
+///   <item><description>If <paramref name="token"/> is provided with any other scheme,
+///   creates a <see cref="BearerTokenAuthProvider"/>.</description></item>
+///   <item><description>If only <paramref name="secretKey"/> is provided (no explicit scheme),
+///   creates an <see cref="HmacAuthProvider"/> as the default.</description></item>
 ///   <item><description>Otherwise, returns a <see cref="NoOpAuthProvider"/>.</description></item>
 /// </list>
 /// </para>
@@ -237,20 +335,54 @@ public static class HttpAuthProviderFactory
     /// <summary>
     /// Creates an <see cref="IHttpAuthProvider"/> based on the provided scheme, token, and secret key.
     /// </summary>
-    /// <param name="scheme">The authentication scheme name (e.g., "bearer", "apikey", "hmac"). Case-insensitive.</param>
+    /// <param name="scheme">[Obsolete] Legacy string-based scheme. Prefer using <paramref name="authScheme"/> instead.</param>
     /// <param name="token">The authentication token or API key value.</param>
-    /// <param name="secretKey">The HMAC secret key. If provided, HMAC authentication takes precedence over other schemes.</param>
+    /// <param name="secretKey">The HMAC secret key. Used as the default authentication when no explicit scheme is specified.</param>
+    /// <param name="basicUsername">The username for HTTP Basic Authentication. Used together with <paramref name="basicPassword"/> when <paramref name="scheme"/> is "basic".</param>
+    /// <param name="basicPassword">The password for HTTP Basic Authentication. Used together with <paramref name="basicUsername"/> when <paramref name="scheme"/> is "basic".</param>
     /// <returns>An <see cref="IHttpAuthProvider"/> instance matching the specified parameters,
     /// or <see cref="NoOpAuthProvider"/> if no matching scheme is found.</returns>
-    public static IHttpAuthProvider Create(string? scheme, string? token, string? secretKey)
+    public static IHttpAuthProvider Create(string? scheme, string? token, string? secretKey, AuthScheme authScheme = AuthScheme.Hmac, string? basicUsername = null, string? basicPassword = null)
     {
-        if (!string.IsNullOrEmpty(secretKey)) return new HmacAuthProvider(secretKey);
-        if (!string.IsNullOrEmpty(token))
-            return (scheme ?? "").ToLowerInvariant() switch
-            {
-                "apikey" => new ApiKeyAuthProvider(token),
-                _ => new BearerTokenAuthProvider(token)
-            };
+        // ── Explicit enum selection (preferred) ──
+        switch (authScheme)
+        {
+            case AuthScheme.Basic:
+                if (!string.IsNullOrWhiteSpace(basicUsername) && !string.IsNullOrWhiteSpace(basicPassword))
+                    return new BasicAuthProvider(BasicAuthProvider.EncodeCredential(basicUsername, basicPassword));
+                if (!string.IsNullOrEmpty(token))
+                    return new BasicAuthProvider(token);
+                break;
+
+            case AuthScheme.ApiKey:
+                if (!string.IsNullOrEmpty(token))
+                    return new ApiKeyAuthProvider(token);
+                break;
+
+            case AuthScheme.Bearer:
+                if (!string.IsNullOrEmpty(token))
+                    return new BearerTokenAuthProvider(token);
+                break;
+
+            case AuthScheme.Hmac:
+            default:
+                // Default: HMAC when secretKey is provided
+                if (!string.IsNullOrEmpty(secretKey))
+                    return new HmacAuthProvider(secretKey);
+                break;
+        }
+
+        // ── Legacy fallback: string-based scheme ──
+        var s = (scheme ?? "").ToLowerInvariant();
+        if (s == "basic" && !string.IsNullOrWhiteSpace(basicUsername) && !string.IsNullOrWhiteSpace(basicPassword))
+            return new BasicAuthProvider(BasicAuthProvider.EncodeCredential(basicUsername, basicPassword));
+        if (s == "basic" && !string.IsNullOrEmpty(token))
+            return new BasicAuthProvider(token);
+        if (s == "apikey" && !string.IsNullOrEmpty(token))
+            return new ApiKeyAuthProvider(token);
+        if (!string.IsNullOrEmpty(token) && s != "basic" && s != "apikey")
+            return new BearerTokenAuthProvider(token);
+
         return new NoOpAuthProvider();
     }
 }

--- a/src/c#/GeneralUpdate.Core/Security/IHttpAuthProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Security/IHttpAuthProvider.cs
@@ -279,8 +279,7 @@ public sealed class BasicAuthProvider : IHttpAuthProvider
     /// <param name="username">The username. Must not be null or empty.</param>
     /// <param name="password">The password. Must not be null or empty.</param>
     /// <returns>The Base64-encoded credential string for use with <c>Authorization: Basic</c>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="username"/> or <paramref name="password"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="username"/> or <paramref name="password"/> is empty or whitespace.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="username"/> or <paramref name="password"/> is null, empty, or whitespace.</exception>
     public static string EncodeCredential(string username, string password)
     {
         if (string.IsNullOrWhiteSpace(username))
@@ -335,9 +334,10 @@ public static class HttpAuthProviderFactory
     /// <summary>
     /// Creates an <see cref="IHttpAuthProvider"/> based on the provided scheme, token, and secret key.
     /// </summary>
-    /// <param name="scheme">[Obsolete] Legacy string-based scheme. Prefer using <paramref name="authScheme"/> instead.</param>
+    /// <param name="scheme">Legacy string-based scheme. Prefer using <paramref name="authScheme"/> instead.</param>
     /// <param name="token">The authentication token or API key value.</param>
     /// <param name="secretKey">The HMAC secret key. Used as the default authentication when no explicit scheme is specified.</param>
+    /// <param name="authScheme">Explicitly selects the HTTP authentication method. Defaults to <see cref="AuthScheme.Hmac"/>.</param>
     /// <param name="basicUsername">The username for HTTP Basic Authentication. Used together with <paramref name="basicPassword"/> when <paramref name="scheme"/> is "basic".</param>
     /// <param name="basicPassword">The password for HTTP Basic Authentication. Used together with <paramref name="basicUsername"/> when <paramref name="scheme"/> is "basic".</param>
     /// <returns>An <see cref="IHttpAuthProvider"/> instance matching the specified parameters,

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -415,7 +415,10 @@ public class ClientStrategy : IStrategy
             GetPlatform(),
             _configInfo.ProductId,
             _configInfo.Scheme,
-            _configInfo.Token);
+            _configInfo.Token,
+            _configInfo.AuthScheme,
+            _configInfo.BasicUsername,
+            _configInfo.BasicPassword);
 
         // Call server validation — returns assets from the two Validate calls
         var sourceResult = await downloadSource.ListAsync().ConfigureAwait(false);

--- a/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
+++ b/tests/CoreTest/Bootstrap/BootstrapFullParameterMatrixTests.cs
@@ -169,7 +169,7 @@ namespace CoreTest.Bootstrap
                 .DownloadPipeline<StubDownloadPipeline>()
                 .DownloadOrchestrator<StubDownloadOrchestrator>()
                 .SslPolicy<StubSslPolicy>()
-                .UpdateAuth<StubUpdateAuth>()
+                .HttpAuth<StubUpdateAuth>()
                 .Strategy<StubStrategy>();
             Assert.NotNull(b);
         }

--- a/tests/CoreTest/Configuration/ProcessContractTests.cs
+++ b/tests/CoreTest/Configuration/ProcessContractTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Security;
 
 namespace CoreTest.Configuration;
 
@@ -14,7 +15,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentNullException>(() =>
             new ProcessContract(null, ExistingDir, "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("appName", ex.Message);
     }
 
@@ -24,7 +25,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentException>(() =>
             new ProcessContract("app", "C:\\nonexistent_path_xyz", "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("path does not exist", ex.Message);
     }
 
@@ -34,7 +35,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentNullException>(() =>
             new ProcessContract("app", ExistingDir, null, "2.0", null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("currentVersion", ex.Message);
     }
 
@@ -44,7 +45,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentNullException>(() =>
             new ProcessContract("app", ExistingDir, "1.0", null, null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("lastVersion", ex.Message);
     }
 
@@ -54,7 +55,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentException>(() =>
             new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", -1, "key",
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("greater than 0", ex.Message);
     }
 
@@ -63,7 +64,7 @@ public class ProcessContractTests
     {
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 0, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
         Assert.Equal(0, info.DownloadTimeOut);
     }
 
@@ -73,7 +74,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentNullException>(() =>
             new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", 30, null,
-                SingleVersion, "url", "backup", null, null, null, null, null, null, null, null));
+                SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("appSecretKey", ex.Message);
     }
 
@@ -86,7 +87,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentException>(() =>
             new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                versions, "url", "backup", null, null, null, null, null, null, null, null));
+                versions, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("Collection", ex.Message);
     }
 
@@ -96,7 +97,7 @@ public class ProcessContractTests
         // ReportUrl is now optional — when not specified, no status reporting is performed.
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
-            SingleVersion, null, "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, null, "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
         Assert.Null(info.ReportUrl);
     }
 
@@ -106,7 +107,7 @@ public class ProcessContractTests
         var ex = Assert.Throws<ArgumentNullException>(() =>
             new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
                 Encoding.UTF8, "ZIP", 30, "key",
-                SingleVersion, "url", null, null, null, null, null, null, null, null, null));
+                SingleVersion, "url", null, null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null));
         Assert.Contains("backupDirectory", ex.Message);
     }
 
@@ -117,7 +118,7 @@ public class ProcessContractTests
             "MyApp", ExistingDir, "1.0.0", "2.0.0", "https://log.example.com",
             Encoding.UTF8, ".zip", 60, "secret-key",
             SingleVersion, "https://report.example.com", "C:\\backup",
-            "BowlProcess", "https", "token-abc", "C:\\drivers", "",
+            "BowlProcess", "https", "token-abc", AuthScheme.Bearer, null, null, "C:\\drivers", "",
             new List<string> { ".tmp" }, new List<string> { "skip.dll" }, new List<string> { "logs" });
 
         Assert.Equal("MyApp", info.AppName);
@@ -147,7 +148,7 @@ public class ProcessContractTests
         // Arrange & Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert
         Assert.Equal("utf-8", info.CompressEncoding);
@@ -159,7 +160,7 @@ public class ProcessContractTests
         // Arrange & Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.ASCII, "ZIP", 30, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert
         Assert.Equal("us-ascii", info.CompressEncoding);
@@ -171,7 +172,7 @@ public class ProcessContractTests
         // Arrange & Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.Unicode, "ZIP", 30, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert
         Assert.Equal("utf-16", info.CompressEncoding);
@@ -184,12 +185,15 @@ public class ProcessContractTests
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
             SingleVersion, "url", "backup",
-            null, null, null, null, null, null, null, null);
+            null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert
         Assert.Null(info.Bowl);
         Assert.Null(info.Scheme);
         Assert.Null(info.Token);
+        Assert.Equal(AuthScheme.Hmac, info.AuthScheme);
+        Assert.Null(info.BasicUsername);
+        Assert.Null(info.BasicPassword);
         Assert.Null(info.DriverDirectory);
         Assert.Null(info.Formats);
         Assert.Null(info.Files);
@@ -224,7 +228,7 @@ public class ProcessContractTests
         // Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
-            versions, "url", "backup", null, null, null, null, null, null, null, null);
+            versions, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert
         Assert.Equal(3, info.UpdateVersions.Count);
@@ -239,7 +243,7 @@ public class ProcessContractTests
         // Arrange & Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null, null, null, null);
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         // Assert — UpdateLogUrl is explicitly allowed to be null
         Assert.Null(info.UpdateLogUrl);
@@ -256,7 +260,7 @@ public class ProcessContractTests
         // Act
         var info = new ProcessContract("app", ExistingDir, "1.0", "2.0", null,
             Encoding.UTF8, "ZIP", 30, "key",
-            SingleVersion, "url", "backup", null, null, null, null, null,
+            SingleVersion, "url", "backup", null, null, null, AuthScheme.Hmac, null, null, null, null,
             formats, files, dirs);
 
         // Assert

--- a/tests/CoreTest/Download/Sources/HttpDownloadSourceTests.cs
+++ b/tests/CoreTest/Download/Sources/HttpDownloadSourceTests.cs
@@ -1,6 +1,7 @@
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Download.Abstractions;
 using GeneralUpdate.Core.Download.Sources;
+using GeneralUpdate.Core.Security;
 
 namespace CoreTest.Download.Sources;
 
@@ -21,7 +22,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, null, AppSecretKey,
-            PlatformType.Windows, null, null, null);
+            PlatformType.Windows, null, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.NotNull(source);
     }
@@ -31,7 +33,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, "2.0.0", AppSecretKey,
-            PlatformType.Linux, "product-1", "Bearer", "token-abc");
+            PlatformType.Linux, "product-1", "Bearer", "token-abc",
+            AuthScheme.Bearer, null, null);
 
         Assert.NotNull(source);
     }
@@ -41,7 +44,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, "1.5.0", AppSecretKey,
-            PlatformType.Windows, null, null, null);
+            PlatformType.Windows, null, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.NotNull(source);
     }
@@ -51,7 +55,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, null, AppSecretKey,
-            PlatformType.MacOS, null, null, null);
+            PlatformType.MacOS, null, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.NotNull(source);
     }
@@ -65,7 +70,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, string.Empty, null, AppSecretKey,
-            PlatformType.Windows, null, null, null);
+            PlatformType.Windows, null, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.NotNull(source);
     }
@@ -75,7 +81,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, null, AppSecretKey,
-            PlatformType.Windows, string.Empty, null, null);
+            PlatformType.Windows, string.Empty, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.NotNull(source);
     }
@@ -89,7 +96,8 @@ public class HttpDownloadSourceTests
     {
         var source = new HttpDownloadSource(
             ValidUrl, ClientVersion, null, AppSecretKey,
-            PlatformType.Windows, null, null, null);
+            PlatformType.Windows, null, null, null,
+            AuthScheme.Hmac, null, null);
 
         Assert.IsAssignableFrom<IDownloadSource>(source);
     }

--- a/tests/CoreTest/Ipc/IpcEncryptionTests.cs
+++ b/tests/CoreTest/Ipc/IpcEncryptionTests.cs
@@ -1,4 +1,5 @@
 using GeneralUpdate.Core.Ipc;
+using GeneralUpdate.Core.Security;
 
 namespace CoreTest.Ipc;
 
@@ -80,7 +81,7 @@ public class EncryptedFileProcessContractProviderTests
             null, System.Text.Encoding.UTF8, ".zip", 30, "secret",
             new List<GeneralUpdate.Core.Configuration.VersionEntry> { new() { Version = "2.0.0" } },
             "https://report.example.com", "C:\\backup",
-            null, null, null, null, null, null, null, null);
+            null, null, null, AuthScheme.Hmac, null, null, null, null, null, null, null, null);
 
         provider.Send(info);
         var received = provider.Receive();

--- a/tests/CoreTest/Ipc/ProcessContractProviderTests.cs
+++ b/tests/CoreTest/Ipc/ProcessContractProviderTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Ipc;
+using GeneralUpdate.Core.Security;
 using Xunit;
 
 namespace CoreTest.Ipc;
@@ -34,6 +35,9 @@ public class ProcessContractProviderTests
                 bowl: "",
                 scheme: "",
                 token: "",
+                authScheme: AuthScheme.Hmac,
+                basicUsername: "",
+                basicPassword: "",
                 driverDirectory: "",
                 tempPath: "",
                 blackFileFormats: new List<string> { ".pdb" },


### PR DESCRIPTION
## Summary

Completes the HTTP authentication system with 5 built-in providers and an explicit AuthScheme enum.

## Changes

### New: BasicAuthProvider
- RFC 7617 HTTP Basic Authentication
- EncodeCredential(username, password) helper for Base64 encoding
- Integrated into HttpAuthProviderFactory

### New: AuthScheme enum
Explicit, type-safe selection: Hmac | Bearer | ApiKey | Basic

### New: BasicUsername / BasicPassword fields
Added through full config pipeline alongside Token/Scheme.

### Rename: UpdateAuth<T>() → HttpAuth<T>()
Consistent naming.

### Fix: Factory priority
Explicit AuthScheme now takes precedence over HMAC default.

## Usage


🤖 Generated with [Claude Code](https://claude.com/claude-code)