### PR TITLE
fix: 修复备份机制递归嵌套及改用时间戳命名 (#501)

### DIFF
--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackDefaults.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackDefaults.cs
@@ -22,5 +22,10 @@ public static class BlackDefaults
 
     /// <summary>Default skipped directory prefixes.</summary>
     public static readonly List<string> DefaultDirectories = new()
-        { "app-", "fail" };
+    {
+        StorageManager.BackupRootDirectory,
+        StorageManager.DirectoryName,
+        StorageManager.LegacyDirectoryPrefix,
+        "fail"
+    };
 }

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -38,12 +38,26 @@ namespace GeneralUpdate.Core.FileSystem
         private long _fileCount = 0;
 
         /// <summary>
-        /// The default prefix name for backup directories.
+        /// The default prefix for backup directory names (e.g. "backup-20260606235200").
         /// </summary>
-        /// <remarks>
-        /// Backup directories are named in the format "app-{version}". This constant defines the prefix portion.
-        /// </remarks>
-        public const string DirectoryName = "app-";
+        public const string DirectoryName = "backup-";
+
+        /// <summary>
+        /// Legacy backup directory prefix used by older versions (e.g. "app-1.0.0").
+        /// Retained for backward compatibility in discovery and cleanup.
+        /// </summary>
+        public const string LegacyDirectoryPrefix = "app-";
+
+        /// <summary>
+        /// The subdirectory under the install path where new-format backups are stored.
+        /// </summary>
+        public const string BackupRootDirectory = ".backups";
+
+        /// <summary>
+        /// Backup directory name prefixes used for enumeration (both new and legacy formats).
+        /// Derived from <see cref="DirectoryName"/> and <see cref="LegacyDirectoryPrefix"/>.
+        /// </summary>
+        private static readonly string[] BackupNamePrefixes = { DirectoryName, LegacyDirectoryPrefix };
 
         /// <summary>
         /// Gets or sets the optional path/file blacklist matcher.
@@ -195,6 +209,64 @@ namespace GeneralUpdate.Core.FileSystem
         }
 
         /// <summary>
+        /// Generates a timestamp-based backup directory name in the format "backup-{yyyyMMddHHmmss}".
+        /// </summary>
+        /// <returns>A backup directory name string, e.g. "backup-20260606235200".</returns>
+        /// <remarks>
+        /// Timestamp naming ensures each backup is unique and naturally sortable by creation time.
+        /// Used by <see cref="Backup"/> to create version-independent backup directory names.
+        /// </remarks>
+        public static string GetBackupDirectoryName() => $"{DirectoryName}{DateTime.Now:yyyyMMddHHmmss}";
+
+        /// <summary>
+        /// Finds the most recent backup directory by scanning for backup directories
+        /// matching patterns derived from <see cref="BlackDefaults.DefaultDirectories"/>.
+        /// </summary>
+        /// <param name="installPath">The application installation root directory.</param>
+        /// <returns>The full path of the most recent backup directory, or <c>null</c> if none exists.</returns>
+        /// <remarks>
+        /// Directories are sorted by name in descending order. Since both "backup-{yyyyMMddHHmmss}"
+        /// and "app-{version}" formats are lexicographically sortable, this works for both.
+        /// Search patterns are derived from <see cref="BlackDefaults.DefaultDirectories"/> by
+        /// appending "*" to each entry — e.g. "backup-" becomes "backup-*".
+        /// </remarks>
+        public static string? GetLatestBackup(string installPath)
+        {
+            if (!Directory.Exists(installPath)) return null;
+
+            var allBackups = new List<string>();
+
+            // Scan BackupRootDirectory subdirectory (new-format backup container)
+            var backupRoot = Path.Combine(installPath, BackupRootDirectory);
+            if (Directory.Exists(backupRoot))
+            {
+                allBackups.AddRange(Directory.GetDirectories(backupRoot, "*", SearchOption.TopDirectoryOnly));
+            }
+
+            // Scan installPath directly for backup dirs matching patterns from defaults
+            allBackups.AddRange(GetBackupDirectories(installPath));
+
+            return allBackups
+                .OrderByDescending(d => d)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Enumerates all backup directories in the given path using patterns derived
+        /// from <see cref="BackupNamePrefixes"/> (both new and legacy formats).
+        /// </summary>
+        private static IEnumerable<string> GetBackupDirectories(string path)
+        {
+            foreach (var prefix in BackupNamePrefixes)
+            {
+                foreach (var dir in Directory.GetDirectories(path, prefix + "*", SearchOption.TopDirectoryOnly))
+                {
+                    yield return dir;
+                }
+            }
+        }
+
+        /// <summary>
         /// Recursively deletes the specified directory and all of its subdirectories and files.
         /// </summary>
         /// <param name="targetDir">The path to the target directory to delete.</param>
@@ -328,19 +400,26 @@ namespace GeneralUpdate.Core.FileSystem
         /// </remarks>
         public static void Backup(string sourcePath, string backupPath, IReadOnlyList<string> directoryNames)
         {
+            // Merge default backup-exclusion prefixes with user-configured directories.
+            // This ensures backup/legacy directories are ALWAYS skipped, preventing
+            // infinite recursion even when the user passes an empty skip list.
+            var effectiveDirectories = new List<string>(directoryNames);
+            effectiveDirectories.AddRange(BlackDefaults.DefaultDirectories);
+
             if (Directory.Exists(backupPath))
             {
                 DeleteDirectory(backupPath);
             }
             Directory.CreateDirectory(backupPath);
-            CopyDirectory(sourcePath, backupPath, directoryNames);
+            CopyDirectory(sourcePath, backupPath, effectiveDirectories);
         }
 
         private static void CopyDirectory(string sourceDir, string targetDir, IReadOnlyList<string> directoryNames)
         {
             foreach (string dirPath in Directory.GetDirectories(sourceDir, "*", SearchOption.TopDirectoryOnly))
             {
-                if (!directoryNames.Any(name => Path.GetFileName(dirPath).Contains(name)))
+                var dirName = Path.GetFileName(dirPath);
+                if (!directoryNames.Any(name => dirName.Contains(name)))
                 {
                     string newTargetDir = Path.Combine(targetDir, Path.GetFileName(dirPath));
                     Directory.CreateDirectory(newTargetDir);
@@ -518,23 +597,49 @@ namespace GeneralUpdate.Core.FileSystem
         /// <param name="installPath">The application installation root directory path.</param>
         /// <param name="keepVersions">The number of most recent backup versions to retain. Default is 3.</param>
         /// <remarks>
-        /// Backup directories are located under <c>{installPath}/__backups</c>, with each subdirectory named by version.
-        /// This method sorts directories by version in descending order, retains the top N versions, and deletes all others.
-        /// If a version cannot be parsed, it is treated as version <c>0.0</c> (and will be deleted first).
-        /// If the <c>__backups</c> directory does not exist, no operation is performed.
+        /// Scans for backup directories in two locations:
+        /// 1. <c>{installPath}\{BackupRootDirectory}\</c> — new-format container for backup-{timestamp} dirs
+        /// 2. <c>{installPath}\</c> directly — backup dirs matching patterns from <see cref="BlackDefaults.DefaultDirectories"/>
+        /// Directories are sorted by name in descending order (both timestamp and version
+        /// strings are lexicographically sortable), retaining the top N and deleting the rest.
         /// </remarks>
         public static void CleanBackup(string installPath, int keepVersions = 3)
         {
-            var backupRoot = Path.Combine(installPath, "__backups");
-            if (!Directory.Exists(backupRoot)) return;
+            // Scan BackupRootDirectory subdirectory (new-format backup container)
+            var backupRoot = Path.Combine(installPath, BackupRootDirectory);
+            if (Directory.Exists(backupRoot))
+            {
+                CleanDirectories(backupRoot, keepVersions);
+            }
 
-            var dirs = Directory.GetDirectories(backupRoot)
+            // Scan installPath directly for backup dirs matching patterns from defaults
+            foreach (var pattern in GetBackupSearchPatterns())
+            {
+                CleanDirectories(installPath, keepVersions, pattern);
+            }
+        }
+
+        /// <summary>
+        /// Derives search patterns from <see cref="BackupNamePrefixes"/>
+        /// by appending "*" to each entry (e.g. "backup-" → "backup-*").
+        /// </summary>
+        private static IEnumerable<string> GetBackupSearchPatterns()
+        {
+            foreach (var prefix in BackupNamePrefixes)
+            {
+                yield return prefix + "*";
+            }
+        }
+
+        /// <summary>
+        /// Cleans directories matching the specified pattern in the given root path,
+        /// retaining only the most recent N directories.
+        /// </summary>
+        private static void CleanDirectories(string rootPath, int keepVersions, string searchPattern = "*")
+        {
+            var dirs = Directory.GetDirectories(rootPath, searchPattern, SearchOption.TopDirectoryOnly)
                 .Select(d => new DirectoryInfo(d))
-                .OrderByDescending(d =>
-                {
-                    var name = d.Name;
-                    return Version.TryParse(name, out var v) ? v : new Version(0, 0);
-                })
+                .OrderByDescending(d => d.Name)
                 .Skip(keepVersions);
 
             foreach (var dir in dirs)
@@ -547,20 +652,37 @@ namespace GeneralUpdate.Core.FileSystem
         /// <param name="installPath">The application installation root directory path.</param>
         /// <returns>A read-only collection of <see cref="BackupInfo"/> for all backup versions.</returns>
         /// <remarks>
-        /// Each backup entry contains the version name, full path, creation time, and total size in bytes.
-        /// If the <c>__backups</c> directory does not exist, an empty collection is returned.
+        /// Scans both <c>{installPath}\{BackupRootDirectory}</c> (new format) and <c>{installPath}</c> directly
+        /// (backup dirs matching patterns from <see cref="BlackDefaults.DefaultDirectories"/>).
+        /// Each backup entry contains the directory name, full path, creation time, and total size in bytes.
         /// </remarks>
         public static IReadOnlyList<BackupInfo> ListBackups(string installPath)
         {
-            var backupRoot = Path.Combine(installPath, "__backups");
-            if (!Directory.Exists(backupRoot)) return Array.Empty<BackupInfo>();
+            var result = new List<BackupInfo>();
 
-            return Directory.GetDirectories(backupRoot)
+            // Scan BackupRootDirectory subdirectory (new-format backup container)
+            var backupRoot = Path.Combine(installPath, BackupRootDirectory);
+            if (Directory.Exists(backupRoot))
+            {
+                result.AddRange(ToBackupInfos(backupRoot, "*"));
+            }
+
+            // Scan installPath directly for backup dirs matching patterns from defaults
+            foreach (var pattern in GetBackupSearchPatterns())
+            {
+                result.AddRange(ToBackupInfos(installPath, pattern));
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<BackupInfo> ToBackupInfos(string rootPath, string searchPattern)
+        {
+            return Directory.GetDirectories(rootPath, searchPattern, SearchOption.TopDirectoryOnly)
                 .Select(d => new DirectoryInfo(d))
                 .Select(d => new BackupInfo(
                     d.Name, d.FullName, d.CreationTime,
-                    d.GetFiles("*", SearchOption.AllDirectories).Sum(f => f.Length)))
-                .ToList();
+                    d.GetFiles("*", SearchOption.AllDirectories).Sum(f => f.Length)));
         }
 
         #endregion

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -387,18 +387,31 @@ namespace GeneralUpdate.Core.Strategy
 
         /// <summary>
         /// Attempts to restore from backup when a pipeline execution fails.
-        /// Only restores if a backup directory exists for the current version.
+        /// Tries the specific backup directory for this update first;
+        /// falls back to the most recent backup if the specific one is unavailable.
         /// </summary>
         private void TryRollback()
         {
             try
             {
                 var backupDir = _configinfo.BackupDirectory;
+                // If the specific backup for this update doesn't exist,
+                // fall back to the most recent backup by timestamp.
+                if (string.IsNullOrWhiteSpace(backupDir) || !Directory.Exists(backupDir))
+                {
+                    GeneralTracer.Info($"AbstractStrategy.TryRollback: specific backup not found ({backupDir}), searching for latest.");
+                    backupDir = StorageManager.GetLatestBackup(_configinfo.InstallPath);
+                }
+
                 if (!string.IsNullOrWhiteSpace(backupDir) && Directory.Exists(backupDir))
                 {
                     GeneralTracer.Warn($"AbstractStrategy.TryRollback: restoring from backup {backupDir} -> {_configinfo.InstallPath}");
                     StorageManager.Restore(backupDir, _configinfo.InstallPath);
                     GeneralTracer.Info("AbstractStrategy.TryRollback: restore completed.");
+                }
+                else
+                {
+                    GeneralTracer.Warn("AbstractStrategy.TryRollback: no backup found, rollback skipped.");
                 }
             }
             catch (Exception ex)

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -544,8 +544,8 @@ public class ClientStrategy : IStrategy
 
         InitBlackPolicy();
         _configInfo.TempPath = StorageManager.GetTempDirectory("main_temp");
-        _configInfo.BackupDirectory = Path.Combine(_configInfo.InstallPath,
-            $"{StorageManager.DirectoryName}{_configInfo.ClientVersion}");
+        _configInfo.BackupDirectory = Path.Combine(_configInfo.InstallPath, StorageManager.BackupRootDirectory,
+            StorageManager.GetBackupDirectoryName());
 
         // Check failed version
         if (!string.IsNullOrEmpty(_configInfo.LastVersion) && CheckFail(_configInfo.LastVersion))
@@ -854,8 +854,9 @@ public class ClientStrategy : IStrategy
     /// </summary>
     /// <remarks>
     /// The backup operation is performed via <c>StorageManager.Backup</c>, excluding directories configured in the blacklist.
-    /// The backup directory path format is: {InstallPath}/backup_{ClientVersion}.
+    /// The backup directory path format is: {InstallPath}/__backups/backup_{yyyyMMddHHmmss}.
     /// This step can be skipped by setting <c>UpdateContext.BackupEnabled</c> to <c>false</c>.
+    /// After a successful backup, old backups are cleaned up, retaining only the most recent 3.
     /// </remarks>
     private void Backup()
     {
@@ -863,6 +864,8 @@ public class ClientStrategy : IStrategy
             $"ClientStrategy: backing up {_configInfo!.InstallPath} -> {_configInfo.BackupDirectory}");
         StorageManager.Backup(_configInfo.InstallPath, _configInfo.BackupDirectory,
             _configInfo.Directories ?? BlackDefaults.DefaultDirectories);
+        // Retain only the most recent 3 backups to prevent disk accumulation
+        StorageManager.CleanBackup(_configInfo.InstallPath, keepVersions: 3);
     }
 
     /// <summary>

--- a/tests/CoreTest/FileSystem/BackupRestoreTests.cs
+++ b/tests/CoreTest/FileSystem/BackupRestoreTests.cs
@@ -45,24 +45,66 @@ public class BackupRestoreTests
     public void CleanBackup_KeepsOnlyRecentVersions()
     {
         var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.CleanBackup." + Guid.NewGuid().ToString("N"));
-        var backupRoot = Path.Combine(installPath, "__backups");
         try
         {
+            // Create new-format backup dirs directly in installPath (backup-{timestamp})
             for (int i = 1; i <= 5; i++)
             {
-                var verDir = Path.Combine(backupRoot, $"{i}.0.0");
-                Directory.CreateDirectory(verDir);
-                File.WriteAllText(Path.Combine(verDir, "app.exe"), $"v{i}");
+                var timestamp = $"2026060600000{i}"; // Use fixed timestamp pattern for deterministic ordering
+                var dir = Path.Combine(installPath, $"backup-{timestamp}");
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(Path.Combine(dir, "app.exe"), $"v{i}");
+            }
+
+            // Also create a legacy app-* backup to verify it's cleaned too
+            var legacyDir = Path.Combine(installPath, "app-0.0.1");
+            Directory.CreateDirectory(legacyDir);
+            File.WriteAllText(Path.Combine(legacyDir, "app.exe"), "v0");
+
+            StorageManager.CleanBackup(installPath, keepVersions: 3);
+
+            // Should keep the 3 most recent backup-* dirs
+            var remaining = Directory.GetDirectories(installPath, "backup-*");
+            Assert.Equal(3, remaining.Length);
+            var names = remaining.Select(Path.GetFileName).OrderBy(n => n).ToList();
+            Assert.Contains("backup-20260606000003", names[0]);
+            Assert.Contains("backup-20260606000004", names[1]);
+            Assert.Contains("backup-20260606000005", names[2]);
+
+            // Legacy app-* should also be cleaned (keeps top 3, but there's only 1 legacy,
+            // and since we're using CleanBackup with keepVersions=3, the one legacy dir
+            // at installPath level would be kept unless there are 3+ newer app-* dirs)
+        }
+        finally
+        {
+            if (Directory.Exists(installPath)) Directory.Delete(installPath, true);
+        }
+    }
+
+    [Fact]
+    public void CleanBackup_AlsoCleansBackupsSubdirectory()
+    {
+        var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.CleanBackupSub." + Guid.NewGuid().ToString("N"));
+        var backupRoot = Path.Combine(installPath, StorageManager.BackupRootDirectory);
+        try
+        {
+            // Create backup dirs in .backups subdirectory (new format)
+            for (int i = 1; i <= 5; i++)
+            {
+                var timestamp = $"2026060600000{i}";
+                var dir = Path.Combine(backupRoot, $"backup-{timestamp}");
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(Path.Combine(dir, "app.exe"), $"v{i}");
             }
 
             StorageManager.CleanBackup(installPath, keepVersions: 3);
 
             var remaining = Directory.GetDirectories(backupRoot);
             Assert.Equal(3, remaining.Length);
-            var names = remaining.Select(Path.GetFileName).OrderBy(n => new Version(n!)).ToList();
-            Assert.Equal("3.0.0", names[0]);
-            Assert.Equal("4.0.0", names[1]);
-            Assert.Equal("5.0.0", names[2]);
+            var names = remaining.Select(Path.GetFileName).OrderBy(n => n).ToList();
+            Assert.Contains("backup-20260606000003", names[0]);
+            Assert.Contains("backup-20260606000004", names[1]);
+            Assert.Contains("backup-20260606000005", names[2]);
         }
         finally
         {
@@ -74,21 +116,152 @@ public class BackupRestoreTests
     public void ListBackups_ReturnsMetadata()
     {
         var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.ListBackups." + Guid.NewGuid().ToString("N"));
-        var backupRoot = Path.Combine(installPath, "__backups");
         try
         {
-            var verDir = Path.Combine(backupRoot, "1.0.0");
-            Directory.CreateDirectory(verDir);
-            File.WriteAllText(Path.Combine(verDir, "app.exe"), "v1");
+            // New format: .backups subdirectory
+            var backupRoot = Path.Combine(installPath, StorageManager.BackupRootDirectory);
+            var newDir = Path.Combine(backupRoot, "backup-20260606235200");
+            Directory.CreateDirectory(newDir);
+            File.WriteAllText(Path.Combine(newDir, "app.exe"), "v1");
+
+            // Legacy format: app-* directly in installPath
+            var legacyDir = Path.Combine(installPath, "app-1.0.0");
+            Directory.CreateDirectory(legacyDir);
+            File.WriteAllText(Path.Combine(legacyDir, "app.exe"), "v2");
 
             var backups = StorageManager.ListBackups(installPath);
-            Assert.Single(backups);
-            Assert.Equal("1.0.0", backups[0].Version);
-            Assert.Contains("__backups", backups[0].Path);
+            Assert.Equal(2, backups.Count);
+            Assert.Contains(backups, b => b.Version == "backup-20260606235200");
+            Assert.Contains(backups, b => b.Version == "app-1.0.0");
         }
         finally
         {
             if (Directory.Exists(installPath)) Directory.Delete(installPath, true);
         }
+    }
+
+    [Fact]
+    public void GetLatestBackup_ReturnsMostRecent()
+    {
+        var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.LatestBackup." + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(installPath);
+
+            // Create backup dirs with different timestamps
+            var dir1 = Path.Combine(installPath, "backup-20260601000000");
+            var dir2 = Path.Combine(installPath, "backup-20260606235200"); // This is the latest
+            var dir3 = Path.Combine(installPath, "backup-20260603000000");
+            Directory.CreateDirectory(dir1);
+            Directory.CreateDirectory(dir2);
+            Directory.CreateDirectory(dir3);
+
+            var latest = StorageManager.GetLatestBackup(installPath);
+            Assert.NotNull(latest);
+            Assert.Equal(dir2, latest); // backup-20260606235200 is alphabetically last
+        }
+        finally
+        {
+            if (Directory.Exists(installPath)) Directory.Delete(installPath, true);
+        }
+    }
+
+    [Fact]
+    public void GetLatestBackup_ReturnsNull_WhenNoBackups()
+    {
+        var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.LatestBackupEmpty." + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(installPath);
+            var latest = StorageManager.GetLatestBackup(installPath);
+            Assert.Null(latest);
+        }
+        finally
+        {
+            if (Directory.Exists(installPath)) Directory.Delete(installPath, true);
+        }
+    }
+
+    [Fact]
+    public void Backup_SkipsBackupDirectories()
+    {
+        var tmpRoot = Path.Combine(Path.GetTempPath(), "CoreTest.SkipBackup." + Guid.NewGuid().ToString("N"));
+        var sourceDir = Path.Combine(tmpRoot, "source");
+        var backupDir = Path.Combine(tmpRoot, "target_backup");
+
+        try
+        {
+            // Create source with both pre-existing backup-format dirs and an empty skip list
+            Directory.CreateDirectory(sourceDir);
+            File.WriteAllText(Path.Combine(sourceDir, "app.exe"), "v1.0");
+
+            // Pre-existing backup directories in source (simulating old backups)
+            var oldBackup = Path.Combine(sourceDir, "backup-20260601000000");
+            Directory.CreateDirectory(oldBackup);
+            File.WriteAllText(Path.Combine(oldBackup, "old.exe"), "old");
+
+            var legacyBackup = Path.Combine(sourceDir, "app-0.0.1");
+            Directory.CreateDirectory(legacyBackup);
+            File.WriteAllText(Path.Combine(legacyBackup, "legacy.exe"), "legacy");
+
+            var backupsDir = Path.Combine(sourceDir, StorageManager.BackupRootDirectory);
+            Directory.CreateDirectory(backupsDir);
+            File.WriteAllText(Path.Combine(backupsDir, "nested.exe"), "nested");
+
+            // Backup with EMPTY skip list — hard-coded exclusion must prevent recursion
+            StorageManager.Backup(sourceDir, backupDir, Array.Empty<string>());
+
+            Assert.True(Directory.Exists(backupDir));
+            Assert.True(File.Exists(Path.Combine(backupDir, "app.exe")));
+
+            // Verify backup-format dirs were NOT copied
+            Assert.False(Directory.Exists(Path.Combine(backupDir, "backup-20260601000000")));
+            Assert.False(Directory.Exists(Path.Combine(backupDir, "app-0.0.1")));
+            Assert.False(Directory.Exists(Path.Combine(backupDir, StorageManager.BackupRootDirectory)));
+        }
+        finally
+        {
+            if (Directory.Exists(tmpRoot)) Directory.Delete(tmpRoot, true);
+        }
+    }
+
+    [Fact]
+    public void Backup_WithBackupDirInsideSource_DoesNotRecurse()
+    {
+        // This test simulates the real-world scenario: backup directory is inside the
+        // source path (installPath). The hard-coded exclusion must prevent recursion.
+        var installPath = Path.Combine(Path.GetTempPath(), "CoreTest.NoRecurse." + Guid.NewGuid().ToString("N"));
+        var backupDir = Path.Combine(installPath, "backup-20260606235200");
+
+        try
+        {
+            Directory.CreateDirectory(installPath);
+            File.WriteAllText(Path.Combine(installPath, "app.exe"), "v1.0");
+            File.WriteAllText(Path.Combine(installPath, "config.json"), "{}");
+
+            // Backup directory IS inside installPath — this MUST NOT recurse
+            StorageManager.Backup(installPath, backupDir, Array.Empty<string>());
+
+            Assert.True(Directory.Exists(backupDir));
+            Assert.True(File.Exists(Path.Combine(backupDir, "app.exe")));
+            Assert.True(File.Exists(Path.Combine(backupDir, "config.json")));
+
+            // Critical: the backup directory must NOT contain a nested copy of itself
+            Assert.False(Directory.Exists(Path.Combine(backupDir, "backup-20260606235200")),
+                "Backup directory was recursively copied into itself! This is the main bug fix.");
+        }
+        finally
+        {
+            if (Directory.Exists(installPath)) Directory.Delete(installPath, true);
+        }
+    }
+
+    [Fact]
+    public void GetBackupDirectoryName_ReturnsTimestampFormat()
+    {
+        var name = StorageManager.GetBackupDirectoryName();
+        Assert.StartsWith("backup-", name);
+        // Format: backup-yyyyMMddHHmmss (17 chars)
+        Assert.Equal(21, name.Length); // "backup-" (7) + "yyyyMMddHHmmss" (14)
     }
 }

--- a/tests/CoreTest/FileSystem/BlackDefaultsTests.cs
+++ b/tests/CoreTest/FileSystem/BlackDefaultsTests.cs
@@ -48,18 +48,20 @@ public class BlackDefaultsTests
     }
 
     [Fact]
-    public void DefaultDirectories_ContainsAppPrefixAndFail()
+    public void DefaultDirectories_ContainsBackupPrefixAndFail()
     {
         var dirs = BlackDefaults.DefaultDirectories;
 
+        Assert.Contains(".backups", dirs);
+        Assert.Contains("backup-", dirs);
         Assert.Contains("app-", dirs);
         Assert.Contains("fail", dirs);
     }
 
     [Fact]
-    public void DefaultDirectories_HasTwoEntries()
+    public void DefaultDirectories_HasFourEntries()
     {
-        Assert.Equal(2, BlackDefaults.DefaultDirectories.Count);
+        Assert.Equal(4, BlackDefaults.DefaultDirectories.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## 修复内容

修复 `StorageManager.Backup()` 三个问题：

### 1. 备份目录递归嵌套导致 PathTooLongException
**根因**: 备份目录在 `InstallPath` 内部创建。若用户配置 `Directories = []`（空列表），`??` 空合并不触发，CopyDirectory 将备份目录递归复制到自身。

**修复**: 备份移至 `.backups/` 子目录隔离；`Backup()` 入口始终将 `BlackDefaults.DefaultDirectories` 合并到跳过列表，不依赖用户配置。

### 2. 命名格式从 `app-{version}` 改为 `backup-{yyyyMMddHHmmss}`
时间戳天然可排序，便于识别最新备份。

### 3. 所有魔法字符串集中为常量
```csharp
public const string DirectoryName = "backup-";          // 新备份名前缀
public const string LegacyDirectoryPrefix = "app-";     // 旧版备份名前缀  
public const string BackupRootDirectory = ".backups";   // 备份容器目录
```
`BlackDefaults.DefaultDirectories` 和所有备份枚举/清理方法统一引用这些常量。

### 其他改进
- `TryRollback()` 增加降级：特定备份不存在时自动找最新备份恢复
- 每次备份后自动清理，仅保留最近 3 个
- 新增 6 个专项测试，含递归防护验证

### 兼容性
Bowl、IPC 传递均不受影响——`BackupDirectory` 为纯字符串透传。

---

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)