### PR TITLE
fix: Copilot 审查后修复 — 备份排序改用创建时间、修正注释、补全测试断言

### DIFF
--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -225,41 +225,44 @@ namespace GeneralUpdate.Core.FileSystem
         /// <param name="installPath">The application installation root directory.</param>
         /// <returns>The full path of the most recent backup directory, or <c>null</c> if none exists.</returns>
         /// <remarks>
-        /// Directories are sorted by name in descending order. Since both "backup-{yyyyMMddHHmmss}"
-        /// and "app-{version}" formats are lexicographically sortable, this works for both.
-        /// Search patterns are derived from <see cref="BlackDefaults.DefaultDirectories"/> by
-        /// appending "*" to each entry — e.g. "backup-" becomes "backup-*".
+        /// Sorts candidates by directory creation time descending (most recent first), with
+        /// a name-based tie-breaker for deterministic results. Unlike lexicographic name
+        /// sorting, this correctly handles mixed paths (e.g. .backups/ vs installPath/)
+        /// and legacy version-format names ("app-10.0.0" vs "app-2.0.0").
         /// </remarks>
         public static string? GetLatestBackup(string installPath)
         {
             if (!Directory.Exists(installPath)) return null;
 
-            var allBackups = new List<string>();
+            var allBackups = new List<DirectoryInfo>();
 
             // Scan BackupRootDirectory subdirectory (new-format backup container)
             var backupRoot = Path.Combine(installPath, BackupRootDirectory);
             if (Directory.Exists(backupRoot))
             {
-                allBackups.AddRange(Directory.GetDirectories(backupRoot, "*", SearchOption.TopDirectoryOnly));
+                allBackups.AddRange(new DirectoryInfo(backupRoot)
+                    .GetDirectories("*", SearchOption.TopDirectoryOnly));
             }
 
             // Scan installPath directly for backup dirs matching patterns from defaults
-            allBackups.AddRange(GetBackupDirectories(installPath));
+            allBackups.AddRange(GetBackupDirectoryInfos(installPath));
 
             return allBackups
-                .OrderByDescending(d => d)
-                .FirstOrDefault();
+                .OrderByDescending(d => d.CreationTime)
+                .ThenByDescending(d => d.Name)
+                .FirstOrDefault()?.FullName;
         }
 
         /// <summary>
         /// Enumerates all backup directories in the given path using patterns derived
         /// from <see cref="BackupNamePrefixes"/> (both new and legacy formats).
         /// </summary>
-        private static IEnumerable<string> GetBackupDirectories(string path)
+        private static IEnumerable<DirectoryInfo> GetBackupDirectoryInfos(string path)
         {
+            var dirInfo = new DirectoryInfo(path);
             foreach (var prefix in BackupNamePrefixes)
             {
-                foreach (var dir in Directory.GetDirectories(path, prefix + "*", SearchOption.TopDirectoryOnly))
+                foreach (var dir in dirInfo.GetDirectories(prefix + "*", SearchOption.TopDirectoryOnly))
                 {
                     yield return dir;
                 }
@@ -637,9 +640,10 @@ namespace GeneralUpdate.Core.FileSystem
         /// </summary>
         private static void CleanDirectories(string rootPath, int keepVersions, string searchPattern = "*")
         {
-            var dirs = Directory.GetDirectories(rootPath, searchPattern, SearchOption.TopDirectoryOnly)
-                .Select(d => new DirectoryInfo(d))
-                .OrderByDescending(d => d.Name)
+            var dirs = new DirectoryInfo(rootPath)
+                .GetDirectories(searchPattern, SearchOption.TopDirectoryOnly)
+                .OrderByDescending(d => d.CreationTime)
+                .ThenByDescending(d => d.Name)
                 .Skip(keepVersions);
 
             foreach (var dir in dirs)

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -854,7 +854,7 @@ public class ClientStrategy : IStrategy
     /// </summary>
     /// <remarks>
     /// The backup operation is performed via <c>StorageManager.Backup</c>, excluding directories configured in the blacklist.
-    /// The backup directory path format is: {InstallPath}/__backups/backup_{yyyyMMddHHmmss}.
+    /// The backup directory path format is: {InstallPath}/.backups/backup-{yyyyMMddHHmmss}.
     /// This step can be skipped by setting <c>UpdateContext.BackupEnabled</c> to <c>false</c>.
     /// After a successful backup, old backups are cleaned up, retaining only the most recent 3.
     /// </remarks>

--- a/tests/CoreTest/FileSystem/BackupRestoreTests.cs
+++ b/tests/CoreTest/FileSystem/BackupRestoreTests.cs
@@ -71,9 +71,10 @@ public class BackupRestoreTests
             Assert.Contains("backup-20260606000004", names[1]);
             Assert.Contains("backup-20260606000005", names[2]);
 
-            // Legacy app-* should also be cleaned (keeps top 3, but there's only 1 legacy,
-            // and since we're using CleanBackup with keepVersions=3, the one legacy dir
-            // at installPath level would be kept unless there are 3+ newer app-* dirs)
+            // Legacy app-* — single directory is retained (only 1 total, keepVersions=3)
+            var legacyRemaining = Directory.GetDirectories(installPath, "app-*");
+            Assert.Single(legacyRemaining);
+            Assert.Equal("app-0.0.1", Path.GetFileName(legacyRemaining[0]));
         }
         finally
         {

--- a/tests/CoreTest/FileSystem/BackupRestoreTests.cs
+++ b/tests/CoreTest/FileSystem/BackupRestoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using GeneralUpdate.Core.FileSystem;
 using Xunit;
 
@@ -149,17 +150,19 @@ public class BackupRestoreTests
         {
             Directory.CreateDirectory(installPath);
 
-            // Create backup dirs with different timestamps
+            // Create backup dirs in creation-time order: oldest first, newest last
             var dir1 = Path.Combine(installPath, "backup-20260601000000");
-            var dir2 = Path.Combine(installPath, "backup-20260606235200"); // This is the latest
-            var dir3 = Path.Combine(installPath, "backup-20260603000000");
+            var dir2 = Path.Combine(installPath, "backup-20260603000000");
+            var dir3 = Path.Combine(installPath, "backup-20260606235200"); // Created last = most recent
             Directory.CreateDirectory(dir1);
+            Thread.Sleep(10); // Ensure distinct creation time on fast filesystems
             Directory.CreateDirectory(dir2);
+            Thread.Sleep(10);
             Directory.CreateDirectory(dir3);
 
             var latest = StorageManager.GetLatestBackup(installPath);
             Assert.NotNull(latest);
-            Assert.Equal(dir2, latest); // backup-20260606235200 is alphabetically last
+            Assert.Equal(dir3, latest); // Most recently created
         }
         finally
         {


### PR DESCRIPTION
Copilot 在 [#502](https://github.com/GeneralLibrary/GeneralUpdate/pull/502) 中提出了 4 条建议，本 PR 逐一修复：

### 1.  /  — 排序改用创建时间
旧版 `app-{version}` 命名（如 `app-10.0.0` vs `app-2.0.0`）不可靠字典排序；混合 `.backups/` 与 `installPath/` 路径时路径字符串排序也不准确。改为按 `CreationTime` 降序排列，`Name` 降序作为 tie-breaker。

### 2.  XML 注释修正
注释仍写 `__backups/backup_{...}`，现已改为 `.backups/backup-{yyyyMMddHHmmss}`。

### 3.  测试补全断言
创建了旧版 `app-*` 目录但未断言清理结果，现在明确验证 `app-0.0.1` 在 `keepVersions=3` 时被保留。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)