### PR TITLE
fix: align cross-version field mapping between client SDK and server API

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/VersionEntry.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/VersionEntry.cs
@@ -31,7 +31,7 @@ namespace GeneralUpdate.Core.Configuration;
 ///             <item>
 ///                 <description>
 ///                     Differential update phase: Uses <see cref="Hash" /> for file verification, and
-///                     <see cref="FromVersion" /> and <see cref="ToVersion" /> to determine the scope of the
+///                     <see cref="FromVersion" /> to determine the scope of the
 ///                     differential patch.
 ///                 </description>
 ///             </item>
@@ -196,21 +196,9 @@ public class VersionEntry : VersionIdentity
     /// </summary>
     /// <remarks>
     ///     Only valid when <see cref="IsCrossVersion" /> is <c>true</c>.
-    ///     Together with <see cref="ToVersion" />, defines the version scope of the differential patch.
     /// </remarks>
     [JsonPropertyName("fromVersion")]
     public string? FromVersion { get; set; }
-
-    /// <summary>
-    ///     The target version number for cross-version upgrade packages.
-    ///     Indicates the target version that will be reached after applying this differential patch.
-    /// </summary>
-    /// <remarks>
-    ///     Only valid when <see cref="IsCrossVersion" /> is <c>true</c>.
-    ///     Together with <see cref="FromVersion" />, defines the version scope of the differential patch.
-    /// </remarks>
-    [JsonPropertyName("toVersion")]
-    public string? ToVersion { get; set; }
 
     /// <summary>
     ///     Whether this version package is frozen (archived and not used for active updates).
@@ -218,4 +206,25 @@ public class VersionEntry : VersionIdentity
     /// </summary>
     [JsonPropertyName("isFreeze")]
     public bool? IsFreeze { get; set; }
+
+    /// <summary>
+    ///     The minimum client version required for this package.
+    ///     If the current client version is below this, the package is not applicable.
+    /// </summary>
+    [JsonPropertyName("minClientVersion")]
+    public string? MinClientVersion { get; set; }
+
+    /// <summary>
+    ///     The hash of the source full-version archive used to build this cross-version package.
+    ///     Only valid when <see cref="IsCrossVersion"/> is <c>true</c>.
+    /// </summary>
+    [JsonPropertyName("sourceArchiveHash")]
+    public string? SourceArchiveHash { get; set; }
+
+    /// <summary>
+    ///     The hash of the target full-version archive used to build this cross-version package.
+    ///     Only valid when <see cref="IsCrossVersion"/> is <c>true</c>.
+    /// </summary>
+    [JsonPropertyName("targetArchiveHash")]
+    public string? TargetArchiveHash { get; set; }
 }

--- a/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Sources/HttpDownloadSource.cs
@@ -182,7 +182,9 @@ public class HttpDownloadSource : Abstractions.IDownloadSource
             AppType: v.AppType,
             IsCrossVersion: v.IsCrossVersion == true,
             FromVersion: v.FromVersion,
-            TargetArchiveHash: v.Hash,
+            MinClientVersion: v.MinClientVersion,
+            SourceArchiveHash: v.SourceArchiveHash,
+            TargetArchiveHash: v.TargetArchiveHash,
             AuthScheme: v.AuthScheme,
             AuthToken: v.AuthToken
         );


### PR DESCRIPTION
Closes #504

## Summary

Aligns the cross-version (CVP) fields between GeneralUpdate.Core (client SDK) and GeneralSpacestation (server API). Three issues fixed:

### Changes

**1. MinClientVersion — now end-to-end**
- Added `MinClientVersion` to `VersionEntry` with JSON property name
- `HttpDownloadSource.MapVersionEntry()` now maps it to `DownloadAsset`
- Previously the server had this field in the DB but the API response didn't include it, so `DownloadPlanBuilder.IsCompatible()` was always a no-op
- Now administrators can set minimum client version requirements that actually work

**2. SourceArchiveHash / TargetArchiveHash — correct mapping**
- Added both fields to `VersionEntry`
- `MapVersionEntry()` now maps them correctly (previously `TargetArchiveHash` was incorrectly set to the package hash instead of the archive hash)

**3. ToVersion — removed (unused)**
- `ToVersion` was defined in `VersionEntry` but never consumed by any code in the SDK. The target version is already represented by the `Version` field itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)