### PR TITLE
feat: disable backup feature by default

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/Option.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/Option.cs
@@ -124,7 +124,7 @@ namespace GeneralUpdate.Core.Configuration
 
         public static Option<bool?> PatchEnabled { get; } = ValueOf<bool?>("PATCH", true);
 
-        public static Option<bool?> BackupEnabled { get; } = ValueOf<bool?>("BACKUP", true);
+        public static Option<bool?> BackupEnabled { get; } = ValueOf<bool?>("BACKUP", false);
 
         public static Option<bool> Silent { get; } = ValueOf<bool>("ENABLESILENTUPDATE", false);
 

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateContext.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateContext.cs
@@ -120,7 +120,7 @@ public class UpdateContext : UpdateConfiguration
 
     /// <summary>
     ///     Whether to back up the current version before applying an update.
-    ///     Computed from <see cref="Option.BackupEnabled" />, defaults to <c>true</c>.
+    ///     Computed from <see cref="Option.BackupEnabled" />, defaults to <c>false</c>.
     /// </summary>
     public bool? BackupEnabled { get; set; }
 

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -727,9 +727,9 @@ namespace GeneralUpdate.Core.FileSystem
         public List<string> Directories { get; set; } = new();
 
         /// <summary>
-        /// Whether the backup feature is enabled. Default is <c>true</c>.
+        /// Whether the backup feature is enabled. Default is <c>false</c>.
         /// </summary>
-        public bool Enabled { get; set; } = true;
+        public bool Enabled { get; set; } = false;
     }
 
     /// <summary>

--- a/tests/CoreTest/Configuration/UpdateContextWiringTests.cs
+++ b/tests/CoreTest/Configuration/UpdateContextWiringTests.cs
@@ -205,8 +205,8 @@ public class UpdateContextWiringTests
         => Assert.True(Option.VerifyChecksum.DefaultValue);
 
     [Fact]
-    public void Options_BackupEnabled_DefaultIsTrue()
-        => Assert.True(Option.BackupEnabled.DefaultValue);
+    public void Options_BackupEnabled_DefaultIsFalse()
+        => Assert.False(Option.BackupEnabled.DefaultValue);
 
     [Fact]
     public void Options_PatchEnabled_DefaultIsTrue()

--- a/tests/CoreTest/Configuration/UpdateOptionsStaticTests.cs
+++ b/tests/CoreTest/Configuration/UpdateOptionsStaticTests.cs
@@ -49,7 +49,7 @@ public class OptionStaticTests
     [Fact]
     public void BackupEnabled_HasCorrectDefault()
     {
-        Assert.True(Option.BackupEnabled.DefaultValue);
+        Assert.False(Option.BackupEnabled.DefaultValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #510

Changed the default value of `BackupEnabled` from `true` to `false`. Backup is now opt-in rather than opt-out, reducing unnecessary I/O and storage consumption for users who don't require rollback capability.

## Changes

| File | Change |
|---|---|
| `src/c#/GeneralUpdate.Core/Configuration/Option.cs` | `Option.BackupEnabled` default: `true` → `false` |
| `src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs` | `BackupConfig.Enabled` default: `true` → `false` |
| `src/c#/GeneralUpdate.Core/Configuration/UpdateContext.cs` | XML doc comment updated |

## Migration

Users who need backup can enable it via:

**Code:**
```csharp
configInfo.BackupEnabled = true;
```

**Environment variable:**
```ini
BACKUP=true
```

Rollback via backup remains fully functional when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)