### PR TITLE
fix: code audit — BSDIFF overflow, Zip traversal, ProcessExit deadlock, Trace listener, Strategy lifecycle, HubConnection, RetryPolicy

### DIFF
--- a/src/c#/GeneralUpdate.Core/Compress/ZipCompressionStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Compress/ZipCompressionStrategy.cs
@@ -153,9 +153,12 @@ public class ZipCompressionStrategy : ICompressionStrategy
                 }
 
                 // Guard against path-traversal entries (e.g. "../../evil.exe")
-                var filePath = directoryInfo + entryFilePath;
+                var filePath = Path.Combine(unZipDir, entryFilePath);
                 var fullTargetPath = Path.GetFullPath(filePath);
-                if (!fullTargetPath.StartsWith(extractionRoot, StringComparison.OrdinalIgnoreCase))
+                var rootWithSep = extractionRoot.EndsWith(dirSeparatorChar)
+                    ? extractionRoot
+                    : extractionRoot + dirSeparatorChar;
+                if (!fullTargetPath.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase))
                     throw new InvalidDataException(
                         $"Zip entry path traversal detected: {entries.FullName} resolves outside extraction directory.");
 

--- a/src/c#/GeneralUpdate.Core/Compress/ZipCompressionStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Compress/ZipCompressionStrategy.cs
@@ -47,8 +47,12 @@ public class ZipCompressionStrategy : ICompressionStrategy
                         var toDelArchives = new List<ZipArchiveEntry>();
                         foreach (var zipArchiveEntry in archive.Entries)
                         {
+                            // Exact match to avoid ambiguity (e.g. "foo.dll" should not match "foobar.dll").
+                            // For directory entries, also match "subdir/" prefix so nested files are replaced.
                             if (toZipedFileName != null &&
-                                (zipArchiveEntry.FullName.StartsWith(toZipedFileName) || toZipedFileName.StartsWith(zipArchiveEntry.FullName)))
+                                (zipArchiveEntry.FullName == toZipedFileName ||
+                                 zipArchiveEntry.FullName.StartsWith(toZipedFileName + "/", StringComparison.Ordinal) ||
+                                 toZipedFileName.StartsWith(zipArchiveEntry.FullName, StringComparison.Ordinal)))
                             {
                                 toDelArchives.Add(zipArchiveEntry);
                             }
@@ -83,7 +87,9 @@ public class ZipCompressionStrategy : ICompressionStrategy
                         foreach (var zipArchiveEntry in archive.Entries)
                         {
                             if (toZipedFileName != null
-                                && (zipArchiveEntry.FullName.StartsWith(toZipedFileName) || toZipedFileName.StartsWith(zipArchiveEntry.FullName)))
+                                && (zipArchiveEntry.FullName == toZipedFileName ||
+                                    zipArchiveEntry.FullName.StartsWith(toZipedFileName + "/", StringComparison.Ordinal) ||
+                                    toZipedFileName.StartsWith(zipArchiveEntry.FullName, StringComparison.Ordinal)))
                             {
                                 toDelArchives.Add(zipArchiveEntry);
                             }
@@ -131,6 +137,8 @@ public class ZipCompressionStrategy : ICompressionStrategy
                 return;
             }
 
+            var extractionRoot = Path.GetFullPath(unZipDir);
+
             using var zipToOpen = new FileStream(zipFilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
             using var archive = new ZipArchive(zipToOpen, ZipArchiveMode.Read, false, encoding);
             for (int i = 0; i < archive.Entries.Count; i++)
@@ -144,20 +152,26 @@ public class ZipCompressionStrategy : ICompressionStrategy
                     continue;
                 }
 
+                // Guard against path-traversal entries (e.g. "../../evil.exe")
                 var filePath = directoryInfo + entryFilePath;
-                var greatFolder = Directory.GetParent(filePath);
+                var fullTargetPath = Path.GetFullPath(filePath);
+                if (!fullTargetPath.StartsWith(extractionRoot, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidDataException(
+                        $"Zip entry path traversal detected: {entries.FullName} resolves outside extraction directory.");
+
+                var greatFolder = Directory.GetParent(fullTargetPath);
                 if (greatFolder is not null && !greatFolder.Exists)
                 {
                     greatFolder.Create();
                 }
 
-                if (File.Exists(filePath))
+                if (File.Exists(fullTargetPath))
                 {
-                    File.SetAttributes(filePath, FileAttributes.Normal);
-                    File.Delete(filePath);
+                    File.SetAttributes(fullTargetPath, FileAttributes.Normal);
+                    File.Delete(fullTargetPath);
                 }
 
-                entries.ExtractToFile(filePath);
+                entries.ExtractToFile(fullTargetPath);
             }
         }
         catch (Exception exception)

--- a/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
@@ -72,13 +72,12 @@ namespace GeneralUpdate.Core.Configuration
         /// </returns>
         public static UpdateContext MapToUpdateContext(UpdateRequest source, UpdateContext target = null)
         {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source), "UpdateRequest source cannot be null — configuration would be empty.");
+
             // 如果 source 和 target 均未提供，则创建新实例
             if (target == null)
                 target = new UpdateContext();
-
-            // 如果 source 为 null，则直接返回空的 target
-            if (source == null)
-                return target;
 
             // 映射基类公共字段
             target.UpdateAppName = source.UpdateAppName;

--- a/src/c#/GeneralUpdate.Core/Configuration/ProcessContract.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ProcessContract.cs
@@ -184,8 +184,8 @@ namespace GeneralUpdate.Core.Configuration
         {
             // Validate required string parameters
             AppName = appName ?? throw new ArgumentNullException(nameof(appName));
-            if (!Directory.Exists(installPath)) throw new ArgumentException($"{nameof(installPath)} path does not exist ! {installPath}.");
             InstallPath = installPath ?? throw new ArgumentNullException(nameof(installPath));
+            if (!Directory.Exists(installPath)) throw new ArgumentException($"{nameof(installPath)} path does not exist ! {installPath}.");
             CurrentVersion = currentVersion ?? throw new ArgumentNullException(nameof(currentVersion));
             LastVersion = lastVersion ?? throw new ArgumentNullException(nameof(lastVersion));
             UpdateLogUrl = updateLogUrl;

--- a/src/c#/GeneralUpdate.Core/Differential/DefaultDirtyMatcher.cs
+++ b/src/c#/GeneralUpdate.Core/Differential/DefaultDirtyMatcher.cs
@@ -36,8 +36,6 @@ public class DefaultDirtyMatcher : IDirtyMatcher
         var findFile = patchFiles.FirstOrDefault(f =>
         {
             var name = Path.GetFileNameWithoutExtension(f.Name);
-            if (name.EndsWith(PatchFormat, System.StringComparison.OrdinalIgnoreCase))
-                name = name.Substring(0, name.Length - PatchFormat.Length);
             return name.Equals(oldFile.Name, System.StringComparison.OrdinalIgnoreCase);
         });
 

--- a/src/c#/GeneralUpdate.Core/Download/Policy/DefaultRetryPolicy.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Policy/DefaultRetryPolicy.cs
@@ -127,8 +127,10 @@ public class DefaultRetryPolicy : IDownloadPolicy
     /// </remarks>
     private static bool IsRetryable(Exception ex)
     {
-        if (ex is OperationCanceledException) return false;
+        // TaskCanceledException derives from OperationCanceledException,
+        // so check it first — timeouts should be retryable.
         if (ex is TaskCanceledException or TimeoutException) return true;
+        if (ex is OperationCanceledException) return false;
         if (ex is IOException) return true;
         if (ex is HttpRequestException hre)
         {
@@ -143,7 +145,7 @@ public class DefaultRetryPolicy : IDownloadPolicy
             var s = hre.Message ?? "";
             return s.Contains("timeout", StringComparison.OrdinalIgnoreCase)
                 || s.Contains("timed out", StringComparison.OrdinalIgnoreCase)
-                || Regex.IsMatch(s, @"\b(500|502|503|504)\b");
+                || Regex.IsMatch(s, @"\b(500|502|503|504)\b(?![\d./])");
         }
         return false;
     }

--- a/src/c#/GeneralUpdate.Core/Download/Policy/DefaultRetryPolicy.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Policy/DefaultRetryPolicy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Download.Abstractions;
@@ -131,11 +132,18 @@ public class DefaultRetryPolicy : IDownloadPolicy
         if (ex is IOException) return true;
         if (ex is HttpRequestException hre)
         {
+#if NET5_0_OR_GREATER
+            var statusCode = hre.StatusCode;
+            if (statusCode.HasValue)
+                return statusCode.Value == System.Net.HttpStatusCode.InternalServerError
+                    || statusCode.Value == System.Net.HttpStatusCode.BadGateway
+                    || statusCode.Value == System.Net.HttpStatusCode.ServiceUnavailable
+                    || statusCode.Value == System.Net.HttpStatusCode.GatewayTimeout;
+#endif
             var s = hre.Message ?? "";
             return s.Contains("timeout", StringComparison.OrdinalIgnoreCase)
                 || s.Contains("timed out", StringComparison.OrdinalIgnoreCase)
-                || s.Contains("500") || s.Contains("502")
-                || s.Contains("503") || s.Contains("504");
+                || Regex.IsMatch(s, @"\b(500|502|503|504)\b");
         }
         return false;
     }

--- a/src/c#/GeneralUpdate.Core/Event/EventManager.cs
+++ b/src/c#/GeneralUpdate.Core/Event/EventManager.cs
@@ -33,7 +33,7 @@ namespace GeneralUpdate.Core.Event
     /// </remarks>
     public class EventManager : IDisposable
     {
-        private static readonly Lazy<EventManager> _lazy = new(() => new EventManager());
+        private static volatile Lazy<EventManager> _lazy = new(() => new EventManager());
         private ConcurrentDictionary<Type, Delegate> _dicDelegates = new();
         private bool _disposed;
 
@@ -47,6 +47,15 @@ namespace GeneralUpdate.Core.Event
         /// Uses <see cref="Lazy{T}"/> for thread-safe lazy initialization.
         /// </remarks>
         public static EventManager Instance => _lazy.Value;
+
+        /// <summary>
+        /// Creates a fresh singleton instance, discarding all previously registered listeners.
+        /// Called when the update lifecycle ends and a clean slate is needed.
+        /// </summary>
+        public static void Reset()
+        {
+            _lazy = new Lazy<EventManager>(() => new EventManager());
+        }
 
         /// <summary>
         /// Registers a listener for a specified event type.

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using GeneralUpdate.Core.HashAlgorithms;
+using GeneralUpdate.Core;
 
 namespace GeneralUpdate.Core.FileSystem
 {
@@ -329,8 +330,9 @@ namespace GeneralUpdate.Core.FileSystem
 
                 return files;
             }
-            catch
+            catch (Exception ex)
             {
+                GeneralTracer.Warn($"StorageManager.GetAllFiles failed for path '{path}': {ex.Message}");
                 return new List<FileInfo>();
             }
         }
@@ -358,8 +360,9 @@ namespace GeneralUpdate.Core.FileSystem
 
                 return files;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                GeneralTracer.Warn($"StorageManager.GetAllfiles failed for path '{path}': {ex.Message}");
                 return new List<FileInfo>();
             }
         }

--- a/src/c#/GeneralUpdate.Core/Hubs/UpgradeHubService.cs
+++ b/src/c#/GeneralUpdate.Core/Hubs/UpgradeHubService.cs
@@ -18,6 +18,7 @@ public class UpgradeHubService : IUpgradeHubService
     private const string Onlineflag = "Online";
     private const string ReceiveMessageflag = "ReceiveMessage";
     private HubConnection? _connection;
+    private bool _disposed;
 
     public UpgradeHubService(string url, string? token = null, string? appkey = null)
         => _connection = BuildHubConnection(url, token, appkey);
@@ -47,24 +48,40 @@ public class UpgradeHubService : IUpgradeHubService
         => _connection?.On(Onlineflag, onlineMessageCallback);
 
     public void AddListenerReconnected(Func<string?, Task>? reconnectedCallback)
-        => _connection!.Reconnected += reconnectedCallback;
+    {
+        if (_disposed || _connection == null) return;
+        _connection.Reconnected += reconnectedCallback;
+    }
 
     public void AddListenerClosed(Func<Exception?, Task> closeCallback)
-        => _connection!.Closed += closeCallback;
+    {
+        if (_disposed || _connection == null) return;
+        _connection.Closed += closeCallback;
+    }
 
     public async Task StartAsync()
     {
+        if (_disposed || _connection == null)
+        {
+            GeneralTracer.Warn("UpgradeHubService.StartAsync: service is disposed or not connected.");
+            return;
+        }
         GeneralTracer.Info($"UpgradeHubService.StartAsync: connecting to SignalR hub. State={_connection?.State}");
-        await _connection!.StartAsync();
+        await _connection.StartAsync();
         GeneralTracer.Info($"UpgradeHubService.StartAsync: SignalR hub connection established. State={_connection?.State}");
     }
 
     public async Task StopAsync()
     {
+        if (_disposed || _connection == null)
+        {
+            GeneralTracer.Warn("UpgradeHubService.StopAsync: service is disposed or not connected.");
+            return;
+        }
         try
         {
             GeneralTracer.Info($"UpgradeHubService.StopAsync: stopping SignalR hub connection. State={_connection?.State}");
-            await _connection!.StopAsync();
+            await _connection.StopAsync();
             GeneralTracer.Info("UpgradeHubService.StopAsync: SignalR hub connection stopped.");
         }
         catch (Exception e)
@@ -75,11 +92,17 @@ public class UpgradeHubService : IUpgradeHubService
 
     public async Task DisposeAsync()
     {
+        if (_disposed) return;
+        _disposed = true;
         try
         {
-            GeneralTracer.Info("UpgradeHubService.DisposeAsync: disposing SignalR hub connection and releasing resources.");
-            await _connection!.DisposeAsync();
-            GeneralTracer.Info("UpgradeHubService.DisposeAsync: SignalR hub connection disposed.");
+            if (_connection != null)
+            {
+                GeneralTracer.Info("UpgradeHubService.DisposeAsync: disposing SignalR hub connection and releasing resources.");
+                await _connection.DisposeAsync();
+                _connection = null;
+                GeneralTracer.Info("UpgradeHubService.DisposeAsync: SignalR hub connection disposed.");
+            }
         }
         catch (Exception e)
         {

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -65,7 +65,7 @@ namespace GeneralUpdate.Core.Network
     public class VersionService
     {
         private static readonly HttpClient _sharedClient;
-        private static ISslValidationPolicy _globalSslPolicy = new StrictSslValidationPolicy();
+        private static volatile ISslValidationPolicy _globalSslPolicy = new StrictSslValidationPolicy();
         private static IHttpAuthProvider? _globalAuthProvider;
 
         private readonly IHttpAuthProvider _auth;

--- a/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Differential;
@@ -523,7 +524,10 @@ public class DiffPipeline
                 // Using StartsWith + Substring instead of string.Replace to avoid
                 // incorrect replacements when appPath is a substring of patchPath.
                 var patchPrefix = patchPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-                var relativePart = file.FullName.StartsWith(patchPrefix, StringComparison.Ordinal)
+                var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+                var relativePart = file.FullName.StartsWith(patchPrefix, comparison)
                     ? file.FullName.Substring(patchPrefix.Length)
                     : file.FullName;
                 var targetPath = Path.Combine(appPath, relativePart);

--- a/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/DiffPipeline.cs
@@ -445,7 +445,7 @@ public class DiffPipeline
     /// deletion failures caused by read-only attributes.
     /// </para>
     /// </remarks>
-    private static void HandleDeleteList(IEnumerable<FileInfo> patchFiles, IEnumerable<FileInfo> oldFiles)
+    private static void HandleDeleteList(IEnumerable<FileInfo> patchFiles, List<FileInfo> oldFiles)
     {
         var json = patchFiles.FirstOrDefault(i => i.Name.Equals(DeleteListFileName, StringComparison.OrdinalIgnoreCase));
         if (json == null) return;
@@ -453,16 +453,34 @@ public class DiffPipeline
         var deleteFiles = StorageManager.GetJson<List<FileNode>>(json.FullName, FileNodesJsonContext.Default.ListFileNode);
         if (deleteFiles == null) return;
 
-        var hashAlgorithm = new Sha256HashAlgorithm();
-        var toDelete = oldFiles
-            .Where(old => deleteFiles.Any(del => del.Hash.SequenceEqual(hashAlgorithm.ComputeHash(old.FullName))))
-            .ToList();
+        // Build a HashSet of delete-manifest hashes (hex strings from FileNode.Hash)
+        // so each oldFile is checked in O(1) instead of O(n × m).
+        var deleteHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var del in deleteFiles)
+        {
+            if (!string.IsNullOrEmpty(del.Hash))
+                deleteHashes.Add(del.Hash);
+        }
+        if (deleteHashes.Count == 0) return;
 
-        foreach (var file in toDelete)
+        // Exclude .patch files from oldFiles — they are patch input, not app files.
+        var appFiles = oldFiles
+            .Where(f => !Path.GetExtension(f.FullName)
+                .Equals(PatchExtension, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (appFiles.Count == 0) return;
+
+        var hashAlgorithm = new Sha256HashAlgorithm();
+        foreach (var file in appFiles)
         {
             if (!File.Exists(file.FullName)) continue;
-            File.SetAttributes(file.FullName, FileAttributes.Normal);
-            File.Delete(file.FullName);
+
+            var fileHash = hashAlgorithm.ComputeHash(file.FullName);
+            if (fileHash != null && deleteHashes.Contains(fileHash))
+            {
+                File.SetAttributes(file.FullName, FileAttributes.Normal);
+                File.Delete(file.FullName);
+            }
         }
     }
 
@@ -501,15 +519,21 @@ public class DiffPipeline
                 var extensionName = Path.GetExtension(file.FullName);
                 if (BlackDefaults.DefaultFormats.Contains(extensionName)) continue;
 
-                var targetFileName = file.FullName.Replace(patchPath, "").TrimStart(Path.DirectorySeparatorChar);
-                var targetPath = Path.Combine(appPath, targetFileName);
+                // Compute the relative path by stripping the patch directory prefix.
+                // Using StartsWith + Substring instead of string.Replace to avoid
+                // incorrect replacements when appPath is a substring of patchPath.
+                var patchPrefix = patchPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                var relativePart = file.FullName.StartsWith(patchPrefix, StringComparison.Ordinal)
+                    ? file.FullName.Substring(patchPrefix.Length)
+                    : file.FullName;
+                var targetPath = Path.Combine(appPath, relativePart);
                 var parentFolder = Directory.GetParent(targetPath);
                 if (parentFolder?.Exists == false)
                     parentFolder.Create();
 
                 // Atomic replace via temp file, same strategy as ApplyPatch.
                 // Avoids file-in-use errors when the process just exited.
-                var safeName = targetFileName.Replace(Path.DirectorySeparatorChar, '_');
+                var safeName = relativePart.Replace(Path.DirectorySeparatorChar, '_');
                 var tempPath = Path.Combine(appPath, $"{Path.GetRandomFileName()}_{safeName}");
                 File.Copy(file.FullName, tempPath, true);
 

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -144,11 +144,16 @@ namespace GeneralUpdate.Core.Strategy
             {
                 AllPackagesSucceeded = true;
                 var status = ReportType.None;
-                var patchPath = StorageManager.GetTempDirectory(Patchs);
+                var patchRoot = StorageManager.GetTempDirectory(Patchs);
                 foreach (var version in _configinfo.UpdateVersions)
                 {
                     try
                     {
+                        // Use a version-specific subdirectory under patchRoot so that
+                        // chain packages do not overwrite each other's extracted patches.
+                        // patchRoot is cleaned as a whole after the loop.
+                        var versionName = Path.GetFileNameWithoutExtension(version.Name) ?? version.Name;
+                        var patchPath = Path.Combine(patchRoot, versionName);
                         var context = CreatePipelineContext(version, patchPath);
                         var pipelineBuilder = BuildPipeline(context);
                         await pipelineBuilder.Build();
@@ -171,7 +176,7 @@ namespace GeneralUpdate.Core.Strategy
                     }
                 }
 
-                Clear(patchPath);
+                Clear(patchRoot);
                 TryCleanTempPath();
                 await OnExecuteCompleteAsync();
             }

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -772,8 +772,11 @@ public class ClientStrategy : IStrategy
         // Run the pre-launch lifecycle hook (e.g. UnixPermissionHooks for chmod +x).
         // In the standard flow this runs inside ExecuteStandardWorkflowAsync; in
         // silent mode it was deferred and must run now, before the process starts.
+        //
+        // Use Task.Run to offload from the current SynchronizationContext and avoid
+        // deadlock when called from AppDomain.ProcessExit (a synchronous event).
         var ctx = BuildUpdateContext();
-        SafeOnBeforeStartAppAsync(ctx).GetAwaiter().GetResult();
+        Task.Run(() => SafeOnBeforeStartAppAsync(ctx)).GetAwaiter().GetResult();
 
         if (_osStrategy is AbstractStrategy abs)
         {

--- a/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/LinuxStrategy.cs
@@ -98,6 +98,7 @@ public class LinuxStrategy : AbstractStrategy
     /// </remarks>
     public override async Task StartAppAsync()
     {
+        var appLaunched = false;
         try
         {
             var appName = LaunchAppName ?? throw new InvalidOperationException("LaunchAppName must be set before calling StartAppAsync.");
@@ -107,6 +108,7 @@ public class LinuxStrategy : AbstractStrategy
 
             GeneralTracer.Info($"GeneralUpdate.Core.LinuxStrategy.StartApp: launching app={appPath}");
             Process.Start(appPath);
+            appLaunched = true;
             GeneralTracer.Info("GeneralUpdate.Core.LinuxStrategy.StartApp: app launched successfully.");
         }
         catch (Exception e)
@@ -114,8 +116,14 @@ public class LinuxStrategy : AbstractStrategy
             GeneralTracer.Error(
                 "The StartApp method in the GeneralUpdate.Core.LinuxStrategy class throws an exception.", e);
             EventManager.Instance.Dispatch(this, new ExceptionEventArgs(e, e.Message));
+
+            // If the main app was already launched, still need to exit the updater.
+            if (!appLaunched) return;
         }
-        finally
+
+        // Only terminate the updater when the main app was launched.
+        // On error before launch, stay alive so callers can attempt recovery.
+        if (appLaunched)
         {
             GeneralTracer.Info("GeneralUpdate.Core.LinuxStrategy.StartApp: releasing tracer and terminating updater process.");
             GeneralTracer.Dispose();

--- a/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
@@ -66,6 +66,7 @@ public class MacStrategy : AbstractStrategy
     /// </remarks>
     public override async Task StartAppAsync()
     {
+        var launchedOrCompleted = false;
         try
         {
             var appName = LaunchAppName ?? throw new InvalidOperationException("LaunchAppName must be set before calling StartAppAsync.");
@@ -76,18 +77,27 @@ public class MacStrategy : AbstractStrategy
                 GeneralTracer.Info($"MacStrategy.StartApp: launching app={mainApp}");
                 System.Diagnostics.Process.Start(mainApp);
             }
+            else
+            {
+                GeneralTracer.Info("MacStrategy.StartApp: no app to launch (app path not found or empty).");
+            }
+
+            launchedOrCompleted = true;
         }
         catch (Exception e)
         {
             GeneralTracer.Error("The StartApp method in MacStrategy threw an exception.", e);
             EventManager.Instance.Dispatch(this, new ExceptionEventArgs(e, e.Message));
+
+            // If the main app was already launched, still need to exit the updater.
+            if (!launchedOrCompleted) return;
         }
-        finally
-        {
-            GeneralTracer.Info("MacStrategy.StartApp: releasing tracer and terminating updater process.");
-            GeneralTracer.Dispose();
-            await GracefulExit.CurrentProcessAsync();
-        }
+
+        // Terminate the updater when the main app was launched OR when there was
+        // no app to launch at all (both are normal terminal states for the updater).
+        GeneralTracer.Info("MacStrategy.StartApp: releasing tracer and terminating updater process.");
+        GeneralTracer.Dispose();
+        await GracefulExit.CurrentProcessAsync();
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
@@ -97,6 +97,7 @@ namespace GeneralUpdate.Core.Strategy
         /// </remarks>
         public override async Task StartAppAsync()
         {
+            var appLaunched = false;
             try
             {
                 var appName = LaunchAppName ?? throw new InvalidOperationException("LaunchAppName must be set before calling StartAppAsync.");
@@ -106,6 +107,7 @@ namespace GeneralUpdate.Core.Strategy
 
                 GeneralTracer.Info($"GeneralUpdate.Core.WindowsStrategy.StartApp: launching app={appPath}");
                 Process.Start(appPath);
+                appLaunched = true;
                 GeneralTracer.Info("GeneralUpdate.Core.WindowsStrategy.StartApp: app launched successfully.");
 
                 if (LaunchBowl)
@@ -122,8 +124,14 @@ namespace GeneralUpdate.Core.Strategy
             {
                 GeneralTracer.Error("The StartApp method in the GeneralUpdate.Core.WindowsStrategy class throws an exception.", e);
                 EventManager.Instance.Dispatch(this, new ExceptionEventArgs(e, e.Message));
+
+                // If the main app was already launched, still need to exit the updater.
+                if (!appLaunched) return;
             }
-            finally
+
+            // Only terminate the updater when the main app was launched.
+            // On error before launch, stay alive so callers can attempt recovery.
+            if (appLaunched)
             {
                 GeneralTracer.Info("GeneralUpdate.Core.WindowsStrategy.StartApp: releasing tracer and terminating updater process.");
                 GeneralTracer.Dispose();

--- a/src/c#/GeneralUpdate.Core/Tracer/GeneralTracer.cs
+++ b/src/c#/GeneralUpdate.Core/Tracer/GeneralTracer.cs
@@ -11,22 +11,33 @@ public static class GeneralTracer
     private static bool _isTracingEnabled;
     private static string _currentLogDate;
     private static TextTraceListener _fileListener;
-  
+    // Track listeners added by GeneralTracer so Dispose() only removes our own,
+    // preserving listeners registered by other libraries in the process.
+    private static readonly List<TraceListener> _ownedListeners = new();
+
     static GeneralTracer()
     {
         Trace.Listeners.Clear();
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Trace.Listeners.Add(new WindowsOutputDebugListener());
+            var debugListener = new WindowsOutputDebugListener();
+            Trace.Listeners.Add(debugListener);
+            _ownedListeners.Add(debugListener);
         }
 
-        Trace.Listeners.Add(new TextWriterTraceListener(Console.Out) { Name = "ConsoleListener" });
-        
+        var consoleListener = new TextWriterTraceListener(Console.Out) { Name = "ConsoleListener" };
+        Trace.Listeners.Add(consoleListener);
+        _ownedListeners.Add(consoleListener);
+
         InitializeFileListener();
 
         if (Debugger.IsAttached)
-            Trace.Listeners.Add(new DefaultTraceListener());
+        {
+            var defaultListener = new DefaultTraceListener();
+            Trace.Listeners.Add(defaultListener);
+            _ownedListeners.Add(defaultListener);
+        }
 
         Trace.AutoFlush = true;
         _isTracingEnabled = true;
@@ -44,6 +55,7 @@ public static class GeneralTracer
             if (_fileListener != null)
             {
                 Trace.Listeners.Remove(_fileListener);
+                _ownedListeners.Remove(_fileListener);
                 _fileListener.Flush();
                 _fileListener.Close();
                 _fileListener.Dispose();
@@ -56,6 +68,7 @@ public static class GeneralTracer
             _fileListener = new TextTraceListener(logFileName);
 
             Trace.Listeners.Add(_fileListener);
+            _ownedListeners.Add(_fileListener);
             _currentLogDate = today;
         }
     }
@@ -155,7 +168,11 @@ public static class GeneralTracer
                     _fileListener = null;
                 }
 
-                Trace.Listeners.Clear();
+                // Remove only the listeners that GeneralTracer added, preserving
+                // listeners registered by other libraries in the same process.
+                foreach (var listener in _ownedListeners)
+                    Trace.Listeners.Remove(listener);
+                _ownedListeners.Clear();
             }
         }
         catch

--- a/src/c#/GeneralUpdate.Core/Tracer/GeneralTracer.cs
+++ b/src/c#/GeneralUpdate.Core/Tracer/GeneralTracer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -17,7 +18,9 @@ public static class GeneralTracer
 
     static GeneralTracer()
     {
-        Trace.Listeners.Clear();
+        // Do NOT call Trace.Listeners.Clear() here — other libraries in the
+        // process may have registered their own TraceListeners. GeneralTracer
+        // only manages the listeners it adds itself via _ownedListeners.
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/src/c#/GeneralUpdate.Differential/Differ/BsdiffDiffer.cs
+++ b/src/c#/GeneralUpdate.Differential/Differ/BsdiffDiffer.cs
@@ -379,6 +379,9 @@ namespace GeneralUpdate.Differential.Differ
                                 // Sanity-check
                                 if (newPosition + control[0] > newSize)
                                     throw new InvalidOperationException("Corrupt patch: diff data exceeds new file size.");
+                                if (control[0] > int.MaxValue)
+                                    throw new InvalidDataException(
+                                        $"Corrupt patch: diff block length {control[0]} exceeds maximum supported size ({int.MaxValue}).");
 
                                 // Seek old file to the position that the new data is diffed against
                                 input.Position = oldPosition;
@@ -392,8 +395,9 @@ namespace GeneralUpdate.Differential.Differ
                                     ReadExactly(diffStream, newData, 0, actualBytesToCopy);
 
                                     // Add old data to diff string
+                                    var remainingInput = input.Length - input.Position;
                                     int availableInputBytes = Math.Min(actualBytesToCopy,
-                                        (int)(input.Length - input.Position));
+                                        remainingInput > int.MaxValue ? int.MaxValue : (int)remainingInput);
                                     ReadExactly(input, oldData, 0, availableInputBytes);
 
                                     for (int index = 0; index < availableInputBytes; index++)
@@ -410,6 +414,9 @@ namespace GeneralUpdate.Differential.Differ
                                 // Sanity-check
                                 if (newPosition + control[1] > newSize)
                                     throw new InvalidOperationException("Corrupt patch: extra data exceeds new file size.");
+                                if (control[1] > int.MaxValue)
+                                    throw new InvalidDataException(
+                                        $"Corrupt patch: extra block length {control[1]} exceeds maximum supported size ({int.MaxValue}).");
 
                                 // Read extra string
                                 bytesToCopy = (int)control[1];
@@ -424,8 +431,12 @@ namespace GeneralUpdate.Differential.Differ
                                     bytesToCopy -= actualBytesToCopy;
                                 }
 
-                                // Adjust position in old file
-                                oldPosition = (int)(oldPosition + control[2]);
+                                // Adjust position in old file (clamp to int range)
+                                var newOldPosition = oldPosition + control[2];
+                                if (newOldPosition > int.MaxValue || newOldPosition < 0)
+                                    throw new InvalidDataException(
+                                        $"Corrupt patch: seek offset overflows int: {newOldPosition}.");
+                                oldPosition = (int)newOldPosition;
                             }
                         }
                     }
@@ -688,7 +699,9 @@ namespace GeneralUpdate.Differential.Differ
         /// </summary>
         private static void WriteInt64(long value, byte[] buf, int offset)
         {
-            long magnitude = value < 0 ? -value : value;
+            // Compute absolute value safely: -long.MinValue would overflow,
+            // so clamp to long.MaxValue — the sign bit is stored separately.
+            long magnitude = value == long.MinValue ? long.MaxValue : (value < 0 ? -value : value);
             buf[offset + 0] = (byte)(magnitude & 0xFF);
             buf[offset + 1] = (byte)((magnitude >> 8) & 0xFF);
             buf[offset + 2] = (byte)((magnitude >> 16) & 0xFF);

--- a/src/c#/GeneralUpdate.Differential/Differ/BsdiffDiffer.cs
+++ b/src/c#/GeneralUpdate.Differential/Differ/BsdiffDiffer.cs
@@ -696,12 +696,16 @@ namespace GeneralUpdate.Differential.Differ
         /// Writes a 64-bit signed integer in BSDIFF sign-magnitude encoding.
         /// Bytes 0-6: magnitude bits 0-55. Byte 7 lower 7 bits: magnitude bits 56-62.
         /// Byte 7 upper bit: sign flag (1 = negative).
+        /// Throws <see cref="ArgumentOutOfRangeException"/> when <paramref name="value"/>
+        /// is <see cref="long.MinValue"/> because BSDIFF sign-magnitude encoding cannot
+        /// represent -2^63 (requires a 64th magnitude bit).
         /// </summary>
         private static void WriteInt64(long value, byte[] buf, int offset)
         {
-            // Compute absolute value safely: -long.MinValue would overflow,
-            // so clamp to long.MaxValue — the sign bit is stored separately.
-            long magnitude = value == long.MinValue ? long.MaxValue : (value < 0 ? -value : value);
+            if (value == long.MinValue)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"{nameof(WriteInt64)} cannot encode long.MinValue ({long.MinValue}) in BSDIFF sign-magnitude format.");
+            long magnitude = value < 0 ? -value : value;
             buf[offset + 0] = (byte)(magnitude & 0xFF);
             buf[offset + 1] = (byte)((magnitude >> 8) & 0xFF);
             buf[offset + 2] = (byte)((magnitude >> 16) & 0xFF);

--- a/src/c#/GeneralUpdate.Differential/Differ/StreamingHdiffDiffer.cs
+++ b/src/c#/GeneralUpdate.Differential/Differ/StreamingHdiffDiffer.cs
@@ -465,9 +465,11 @@ namespace GeneralUpdate.Differential.Differ
 
         private static void WriteInt64(long value, byte[] buf, int offset)
         {
-            // Compute absolute value safely: -long.MinValue would overflow,
-            // so clamp to long.MaxValue — the sign bit is stored separately.
-            long magnitude = value == long.MinValue ? long.MaxValue : (value < 0 ? -value : value);
+            // BSDIFF sign-magnitude encoding cannot represent -2^63.
+            if (value == long.MinValue)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"{nameof(WriteInt64)} cannot encode long.MinValue ({long.MinValue}) in BSDIFF sign-magnitude format.");
+            long magnitude = value < 0 ? -value : value;
             buf[offset + 0] = (byte)(magnitude & 0xFF);
             buf[offset + 1] = (byte)((magnitude >> 8) & 0xFF);
             buf[offset + 2] = (byte)((magnitude >> 16) & 0xFF);

--- a/src/c#/GeneralUpdate.Differential/Differ/StreamingHdiffDiffer.cs
+++ b/src/c#/GeneralUpdate.Differential/Differ/StreamingHdiffDiffer.cs
@@ -433,8 +433,19 @@ namespace GeneralUpdate.Differential.Differ
             if (string.IsNullOrWhiteSpace(patchPath)) throw new ArgumentNullException(nameof(patchPath));
         }
 
+        /// <summary>
+        /// Reads up to <paramref name="maxBytes"/> from the file at <paramref name="path"/>.
+        /// Throws <see cref="InvalidOperationException"/> when the file is larger than <paramref name="maxBytes"/>
+        /// so callers never silently operate on truncated data.
+        /// </summary>
         private static byte[] ReadFileWithBudget(string path, int maxBytes)
         {
+            var fileLength = new FileInfo(path).Length;
+            if (fileLength > maxBytes)
+                throw new InvalidOperationException(
+                    $"File '{path}' is {fileLength} bytes, which exceeds the maximum window size of {maxBytes} bytes. " +
+                    $"Increase MaxWindowSize or reduce the file size.");
+
             byte[] buffer = new byte[maxBytes];
             int totalRead = 0;
             using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -446,8 +457,7 @@ namespace GeneralUpdate.Differential.Differ
                     totalRead += read;
                 }
             }
-            // Trim to actual bytes read so callers using .Length see the real data,
-            // not zero-initialized tail bytes that would corrupt patch computation.
+            // Trim buffer to actual bytes read.
             if (totalRead < maxBytes)
                 Array.Resize(ref buffer, totalRead);
             return buffer;
@@ -455,7 +465,9 @@ namespace GeneralUpdate.Differential.Differ
 
         private static void WriteInt64(long value, byte[] buf, int offset)
         {
-            long magnitude = value < 0 ? -value : value;
+            // Compute absolute value safely: -long.MinValue would overflow,
+            // so clamp to long.MaxValue — the sign bit is stored separately.
+            long magnitude = value == long.MinValue ? long.MaxValue : (value < 0 ? -value : value);
             buf[offset + 0] = (byte)(magnitude & 0xFF);
             buf[offset + 1] = (byte)((magnitude >> 8) & 0xFF);
             buf[offset + 2] = (byte)((magnitude >> 16) & 0xFF);

--- a/tests/CoreTest/Bootstrap/ParameterMatrixAndEventTests.cs
+++ b/tests/CoreTest/Bootstrap/ParameterMatrixAndEventTests.cs
@@ -30,6 +30,7 @@ namespace CoreTest.Bootstrap
         {
             _testDir = Path.Combine(Path.GetTempPath(), $"GU_ParamMatrix_{Guid.NewGuid()}");
             Directory.CreateDirectory(_testDir);
+            EventManager.Reset();
         }
 
         public void Dispose()

--- a/tests/CoreTest/Download/DefaultRetryPolicyTests.cs
+++ b/tests/CoreTest/Download/DefaultRetryPolicyTests.cs
@@ -47,10 +47,9 @@ public class DefaultRetryPolicyTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_TaskCanceledException_IsNotRetryable()
+    public async Task ExecuteAsync_TaskCanceledException_IsRetryable()
     {
-        // TaskCanceledException inherits from OperationCanceledException,
-        // so IsRetryable returns false (not retryable)
+        // TaskCanceledException (e.g. HttpClient timeout) should be retried
         var policy = new DefaultRetryPolicy(3, TimeSpan.FromMilliseconds(10));
         var attempts = 0;
         await Assert.ThrowsAsync<TaskCanceledException>(() =>
@@ -59,7 +58,7 @@ public class DefaultRetryPolicyTests
                 attempts++;
                 throw new TaskCanceledException("timeout");
             }));
-        Assert.Equal(1, attempts); // Not retried
+        Assert.Equal(3, attempts); // Retried up to maxRetries
     }
 
     [Fact]

--- a/tests/CoreTest/Strategy/StrategyCreationTests.cs
+++ b/tests/CoreTest/Strategy/StrategyCreationTests.cs
@@ -1,5 +1,6 @@
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Strategy;
+using GeneralUpdate.Core.Pipeline;
 
 namespace CoreTest.Strategy;
 
@@ -185,6 +186,71 @@ public class AbstractStrategyCheckPathTests
             return string.Empty;
         var tempPath = Path.Combine(path, name);
         return File.Exists(tempPath) ? tempPath : string.Empty;
+    }
+}
+
+/// <summary>
+/// Tests that AbstractStrategy.ExecuteAsync creates per-version subdirectories
+/// for patch paths (regression for R4 — chain packages sharing PatchPath).
+/// </summary>
+public class AbstractStrategyPatchPathTests
+{
+    private sealed class RecordingStrategy : AbstractStrategy
+    {
+        public List<string> RecordedPatchPaths { get; } = new();
+
+        protected override PipelineBuilder BuildPipeline(PipelineContext context)
+        {
+            // Capture what CreatePipelineContext stored as PatchPath
+            RecordedPatchPaths.Add(context.Get<string>("PatchPath"));
+            return new PipelineBuilder(context);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ChainVersions_HaveDistinctPatchPaths()
+    {
+        var strategy = new RecordingStrategy();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"R4Test_{Guid.NewGuid():N}");
+        var tempPath = Path.Combine(tempDir, "tmp");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            Directory.CreateDirectory(tempPath);
+            var config = new UpdateContext
+            {
+                ClientVersion = "1.0.0",
+                InstallPath = tempDir,
+                TempPath = tempPath,
+                Format = Format.Zip,
+                AppSecretKey = "k",
+                UpdateAppName = "Update.exe",
+                MainAppName = "App.exe",
+                PatchEnabled = true,
+                UpdateVersions = new List<VersionEntry>
+                {
+                    new() { Name = "v1.0_to_v1.1", Version = "1.1.0" },
+                    new() { Name = "v1.1_to_v1.2", Version = "1.2.0" },
+                }
+            };
+            strategy.Create(config);
+            await strategy.ExecuteAsync();
+
+            // Each version should have been served a distinct PatchPath subdirectory
+            Assert.Equal(2, strategy.RecordedPatchPaths.Count);
+            Assert.NotEqual(strategy.RecordedPatchPaths[0], strategy.RecordedPatchPaths[1]);
+            // Verify they are siblings under the same root
+            var root1 = Path.GetDirectoryName(strategy.RecordedPatchPaths[0]);
+            var root2 = Path.GetDirectoryName(strategy.RecordedPatchPaths[1]);
+            Assert.NotNull(root1);
+            Assert.NotNull(root2);
+            Assert.Equal(root1, root2);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
     }
 }
 

--- a/tests/DifferentialTest/ComprehensiveDifferentialTests.cs
+++ b/tests/DifferentialTest/ComprehensiveDifferentialTests.cs
@@ -828,6 +828,66 @@ public class ComprehensiveDifferentialTests : IDisposable
     }
 
     // =========================================================================
+    // Section 5: Patch-requested regression tests (R3 / R5)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that CopyUnknownFiles correctly handles a subdirectory structure under patch
+    /// — files in patch/sub/ should land in app/sub/.
+    /// </summary>
+    [Fact]
+    public async Task DirtyAsync_CopyUnknownFiles_SubdirectoryPreserved()
+    {
+        var app = Path.Combine(_testDir, "rf_sub_app");
+        var patch = Path.Combine(_testDir, "rf_sub_patch");
+        var src = Path.Combine(_testDir, "rf_sub_src");
+        var tgt = Path.Combine(_testDir, "rf_sub_tgt");
+        Directory.CreateDirectory(app);
+        Directory.CreateDirectory(patch);
+        Directory.CreateDirectory(src);
+        Directory.CreateDirectory(tgt);
+
+        // Target has files in a subdirectory
+        var tgtSub = Path.Combine(tgt, "plugins");
+        Directory.CreateDirectory(tgtSub);
+        File.WriteAllBytes(Path.Combine(tgtSub, "plug.dll"), [9, 8, 7]);
+
+        var pipeline = new DiffPipelineBuilder().WithParallelism(1).Build();
+        await pipeline.CleanAsync(src, tgt, patch);
+        await pipeline.DirtyAsync(app, patch);
+
+        // Assert: plug.dll is at app / plugins / plug.dll
+        Assert.True(File.Exists(Path.Combine(app, "plugins", "plug.dll")));
+    }
+
+    /// <summary>
+    /// Verifies that CopyUnknownFiles correctly places files when the patch dir path
+    /// is unrelated to the app dir (the normal case after R3 fix).
+    /// </summary>
+    [Fact]
+    public async Task DirtyAsync_CopyUnknownFiles_IndependentPaths()
+    {
+        var app = Path.Combine(_testDir, "cu_indep_app");
+        var patch = Path.Combine(_testDir, "cu_indep_patch");
+        var src = Path.Combine(_testDir, "cu_indep_src");
+        var tgt = Path.Combine(_testDir, "cu_indep_tgt");
+        Directory.CreateDirectory(app);
+        Directory.CreateDirectory(patch);
+        Directory.CreateDirectory(src);
+        Directory.CreateDirectory(tgt);
+
+        // One new file in target (no old files)
+        File.WriteAllBytes(Path.Combine(tgt, "new.dll"), [1, 2, 3]);
+
+        var pipeline = new DiffPipelineBuilder().WithParallelism(1).Build();
+        await pipeline.CleanAsync(src, tgt, patch);
+        await pipeline.DirtyAsync(app, patch);
+
+        Assert.True(File.Exists(Path.Combine(app, "new.dll")));
+        Assert.Equal([1, 2, 3], File.ReadAllBytes(Path.Combine(app, "new.dll")));
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 


### PR DESCRIPTION
## Summary

Fixes **~25 bugs** from full code audit across GeneralUpdate.Core and GeneralUpdate.Differential.

### 🔴 Critical
- **BSDIFF** `WriteInt64` `long.MinValue` overflow (BsdiffDiffer + StreamingHdiffDiffer)
- **BSDIFF** `(int)control[0]` truncation in Dirty method — data loss on patches >2GB
- **BSDIFF** `ReadFileWithBudget` silently truncates files >128MB
- **Zip** decompress path traversal (no guard on `../../evil.exe`)
- **Zip** `StartsWith` fuzzy match — `foo.dll` matches `foobar.dll`

### 🟠 High
- **ProcessExit deadlock** — `GetAwaiter().GetResult()` in sync handler (WPF/WinForms)
- **Strategy suicide** — `finally` kills updater on app launch failure, blocking recovery
- **`Trace.Listeners.Clear()`** — GeneralTracer.Dispose nukes other libraries' trace output
- **`ProcessContract`** — null check order: `Directory.Exists(null)` before null guard
- **`UpgradeHubService`** — `DisposeAsync` doesn't null `_connection` → NRE on reconnect
- **`ConfigurationMapper`** — null source returns empty config silently
- **`DefaultRetryPolicy`** — `s.Contains(\"500\")` matches URL paths, not just status codes

### 🟡 Medium
- **`EventManager`** — added `Reset()` for re-creatable singleton

Closes #514