### PR TITLE
feat(core): unified HTTP auth provider + custom headers + CVP fix

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -14,6 +14,7 @@ using GeneralUpdate.Core.Strategy;
 using GeneralUpdate.Core.Ipc;
 using GeneralUpdate.Core.Differential;
 using GeneralUpdate.Core.Pipeline;
+using GeneralUpdate.Core.Network;
 using GeneralUpdate.Differential.Differ;
 
 namespace GeneralUpdate.Core;
@@ -197,6 +198,14 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
     {
         configInfo.Validate();
         _configInfo = ConfigurationMapper.MapToUpdateContext(configInfo);
+
+        // Sync custom headers to the global HTTP client so they are applied
+        // to every request (Verification + Report) without manual extra setup.
+        if (_configInfo.CustomHeaders is { Count: > 0 })
+        {
+            foreach (var kv in _configInfo.CustomHeaders)
+                HttpClientProvider.ExtraHeaders[kv.Key] = kv.Value;
+        }
 
         var appType = GetOption(Option.AppType);
         if (appType != AppType.Upgrade)

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -89,6 +89,7 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
     private CancellationTokenSource? _cts;
     private DiffPipelineBuilder? _diffPipelineBuilder;
     private Silent.SilentPollOrchestrator? _silentOrchestrator;
+    private List<string> _syncedCustomHeaders = new();
 
     /// <summary>
     /// When silent mode is active, provides access to the background polling orchestrator.
@@ -201,10 +202,19 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
         // Sync custom headers to the global HTTP client so they are applied
         // to every request (Verification + Report) without manual extra setup.
+        // First clear stale headers from a previous SetConfig call, then apply
+        // the current ones — avoids leaking headers between bootstrap instances.
+        var oldHeaders = _syncedCustomHeaders;
+        _syncedCustomHeaders = new List<string>();
+        foreach (var key in oldHeaders)
+            HttpClientProvider.ExtraHeaders.TryRemove(key, out _);
         if (_configInfo.CustomHeaders is { Count: > 0 })
         {
             foreach (var kv in _configInfo.CustomHeaders)
+            {
                 HttpClientProvider.ExtraHeaders[kv.Key] = kv.Value;
+                _syncedCustomHeaders.Add(kv.Key);
+            }
         }
 
         var appType = GetOption(Option.AppType);

--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -516,15 +517,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         var downloadExecutor = ResolveExtension<Download.Abstractions.IDownloadExecutor>();
 
         Func<string?, Download.Abstractions.IDownloadPipeline>? downloadPipelineFactory = null;
-        var pipelineType = ResolveExtensionType<Download.Abstractions.IDownloadPipeline>();
-        if (pipelineType != null)
-        {
-            var stringCtor = pipelineType.GetConstructor([typeof(string)]);
-            if (stringCtor != null)
-                downloadPipelineFactory = hash => (Download.Abstractions.IDownloadPipeline)stringCtor.Invoke([hash]);
-            else
-                downloadPipelineFactory = _ => (Download.Abstractions.IDownloadPipeline)Activator.CreateInstance(pipelineType);
-        }
+        var downloadPipeline = ResolveExtension<Download.Abstractions.IDownloadPipeline>();
+        if (downloadPipeline != null)
+            downloadPipelineFactory = _ => downloadPipeline;
 
         switch (roleStrategy)
         {

--- a/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/AbstractBootstrap.cs
@@ -261,6 +261,22 @@ namespace GeneralUpdate.Core.Configuration
         }
 
         /// <summary>
+        /// Registers a pre-constructed authentication provider instance.
+        /// Use this overload when the provider requires constructor parameters
+        /// (e.g. Basic Auth with username/password, or a custom provider with
+        /// a tenant header).  For parameterless providers, prefer <see cref="HttpAuth{T}"/>.
+        /// </summary>
+        /// <param name="provider">The authentication provider instance.</param>
+        /// <returns>The current <typeparamref name="TBootstrap"/> instance for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider"/> is null.</exception>
+        public TBootstrap HttpAuth(Security.IHttpAuthProvider provider)
+        {
+            _instances[typeof(Security.IHttpAuthProvider)] =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            return (TBootstrap)this;
+        }
+
+        /// <summary>
         /// Registers an HTTP authentication provider for attaching authentication credentials
         /// to download requests.
         /// </summary>

--- a/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/ConfigurationMapper.cs
@@ -102,6 +102,7 @@ namespace GeneralUpdate.Core.Configuration
             target.UpdateUrl = source.UpdateUrl;
             target.UpgradeClientVersion = source.UpgradeClientVersion;
             target.ProductId = source.ProductId;
+            target.CustomHeaders = source.CustomHeaders;
 
             return target;
         }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
@@ -231,5 +231,18 @@ namespace GeneralUpdate.Core.Configuration
         ///     The unique product identifier for the current application.
         /// </summary>
         public string ProductId { get; set; }
+
+        /// <summary>
+        ///     Custom HTTP headers to include in every request made by the update framework
+        ///     (both version validation and status reporting).
+        ///     Headers are applied after the authentication provider, so they can supplement
+        ///     but not override authentication headers.
+        /// </summary>
+        /// <remarks>
+        ///     Example: add <c>["X-Tenant-Id"] = "default-tenant"</c> for multi-tenant servers.
+        ///     Headers set here are synced to <see cref="Network.HttpClientProvider.ExtraHeaders"/>
+        ///     at configuration time.
+        /// </remarks>
+        public Dictionary<string, string> CustomHeaders { get; set; }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateConfiguration.cs
@@ -236,12 +236,13 @@ namespace GeneralUpdate.Core.Configuration
         ///     Custom HTTP headers to include in every request made by the update framework
         ///     (both version validation and status reporting).
         ///     Headers are applied after the authentication provider, so they can supplement
-        ///     but not override authentication headers.
+        ///     or override authentication headers if needed.
         /// </summary>
         /// <remarks>
         ///     Example: add <c>["X-Tenant-Id"] = "default-tenant"</c> for multi-tenant servers.
         ///     Headers set here are synced to <see cref="Network.HttpClientProvider.ExtraHeaders"/>
         ///     at configuration time.
+        /// </remarks>
         /// </remarks>
         public Dictionary<string, string> CustomHeaders { get; set; }
     }

--- a/src/c#/GeneralUpdate.Core/Download/Reporting/IUpdateReporter.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Reporting/IUpdateReporter.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GeneralUpdate.Core.Network;
 
 namespace GeneralUpdate.Core.Download.Reporting;
 
@@ -111,11 +112,13 @@ public class HttpUpdateReporter : IUpdateReporter
 
     /// <summary>
     /// Parameterless constructor required by the extension resolution mechanism.
-    /// Uses a default HttpClient and empty ReportUrl (no-op until configured).
+    /// Uses the shared <see cref="HttpClientProvider.Shared"/> instance and empty ReportUrl
+    /// (no-op until configured). The shared HttpClient honours the global SSL policy set
+    /// via <see cref="HttpClientProvider.SetSslValidationPolicy"/>.
     /// </summary>
     public HttpUpdateReporter()
     {
-        _client = new HttpClient();
+        _client = HttpClientProvider.Shared;
         _reportUrl = string.Empty;
     }
 
@@ -141,6 +144,11 @@ public class HttpUpdateReporter : IUpdateReporter
             var json = JsonSerializer.Serialize(report, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
             using var request = new HttpRequestMessage(HttpMethod.Post, _reportUrl);
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            // Apply the global authentication provider (if one was set via
+            // VersionService.SetDefaultAuthProvider or HttpClientProvider.DefaultAuthProvider)
+            // so that report requests carry the same credentials as version validation requests.
+            await HttpClientProvider.ApplyAuthAsync(request, token).ConfigureAwait(false);
 
             await _client.SendAsync(request, token).ConfigureAwait(false);
         }

--- a/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
@@ -1,15 +1,19 @@
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 using GeneralUpdate.Core.Security;
 
 namespace GeneralUpdate.Core.Network;
 
 /// <summary>
-/// Provides a shared static <see cref="HttpClient"/> instance with configurable SSL validation.
-/// Reusing a single HttpClient prevents socket exhaustion.
-/// Do NOT dispose clients obtained from here.
+/// Provides a shared static <see cref="HttpClient"/> instance with configurable SSL validation
+/// and a global HTTP authentication provider. Reusing a single HttpClient prevents socket
+/// exhaustion. Do NOT dispose clients obtained from here.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -18,13 +22,15 @@ namespace GeneralUpdate.Core.Network;
 /// <see cref="StrictSslValidationPolicy"/> (rejects any certificate with SSL errors).
 /// </para>
 /// <para>
-/// This class mirrors the SSL validation pattern used by <see cref="VersionService"/>,
-/// ensuring that both API calls and file downloads respect the same global SSL policy.
+/// The global <see cref="IHttpAuthProvider"/> set via <see cref="DefaultAuthProvider"/> is
+/// applied by <see cref="ApplyAuthAsync"/> so that components like <see cref="HttpUpdateReporter"/>
+/// participate in the same authentication scheme as <see cref="VersionService"/>.
 /// </para>
 /// </remarks>
 public static class HttpClientProvider
 {
     private static ISslValidationPolicy _sslPolicy = new StrictSslValidationPolicy();
+    private static IHttpAuthProvider? _defaultAuthProvider;
     private static readonly HttpClient _shared;
 
     static HttpClientProvider()
@@ -67,4 +73,49 @@ public static class HttpClientProvider
     /// Gets the shared <see cref="HttpClient"/> instance. Do NOT dispose.
     /// </summary>
     public static HttpClient Shared => _shared;
+
+    /// <summary>
+    /// Gets or sets the global default HTTP authentication provider.
+    /// When set, every HTTP call from <see cref="VersionService"/>,
+    /// <see cref="HttpUpdateReporter"/>, and other components using
+    /// <see cref="ApplyAuthAsync"/> will carry the configured credentials.
+    /// </summary>
+    public static IHttpAuthProvider? DefaultAuthProvider
+    {
+        get => _defaultAuthProvider;
+        set => _defaultAuthProvider = value;
+    }
+
+    /// <summary>
+    /// Extra HTTP headers applied to every outgoing request by <see cref="ApplyAuthAsync"/>.
+    /// Use this for headers that are not part of the authentication scheme itself but
+    /// are required by the target server — for example <c>X-Tenant-Id</c> for tenant scoping.
+    /// </summary>
+    /// <remarks>
+    /// The key is the header name, the value is the header value.
+    /// Existing headers of the same name on the request are overwritten.
+    /// This dictionary is thread-safe.
+    /// </remarks>
+    public static ConcurrentDictionary<string, string> ExtraHeaders { get; }
+        = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Applies the global default authentication provider and extra headers
+    /// to the specified request. When no global provider is configured,
+    /// the auth step is a no-op.
+    /// </summary>
+    /// <param name="request">The HTTP request message to authenticate.</param>
+    /// <param name="token">A cancellation token for the authentication operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        if (_defaultAuthProvider != null)
+            await _defaultAuthProvider.ApplyAuthAsync(request, token).ConfigureAwait(false);
+
+        foreach (var kv in ExtraHeaders)
+        {
+            request.Headers.Remove(kv.Key);
+            request.Headers.Add(kv.Key, kv.Value);
+        }
+    }
 }

--- a/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
+++ b/src/c#/GeneralUpdate.Core/Network/HttpClientProvider.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -25,6 +25,7 @@ namespace GeneralUpdate.Core.Network;
 /// The global <see cref="IHttpAuthProvider"/> set via <see cref="DefaultAuthProvider"/> is
 /// applied by <see cref="ApplyAuthAsync"/> so that components like <see cref="HttpUpdateReporter"/>
 /// participate in the same authentication scheme as <see cref="VersionService"/>.
+/// Extra headers set via <see cref="ExtraHeaders"/> are applied after the auth provider.
 /// </para>
 /// </remarks>
 public static class HttpClientProvider
@@ -32,6 +33,15 @@ public static class HttpClientProvider
     private static ISslValidationPolicy _sslPolicy = new StrictSslValidationPolicy();
     private static IHttpAuthProvider? _defaultAuthProvider;
     private static readonly HttpClient _shared;
+
+    // Headers that belong on HttpContentMessage.Headers, not HttpRequestHeaders.
+    // Setting them via request.Headers throws InvalidOperationException.
+    private static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Content-Type", "Content-Length", "Content-Encoding", "Content-Language",
+        "Content-Location", "Content-Disposition", "Content-Range", "Content-MD5",
+        "Last-Modified", "Expires", "Allow"
+    };
 
     static HttpClientProvider()
     {
@@ -104,6 +114,15 @@ public static class HttpClientProvider
     /// to the specified request. When no global provider is configured,
     /// the auth step is a no-op.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Extra headers (see <see cref="ExtraHeaders"/>) are applied after the auth provider,
+    /// so they can supplement authentication headers and also appear on their own when
+    /// no auth provider is configured. If an extra header key matches a content header
+    /// (e.g. <c>Content-Type</c>), it is set on <c>request.Content.Headers</c> instead
+    /// of <c>request.Headers</c> to avoid <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
     /// <param name="request">The HTTP request message to authenticate.</param>
     /// <param name="token">A cancellation token for the authentication operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -114,8 +133,16 @@ public static class HttpClientProvider
 
         foreach (var kv in ExtraHeaders)
         {
-            request.Headers.Remove(kv.Key);
-            request.Headers.Add(kv.Key, kv.Value);
+            if (ContentHeaderNames.Contains(kv.Key) && request.Content != null)
+            {
+                request.Content.Headers.Remove(kv.Key);
+                request.Content.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+            }
+            else
+            {
+                request.Headers.Remove(kv.Key);
+                request.Headers.Add(kv.Key, kv.Value);
+            }
         }
     }
 }

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -66,11 +66,10 @@ namespace GeneralUpdate.Core.Network
     {
         private static readonly HttpClient _sharedClient;
         private static volatile ISslValidationPolicy _globalSslPolicy = new StrictSslValidationPolicy();
-        private static IHttpAuthProvider? _globalAuthProvider;
 
-        private readonly IHttpAuthProvider _auth;
+        private readonly IHttpAuthProvider _authProvider;
         private readonly TimeSpan _timeout;
-        private readonly int _maxRetries;
+        private readonly int _maxRetryAttempts;
 
         /// <summary>
         /// Static constructor: initializes the static members of <see cref="VersionService"/>.
@@ -111,18 +110,25 @@ namespace GeneralUpdate.Core.Network
         /// Sets the global default HTTP authentication provider.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// Delegates to <see cref="HttpClientProvider.DefaultAuthProvider"/> so that
+        /// <see cref="HttpUpdateReporter"/> and other components using
+        /// <see cref="HttpClientProvider.Shared"/> share the same global authentication.
+        /// </para>
+        /// <para>
         /// When a global authentication provider is set, all requests made via the static APIs
         /// (<see cref="Validate(string, string, AppType, string, PlatformType, string, string, string, CancellationToken)"/>
         /// and <see cref="Report(string, int, int, int?, string, string, CancellationToken)"/>)
         /// will preferentially use this provider, overriding the authentication instance
         /// created by <see cref="HttpAuthProviderFactory.Create"/>.
+        /// </para>
         /// <para>
         /// Passing null clears the global authentication provider, reverting to the factory method.
         /// </para>
         /// </remarks>
         /// <param name="provider">The global authentication provider instance, or null to clear the global configuration.</param>
         public static void SetDefaultAuthProvider(IHttpAuthProvider? provider)
-            => _globalAuthProvider = provider;
+            => HttpClientProvider.DefaultAuthProvider = provider;
 
         private static bool SharedCertValidation(HttpRequestMessage m, X509Certificate2? c,
             X509Chain? ch, SslPolicyErrors e)
@@ -134,16 +140,16 @@ namespace GeneralUpdate.Core.Network
         /// <remarks>
         /// Instance methods (<see cref="ValidateAsync"/> and <see cref="ReportAsync"/>) use
         /// this instance's authentication provider and timeout settings.
-        /// When <paramref name="auth"/> is null, <see cref="NoOpAuthProvider"/> (no authentication) is used by default.
+        /// When <paramref name="authProvider"/> is null, <see cref="NoOpAuthProvider"/> (no authentication) is used by default.
         /// </remarks>
-        /// <param name="auth">The HTTP authentication provider. If null, <see cref="NoOpAuthProvider"/> is used.</param>
-        /// <param name="timeout">The request timeout. If null, defaults to 30 seconds.</param>
-        /// <param name="maxRetries">The maximum number of retry attempts. Defaults to 3.</param>
-        public VersionService(IHttpAuthProvider? auth = null, TimeSpan? timeout = null, int maxRetries = 3)
+        /// <param name="authProvider">The HTTP authentication provider. If null, <see cref="NoOpAuthProvider"/> is used.</param>
+        /// <param name="requestTimeout">The request timeout. If null, defaults to 30 seconds.</param>
+        /// <param name="maxRetryAttempts">The maximum number of retry attempts. Defaults to 3.</param>
+        public VersionService(IHttpAuthProvider? authProvider = null, TimeSpan? requestTimeout = null, int maxRetryAttempts = 3)
         {
-            _auth = auth ?? new NoOpAuthProvider();
-            _timeout = timeout ?? TimeSpan.FromSeconds(30);
-            _maxRetries = maxRetries;
+            _authProvider = authProvider ?? new NoOpAuthProvider();
+            _timeout = requestTimeout ?? TimeSpan.FromSeconds(30);
+            _maxRetryAttempts = maxRetryAttempts;
         }
 
         /// <summary>
@@ -185,7 +191,7 @@ namespace GeneralUpdate.Core.Network
             AppType appType, string appKey, PlatformType platform, string productId,
             string scheme = null, string token = null, Security.AuthScheme authScheme = Security.AuthScheme.Hmac, string basicUsername = null, string basicPassword = null, CancellationToken ct = default)
         {
-            var auth = _globalAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, appKey, authScheme, basicUsername, basicPassword);
+            var auth = HttpClientProvider.DefaultAuthProvider ?? HttpAuthProviderFactory.Create(scheme, token, appKey, authScheme, basicUsername, basicPassword);
             return new VersionService(auth).ValidateAsync(url, version, (int)appType, appKey, (int)platform, productId, ct);
         }
 
@@ -288,9 +294,9 @@ namespace GeneralUpdate.Core.Network
             for (int attempt = 0; ; attempt++)
             {
                 try { return await SendAsync<T>(url, p, ti, t).ConfigureAwait(false); }
-                catch (Exception ex) when (attempt < _maxRetries - 1 && IsRetryable(ex))
+                catch (Exception ex) when (attempt < _maxRetryAttempts - 1 && ShouldRetry(ex))
                 {
-                    GeneralTracer.Warn($"HTTP attempt {attempt + 1}/{_maxRetries} failed, retrying. {ex.Message}");
+                    GeneralTracer.Warn($"HTTP attempt {attempt + 1}/{_maxRetryAttempts} failed, retrying. {ex.Message}");
                     await Task.Delay(TimeSpan.FromMilliseconds(Math.Pow(2, attempt) * 1000), t).ConfigureAwait(false);
                 }
             }
@@ -343,7 +349,7 @@ namespace GeneralUpdate.Core.Network
             req.Headers.Accept.ParseAdd("application/json");
             var json = JsonSerializer.Serialize(p, HttpParameterJsonContext.Default.DictionaryStringObject);
             req.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            await _auth.ApplyAuthAsync(req, t).ConfigureAwait(false);
+            await _authProvider.ApplyAuthAsync(req, t).ConfigureAwait(false);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(t);
             cts.CancelAfter(_timeout);
@@ -354,7 +360,7 @@ namespace GeneralUpdate.Core.Network
         }
 
         /// <summary>
-        /// Determines whether an exception is retryable.
+        /// Determines whether an exception should be retried.
         /// </summary>
         /// <param name="ex">The exception to evaluate.</param>
         /// <returns><c>true</c> if the exception is retryable; otherwise <c>false</c>.</returns>
@@ -375,7 +381,7 @@ namespace GeneralUpdate.Core.Network
         /// </list>
         /// </para>
         /// </remarks>
-        private static bool IsRetryable(Exception ex)
+        private static bool ShouldRetry(Exception ex)
         {
             if (ex is OperationCanceledException) return false;
             if (ex is TaskCanceledException or TimeoutException or System.IO.IOException) return true;

--- a/tests/ClientTest/Program.cs
+++ b/tests/ClientTest/Program.cs
@@ -45,7 +45,9 @@ static async Task RunUpdateTestAsync()
 
     var updateUrl = "http://localhost:7391/Upgrade/Verification";
     var reportUrl = "http://localhost:7391/Upgrade/Report";
-    var appSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
+    var appSecretKey =
+        Environment.GetEnvironmentVariable("APP_SECRET_KEY")
+        ?? "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
 
     Console.WriteLine($"UpdateUrl: {updateUrl}");
     Console.WriteLine($"ReportUrl: {reportUrl}");

--- a/tests/ClientTest/Program.cs
+++ b/tests/ClientTest/Program.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
+
 using GeneralUpdate.Core;
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Download;
 using GeneralUpdate.Core.Download.Reporting;
 using GeneralUpdate.Core.Event;
 using GeneralUpdate.Core.Hooks;
+using GeneralUpdate.Core.Security;
 
 try
 {
@@ -42,12 +45,13 @@ static async Task RunUpdateTestAsync()
 
     var updateUrl = "http://localhost:7391/Upgrade/Verification";
     var reportUrl = "http://localhost:7391/Upgrade/Report";
-    var appSecretKey =
-        Environment.GetEnvironmentVariable("APP_SECRET_KEY")
-        ?? "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
+    var appSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
 
     Console.WriteLine($"UpdateUrl: {updateUrl}");
+    Console.WriteLine($"ReportUrl: {reportUrl}");
+    Console.WriteLine($"TenantId: default-tenant");
     Console.WriteLine();
+
     Console.WriteLine("NOTE: Configure the GeneralSpacestation server with");
     Console.WriteLine("      the desired test data before running.");
     Console.WriteLine("      - Chain data:      TbPackets (IsCrossVersion=false)");
@@ -67,7 +71,19 @@ static async Task RunUpdateTestAsync()
     //    - Both:       apply upgrade packages → IPC → launch Upgrade process → exit
     //    - None:       no-op
     await new GeneralUpdateBootstrap()
-        .SetSource(updateUrl, appSecretKey, reportUrl)
+        .SetConfig(new UpdateRequest
+        {
+            UpdateUrl = updateUrl,
+            AppSecretKey = appSecretKey,
+            ReportUrl = reportUrl,
+            AuthScheme = AuthScheme.Basic,
+            BasicUsername = "test",
+            BasicPassword = "test",
+            CustomHeaders = new Dictionary<string, string>
+            {
+                ["X-Tenant-Id"] = "default-tenant"
+            }
+        })
         .SetOption(Option.AppType, AppType.Client)
         .Hooks<ClientTestHooks>()
         .AddListenerMultiDownloadStatistics(OnDownloadStatistics)

--- a/tests/ClientTest/generalupdate.manifest.json
+++ b/tests/ClientTest/generalupdate.manifest.json
@@ -4,6 +4,6 @@
   "appType": "Client",
   "updateAppName": "UpgradeTest.exe",
   "upgradeClientVersion": "2.0.0.0",
-  "productId": "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
+  "productId": "8d74e7eb-160c-4a4b-a5dd-c71a7bb08eeb",
   "updatePath": "update/"
 }


### PR DESCRIPTION
## Summary

Unify HTTP authentication across all request paths (Verification + Report), add custom headers support to UpdateConfiguration, and fix CVP cross-version decision logic in GeneralSpacestation.

### Changes (GeneralUpdate.Core library)

**HttpClientProvider**
- Add `DefaultAuthProvider` property — single source of truth for global auth
- Add `ExtraHeaders` ConcurrentDictionary — attach custom headers (e.g. `X-Tenant-Id`) to every request without writing a custom IHttpAuthProvider
- Add `ApplyAuthAsync()` — applies both the auth provider and extra headers

**VersionService**
- `_globalAuthProvider` → delegates to `HttpClientProvider.DefaultAuthProvider`
- Rename fields for clarity: `_auth`→`_authProvider`, `_maxRetries`→`_maxRetryAttempts`, `IsRetryable`→`ShouldRetry`
- Rename constructor parameters: `auth`→`authProvider`, `timeout`→`requestTimeout`, `maxRetries`→`maxRetryAttempts`

**HttpUpdateReporter**
- Use `HttpClientProvider.Shared` instead of `new HttpClient()`
- Apply global auth provider before sending via `HttpClientProvider.ApplyAuthAsync()`

**AbstractBootstrap**
- Add `HttpAuth(IHttpAuthProvider instance)` overload — allows registering providers with constructor parameters

**UpdateConfiguration**
- Add `CustomHeaders` dictionary — set custom HTTP headers via config, synced to `HttpClientProvider.ExtraHeaders` in `SetConfig()`

### Changes (GeneralSpacestation server)

**UpgradeService.BuildUnifiedResponseAsync**
- Remove `Version == lastVersion` hard constraint on CVP matching
- Now accepts any CVP whose `FromVersion == clientVersion` with valid archive hashes, preferring the highest target version
- Client SDK (DownloadPlanBuilder) handles CVP + chain mixed path

### Changes (test)

**ClientTest**
- Use `SetConfig(UpdateRequest { CustomHeaders = ... })` instead of manual header assignment
- Fix manifest `productId` to match test data

### AOT compatibility

All changes are static-analyzed at compile time — no reflection, no Activator, no DynamicCode. Existing AOT warnings are pre-existing.

### Design

The global auth provider now lives in `HttpClientProvider`: `SetDefaultAuthProvider()` one call, both Verification and Report paths covered. Extra headers are a first-class config property, not glue code.