### PR TITLE
fix(core): skip redundant chain packages after full fallback

### DIFF
--- a/src/c#/GeneralUpdate.Core/Configuration/VersionEntry.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/VersionEntry.cs
@@ -205,4 +205,12 @@ public class VersionEntry : VersionIdentity
     /// </summary>
     [JsonPropertyName("fallbackFullHash")]
     public string? FallbackFullHash { get; set; }
+
+    /// <summary>
+    ///     The version string of the fallback full replacement package.
+    ///     Used by <see cref="Strategy.AbstractStrategy"/> to skip chain packages
+    ///     already covered by a previous fallback.
+    /// </summary>
+    [JsonPropertyName("fallbackFullVersion")]
+    public string? FallbackFullVersion { get; set; }
 }

--- a/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
@@ -205,7 +205,8 @@ public static class DownloadPlanBuilder
                         {
                             FallbackFullName = match.Name,
                             FallbackFullUrl = match.Url,
-                            FallbackFullHash = match.SHA256
+                            FallbackFullHash = match.SHA256,
+                            FallbackFullVersion = match.Version
                         };
                     }
                     return chain;

--- a/src/c#/GeneralUpdate.Core/Download/Models/DownloadAsset.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Models/DownloadAsset.cs
@@ -15,6 +15,7 @@ public record DownloadAsset(
     string? FallbackFullName = null,
     string? FallbackFullUrl = null,
     string? FallbackFullHash = null,
+    string? FallbackFullVersion = null,
     bool IsForcibly = false,
     bool IsFreeze = false,
     int RecordId = 0,

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -7,6 +7,7 @@ using GeneralUpdate.Core.FileSystem;
 using GeneralUpdate.Core.Event;
 using GeneralUpdate.Core.Pipeline;
 using GeneralUpdate.Core.Configuration;
+using GeneralUpdate.Core.Utilities;
 
 using GeneralUpdate.Core.Hooks;
 using IUpdateReporter = GeneralUpdate.Core.Download.Reporting.IUpdateReporter;
@@ -146,8 +147,25 @@ namespace GeneralUpdate.Core.Strategy
                 AllPackagesSucceeded = true;
                 var status = ReportType.None;
                 patchRoot = StorageManager.GetTempDirectory(Patchs);
+
+                // Track the highest version already applied via full-package fallback,
+                // so subsequent chain packages covered by that version are skipped.
+                SemVersion? fallbackEffectiveVersion = null;
+
                 foreach (var version in _configinfo.UpdateVersions)
                 {
+                    // When a previous chain package fell back to a full package,
+                    // the application is already at or beyond that full version.
+                    // Skip any remaining chain packages whose version is ≤ the
+                    // fallback version — applying them would be redundant.
+                    if (fallbackEffectiveVersion != null
+                        && version.PackageType == (int)PackageType.Chain
+                        && Semver.TryParse(version.Version, out var versionSv)
+                        && versionSv <= fallbackEffectiveVersion)
+                    {
+                        GeneralTracer.Info($"AbstractStrategy.ExecuteAsync: skipping {version.Version} ({version.Name}) — already covered by fallback full package v{fallbackEffectiveVersion}.");
+                        continue;
+                    }
                     try
                     {
                         // Use a version-specific subdirectory under patchRoot so that
@@ -193,6 +211,14 @@ namespace GeneralUpdate.Core.Strategy
                         var fallbackBuilder = BuildPipeline(fallbackContext);
                         await fallbackBuilder.Build();
                         status = ReportType.Success;
+                        // Record the fallback full package version so subsequent
+                        // chain packages ≤ this version are skipped.
+                        if (!string.IsNullOrEmpty(version.FallbackFullVersion)
+                            && Semver.TryParse(version.FallbackFullVersion, out var ffv)
+                            && (fallbackEffectiveVersion == null || ffv > fallbackEffectiveVersion))
+                        {
+                            fallbackEffectiveVersion = ffv;
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -631,7 +631,8 @@ public class ClientStrategy : IStrategy
                 PackageType = a.PackageType,
                 FallbackFullName = a.FallbackFullName,
                 FallbackFullUrl = a.FallbackFullUrl,
-                FallbackFullHash = a.FallbackFullHash
+                FallbackFullHash = a.FallbackFullHash,
+                FallbackFullVersion = a.FallbackFullVersion
             }).ToList();
 
             var uVersions = dVersions.Where(v => v.AppType == (int)AppType.Upgrade).ToList();

--- a/tests/ClientTest/Program.cs
+++ b/tests/ClientTest/Program.cs
@@ -7,6 +7,8 @@ using GeneralUpdate.Core.Download.Reporting;
 using GeneralUpdate.Core.Event;
 using GeneralUpdate.Core.Hooks;
 using GeneralUpdate.Core.Security;
+using GeneralUpdate.Core.Pipeline;
+using GeneralUpdate.Core.Configuration;
 
 try
 {
@@ -87,6 +89,7 @@ static async Task RunUpdateTestAsync()
             }
         })
         .SetOption(Option.AppType, AppType.Client)
+        .UseDiffPipeline(builder => builder.WithStopOnFirstError(true))
         .Hooks<ClientTestHooks>()
         .AddListenerMultiDownloadStatistics(OnDownloadStatistics)
         .AddListenerMultiDownloadCompleted(OnDownloadCompleted)
@@ -140,7 +143,7 @@ static void OnUpdateInfo(object sender, UpdateInfoEventArgs e)
     {
         foreach (var vi in e.Info.Body)
         {
-            var mode = vi.IsCrossVersion == true ? "CVP" : "Chain";
+            var mode = vi.PackageType == (int)PackageType.Full ? "Full" : "Chain";
             var appType = vi.AppType switch
             {
                 1 => "Client",
@@ -149,8 +152,7 @@ static void OnUpdateInfo(object sender, UpdateInfoEventArgs e)
             };
             Console.WriteLine($"  - [{mode}] {vi.Version} ({vi.Name}) [{vi.Size} bytes] " +
                               $"AppType={appType} " +
-                              $"{(vi.IsForcibly == true ? "(forced)" : "")}" +
-                              $"{(!string.IsNullOrEmpty(vi.FromVersion) ? $" from={vi.FromVersion}" : "")}");
+                              $"{(vi.IsForcibly == true ? "(forced)" : "")}");
         }
     }
     else

--- a/tests/UpgradeTest/Program.cs
+++ b/tests/UpgradeTest/Program.cs
@@ -3,6 +3,7 @@ using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Download;
 using GeneralUpdate.Core.Event;
 using GeneralUpdate.Core.Hooks;
+using GeneralUpdate.Core.Pipeline;
 
 try
 {
@@ -41,6 +42,7 @@ static async Task RunStandardUpgradeAsync()
 
     await new GeneralUpdateBootstrap()
         .SetOption(Option.AppType, AppType.Upgrade)
+        .UseDiffPipeline(builder => builder.WithStopOnFirstError(true))
         .Hooks<UpgradeTestHooks>()
         .AddListenerMultiDownloadStatistics(OnDownloadStatistics)
         .AddListenerMultiDownloadCompleted(OnDownloadCompleted)


### PR DESCRIPTION
## Problem

When a chain package fails and falls back to a full replacement package, the application state is already at or beyond the full package's version. However, the pipeline loop continues processing subsequent chain packages with version ≤ the fallback version, causing redundant work (re-extracting and re-applying the same full package multiple times).

## Root Cause

`AbstractStrategy.ExecuteAsync` iterates over all `UpdateVersions` in order, with no awareness that a previous fallback has already brought the application to a higher version. Each chain package failure independently triggers the same full-package fallback.

## Solution

Track `fallbackEffectiveVersion` — the highest version achieved via full-package fallback — and skip any remaining chain packages whose version ≤ that value.

### Changes

| File | Change |
|------|--------|
| `VersionEntry.cs` | Added `FallbackFullVersion` property |
| `DownloadAsset.cs` | Added `FallbackFullVersion` field |
| `DownloadPlanBuilder.cs` | Populate `FallbackFullVersion` from matching full package |
| `ClientStrategy.cs` | Pass `FallbackFullVersion` to `VersionEntry` |
| `AbstractStrategy.cs` | Track `fallbackEffectiveVersion`, skip covered chain packages |
| `tests/ClientTest/Program.cs` | Enable `StopOnFirstError`, use `PackageType.Full` enum |
| `tests/UpgradeTest/Program.cs` | Enable `StopOnFirstError` |

### Verification

Test output after fix:
```
AbstractStrategy.ExecuteAsync: skipping 2.0.0 (Client_C_v2.0.0) — already covered by fallback full package v3.0.0.
AbstractStrategy.ExecuteAsync: skipping 3.0.0 (Client_C_v3.0.0) — already covered by fallback full package v3.0.0.
```
