### PR TITLE
fix(core): resolve 16 audit findings — race conditions, design flaws, glue code, and performance issues

### DIFF
--- a/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
+++ b/src/c#/GeneralUpdate.Core/Bootstrap/GeneralUpdateBootstrap.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -158,16 +157,12 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
             var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
             if (sslPolicy != null)
             {
-                Network.VersionService.SetSslValidationPolicy(sslPolicy);
                 Network.HttpClientProvider.SetSslValidationPolicy(sslPolicy);
             }
             var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
             if (authProvider != null) Network.VersionService.SetDefaultAuthProvider(authProvider);
 
             ConfigureStrategy(roleStrategy);
-
-            if (roleStrategy is ClientStrategy cs)
-                await CallSmallBowlHomeAsync(_configInfo.Bowl).ConfigureAwait(false);
 
             roleStrategy.Create(_configInfo);
 
@@ -221,6 +216,9 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         var appType = GetOption(Option.AppType);
         if (appType != AppType.Upgrade)
         {
+            // Cleanup temp directories from previous runs (older than 24h) to
+            // prevent disk accumulation from silent-mode polling or crashes.
+            StorageManager.CleanupOldTempDirectories();
             _configInfo.TempPath = StorageManager.GetTempDirectory("upgrade_temp");
             InitBlackPolicy();
         }
@@ -466,7 +464,6 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
         var sslPolicy = ResolveExtension<Security.ISslValidationPolicy>();
         if (sslPolicy != null)
         {
-            Network.VersionService.SetSslValidationPolicy(sslPolicy);
             Network.HttpClientProvider.SetSslValidationPolicy(sslPolicy);
         }
         var authProvider = ResolveExtension<Security.IHttpAuthProvider>();
@@ -577,38 +574,12 @@ public class GeneralUpdateBootstrap : AbstractBootstrap<GeneralUpdateBootstrap, 
 
     private void InitBlackPolicy()
     {
-        // Build blacklist matcher from UpdateContext and set on StorageManager.
-        // The matcher combines user config with system defaults.
-        var effectiveConfig = new BlackPolicy(
-            _configInfo.Files?.Count > 0 ? _configInfo.Files : BlackDefaults.DefaultFiles,
-            _configInfo.Formats?.Count > 0 ? _configInfo.Formats : BlackDefaults.DefaultFormats,
-            _configInfo.Directories?.Count > 0
-                ? _configInfo.Directories
-                : BlackDefaults.DefaultDirectories
-        );
-        StorageManager.BlackMatcher = new BlackMatcher(effectiveConfig);
-    }
-
-    private async Task CallSmallBowlHomeAsync(string processName)
-    {
-        if (string.IsNullOrWhiteSpace(processName))
-        {
-            GeneralTracer.Warn("CallSmallBowlHomeAsync: Bowl process name is empty or whitespace, skipping shutdown.");
-            return;
-        }
-        try
-        {
-            var processes = Process.GetProcessesByName(processName);
-            foreach (var process in processes)
-            {
-                GeneralTracer.Info($"Shutting down process {process.ProcessName} (ID: {process.Id})");
-                await GracefulExit.ShutdownAsync(process).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            GeneralTracer.Error("CallSmallBowlHomeAsync failed.", ex);
-        }
+        StorageManager.BlackMatcher = new BlackMatcher(
+            BlackDefaults.CreatePolicyWithDefaults(
+                _configInfo.Files,
+                _configInfo.Formats,
+                _configInfo.Directories
+            ));
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/src/c#/GeneralUpdate.Core/Configuration/Option.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/Option.cs
@@ -69,9 +69,9 @@ namespace GeneralUpdate.Core.Configuration
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> is <c>null</c>.</exception>
         public static Option<T> ValueOf<T>(string name, T defaultValue = default!)
         {
-            // GetOrAdd is lock-free on ConcurrentDictionary; the factory runs at most once per key.
-            // First registration wins — subsequent calls with the same name return the existing
-            // singleton instance (preserving the original default value).
+            // GetOrAdd is lock-free on ConcurrentDictionary. Under contention the
+            // factory may run multiple times, but only one instance is stored and
+            // returned by all racing callers. The factory must be side-effect-free.
             var raw = _registry.GetOrAdd(name, _ => new Option<T>(name, defaultValue));
 
             // If the existing entry was registered with a different type T, create a new one.

--- a/src/c#/GeneralUpdate.Core/Configuration/Option.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/Option.cs
@@ -38,11 +38,6 @@ namespace GeneralUpdate.Core.Configuration
         private static readonly ConcurrentDictionary<string, Option> _registry = new();
 
         /// <summary>
-        ///     The synchronization lock object for thread-safe option creation.
-        /// </summary>
-        private static readonly object _lock = new();
-
-        /// <summary>
         ///     The unique name identifier for this option.
         ///     Remains unique throughout the application lifetime.
         /// </summary>
@@ -74,15 +69,19 @@ namespace GeneralUpdate.Core.Configuration
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> is <c>null</c>.</exception>
         public static Option<T> ValueOf<T>(string name, T defaultValue = default!)
         {
-            lock (_lock)
-            {
-                if (_registry.TryGetValue(name, out var existing) && existing is Option<T> typed)
-                    return typed;
+            // GetOrAdd is lock-free on ConcurrentDictionary; the factory runs at most once per key.
+            // First registration wins — subsequent calls with the same name return the existing
+            // singleton instance (preserving the original default value).
+            var raw = _registry.GetOrAdd(name, _ => new Option<T>(name, defaultValue));
 
-                var option = new Option<T>(name, defaultValue);
-                _registry[name] = option;
-                return option;
-            }
+            // If the existing entry was registered with a different type T, create a new one.
+            // This is the same "last writer wins" behavior as the original lock-based implementation.
+            if (raw is Option<T> typed)
+                return typed;
+
+            var replacement = new Option<T>(name, defaultValue);
+            _registry[name] = replacement;
+            return replacement;
         }
 
         /// <summary>

--- a/src/c#/GeneralUpdate.Core/Configuration/UpdateRequest.cs
+++ b/src/c#/GeneralUpdate.Core/Configuration/UpdateRequest.cs
@@ -37,13 +37,7 @@ namespace GeneralUpdate.Core.Configuration
         ///         <item>
         ///             <c>UpdateLogUrl</c>: If set, must be a valid absolute URI.</item>
         ///         <item>
-        ///             <c>UpdateAppName</c>: Must not be empty.</item>
-        ///         <item>
-        ///             <c>MainAppName</c>: Must not be empty.</item>
-        ///         <item>
         ///             <c>AppSecretKey</c>: Must not be empty.</item>
-        ///         <item>
-        ///             <c>ClientVersion</c>: Must not be empty.</item>
         ///     </list>
         ///     <para>
         ///         This method is typically called at the end of the <see cref="UpdateRequestBuilder.Build" /> method

--- a/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
@@ -86,9 +86,15 @@ public static class DownloadPlanBuilder
     /// <summary>Pre-parses versions for a list of assets to avoid repeated Semver.TryParse calls.</summary>
     private static Dictionary<DownloadAsset, SemVersion?> PreParseVersions(IEnumerable<DownloadAsset> assets)
     {
-        return assets.ToDictionary(
-            a => a,
-            a => ParseVersion(a.Version));
+        var map = new Dictionary<DownloadAsset, SemVersion?>();
+        foreach (var a in assets)
+        {
+            // Custom IDownloadSource implementations could return duplicate records;
+            // silently accept the first occurrence rather than throwing.
+            if (!map.ContainsKey(a))
+                map[a] = ParseVersion(a.Version);
+        }
+        return map;
     }
 
     /// <summary>

--- a/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
+++ b/src/c#/GeneralUpdate.Core/Download/DownloadPlanBuilder.cs
@@ -83,6 +83,14 @@ public static class DownloadPlanBuilder
         return serverVersions.Max() > local;
     }
 
+    /// <summary>Pre-parses versions for a list of assets to avoid repeated Semver.TryParse calls.</summary>
+    private static Dictionary<DownloadAsset, SemVersion?> PreParseVersions(IEnumerable<DownloadAsset> assets)
+    {
+        return assets.ToDictionary(
+            a => a,
+            a => ParseVersion(a.Version));
+    }
+
     /// <summary>
     /// Builds a download plan with AppType-aware version filtering.
     /// Client-type assets are compared against <paramref name="clientVersion"/>.
@@ -107,6 +115,16 @@ public static class DownloadPlanBuilder
         var parsedUpgrade = ParseVersion(upgradeClientVersion) ?? parsedClient;
         var uv = parsedUpgrade.Value;
 
+        // Pre-parse all asset versions to avoid repeated Semver.TryParse calls.
+        var versionMap = PreParseVersions(assets);
+
+        // Helper: safe lookup that matches netstandard2.0 (no GetValueOrDefault).
+        SemVersion? Lookup(DownloadAsset a)
+        {
+            versionMap.TryGetValue(a, out var sv);
+            return sv;
+        }
+
         // 1. Filter out frozen packages
         var active = assets
             .Where(a => !a.IsFreeze)
@@ -122,23 +140,22 @@ public static class DownloadPlanBuilder
         var candidates = active
             .Where(a =>
             {
-                if (!Semver.TryParse(a.Version, out var pv)) return false;
+                var pv = Lookup(a);
+                if (pv == null) return false;
 
                 var localVersion = (a.AppType == (int)AppType.Upgrade)
                     ? uv
                     : cv;
 
-                return pv > localVersion;
+                return pv.Value > localVersion;
             })
             .Where(a => IsCompatible(a.MinClientVersion, clientVersion))
-            .OrderBy(a => { Semver.TryParse(a.Version, out var sv); return sv; })
+            .OrderBy(a => Lookup(a))
             .ToList();
 
         if (candidates.Count == 0) return DownloadPlan.Empty;
 
-        // Separate chain vs full packages.
-        // Treat Unspecified (0) as Chain for backward compatibility with older
-        // servers that do not set PackageType yet.
+        // 4. Separate chain vs full packages.
         var chainCandidates = candidates
             .Where(a => a.PackageType == (int)Configuration.PackageType.Chain
                         || a.PackageType == (int)Configuration.PackageType.Unspecified)
@@ -149,17 +166,12 @@ public static class DownloadPlanBuilder
             .ToList();
 
         // ── Chain vs Full size-based decision ──
-        // If a full replacement package is available and the total chain download
-        // size approaches or exceeds the full package size, skip chain and use full.
         if (chainCandidates.Count > 0 && fullCandidates.Count > 0)
         {
-            // Pick the latest full package (highest version) across all AppTypes
             var bestFull = fullCandidates
-                .OrderByDescending(a => { Semver.TryParse(a.Version, out var sv); return sv; })
+                .OrderByDescending(a => Lookup(a))
                 .First();
 
-            // Only compare against chain packages of the same AppType as bestFull.
-            // Mixing Client and Upgrade sizes together could trigger incorrect switching.
             long chainTotal = chainCandidates
                 .Where(a => a.AppType == bestFull.AppType)
                 .Sum(a => a.Size);
@@ -167,23 +179,18 @@ public static class DownloadPlanBuilder
 
             if (chainTotal >= threshold)
             {
-                // Chain is too expensive — use full package instead.
-                // Supplement with chain packages for other AppTypes not covered by full.
                 GeneralTracer.Info($"DownloadPlanBuilder: chain total {chainTotal} >= 80% of full size {bestFull.Size}, switching to full package {bestFull.Name}");
+                var bestFullSv = Lookup(bestFull);
                 var planAssets = new List<DownloadAsset> { bestFull };
                 planAssets.AddRange(chainCandidates
                     .Where(a => a.AppType != bestFull.AppType
-                                || (Semver.TryParse(a.Version, out var av)
-                                    && Semver.TryParse(bestFull.Version, out var fv)
-                                    && av > fv))
-                    .OrderBy(a => { Semver.TryParse(a.Version, out var sv); return sv; }));
+                                || (Lookup(a) is { } av && bestFullSv != null && av > bestFullSv))
+                    .OrderBy(a => Lookup(a)));
                 return new DownloadPlan(planAssets, isForcibly);
             }
         }
 
         // ── Chain plan with fallback fulls ──
-        // Use chain packages normally. Attach FallbackFull* info to each chain entry
-        // so that if a chain patch fails, AbstractStrategy can fall back to full.
         if (fullCandidates.Count > 0)
         {
             var fallbackFulls = new List<DownloadAsset>();
@@ -191,20 +198,18 @@ public static class DownloadPlanBuilder
             var chainWithFallback = chainCandidates
                 .Select(chain =>
                 {
-                    // Find a matching full: same AppType + same Version (or closest)
                     var match = fullCandidates
                         .Where(f => f.AppType == chain.AppType)
-                        .OrderBy(f => { Semver.TryParse(f.Version, out var sv); return sv; })
+                        .OrderBy(f => Lookup(f))
                         .FirstOrDefault(f =>
                         {
-                            if (!Semver.TryParse(f.Version, out var fv)) return false;
-                            if (!Semver.TryParse(chain.Version, out var cv)) return false;
-                            return fv >= cv;
+                            var fv = Lookup(f);
+                            var cv = Lookup(chain);
+                            return fv != null && cv != null && fv.Value >= cv.Value;
                         });
 
                     if (match != null)
                     {
-                        // Add matching full to the fallback list once
                         if (!fallbackFulls.Any(f => f.Url == match.Url))
                             fallbackFulls.Add(match);
 
@@ -226,7 +231,6 @@ public static class DownloadPlanBuilder
             };
         }
 
-        // No full packages at all: return chain packages as-is
         return new DownloadPlan(chainCandidates, isForcibly);
     }
 
@@ -245,11 +249,7 @@ public static class DownloadPlanBuilder
 
     /// <summary>
     /// Checks whether the specified MinClientVersion is compatible with the current client version.
-    /// If a package's MinClientVersion is higher than the current version, the package is not applicable.
     /// </summary>
-    /// <param name="minClientVersion">The minimum client version required by the package. If null or empty, the package is considered compatible.</param>
-    /// <param name="currentVersion">The current client version string.</param>
-    /// <returns>True if the current version meets or exceeds the minimum requirement; otherwise false.</returns>
     internal static bool IsCompatible(string? minClientVersion, string currentVersion)
     {
         if (string.IsNullOrEmpty(minClientVersion)) return true;
@@ -260,8 +260,6 @@ public static class DownloadPlanBuilder
     }
 
     /// <summary>Parses a version string and returns null if the string cannot be parsed.</summary>
-    /// <param name="version">The version string to parse.</param>
-    /// <returns>A parsed <see cref="SemVersion"/> value, or null if parsing fails.</returns>
     internal static SemVersion? ParseVersion(string? version)
     {
         if (string.IsNullOrWhiteSpace(version)) return null;

--- a/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
+++ b/src/c#/GeneralUpdate.Core/Download/Orchestrators/DefaultDownloadOrchestrator.cs
@@ -210,10 +210,10 @@ public class DefaultDownloadOrchestrator : IDownloadOrchestrator
 
         var tasks = plan.Assets.Select(async asset =>
         {
-            var acquired = await sem.WaitAsync(TimeSpan.FromMinutes(5), token).ConfigureAwait(false);
+            var acquired = await sem.WaitAsync(TimeSpan.FromMinutes(1), token).ConfigureAwait(false);
             if (!acquired)
             {
-                GeneralTracer.Warn("DefaultDownloadOrchestrator: semaphore wait timed out for " + asset.Name + ", skipping.");
+                GeneralTracer.Warn($"DefaultDownloadOrchestrator: semaphore wait timed out (1 min) for '{asset.Name}'. Concurrency={effectiveConcurrency}, ActiveSlots={effectiveConcurrency - sem.CurrentCount}. Skipping asset.");
                 lock (results)
                 {
                     results.Add(new DownloadResult(asset, null, 0, TimeSpan.Zero, 0, false, "Semaphore wait timed out"));

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackDefaults.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackDefaults.cs
@@ -28,4 +28,21 @@ public static class BlackDefaults
         StorageManager.LegacyDirectoryPrefix,
         "fail"
     };
+
+    /// <summary>
+    /// Creates a <see cref="BlackPolicy"/> using caller-provided lists, falling back to
+    /// <see cref="DefaultFiles"/>, <see cref="DefaultFormats"/>, and <see cref="DefaultDirectories"/>
+    /// for any list that is null or empty.
+    /// </summary>
+    public static BlackPolicy CreatePolicyWithDefaults(
+        IReadOnlyList<string>? files,
+        IReadOnlyList<string>? formats,
+        IReadOnlyList<string>? directories)
+    {
+        return new BlackPolicy(
+            files?.Count > 0 ? new List<string>(files) : DefaultFiles,
+            formats?.Count > 0 ? new List<string>(formats) : DefaultFormats,
+            directories?.Count > 0 ? new List<string>(directories) : DefaultDirectories
+        );
+    }
 }

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackMatcher.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackMatcher.cs
@@ -95,9 +95,16 @@ public class BlackMatcher : IBlackMatcher
     /// Uses case-insensitive substring containment matching (<c>string.IndexOf</c>) for evaluation.
     /// The directory is considered skippable if its name contains any string from the <c>Directories</c> list.
     /// </remarks>
-    public bool ShouldSkipDirectory(string directoryName)
-        => _config.Directories?.Any(d =>
-            directoryName.StartsWith(d, StringComparison.OrdinalIgnoreCase)) == true;
+    public bool ShouldSkipDirectory(string directoryOrPath)
+    {
+        // Extract the directory name from a possible full path so both
+        // bare names ("backup-2026") and full paths (".backups/backup-2026") work.
+        var dirName = Path.GetFileName(directoryOrPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrEmpty(dirName)) return false;
+
+        return _config.Directories?.Any(d =>
+            dirName.StartsWith(d, StringComparison.OrdinalIgnoreCase)) == true;
+    }
 
     /// <summary>
     /// Matches a file name against a simple Glob pattern.

--- a/src/c#/GeneralUpdate.Core/FileSystem/BlackMatcher.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/BlackMatcher.cs
@@ -97,7 +97,7 @@ public class BlackMatcher : IBlackMatcher
     /// </remarks>
     public bool ShouldSkipDirectory(string directoryName)
         => _config.Directories?.Any(d =>
-            directoryName.IndexOf(d, StringComparison.OrdinalIgnoreCase) >= 0) == true;
+            directoryName.StartsWith(d, StringComparison.OrdinalIgnoreCase)) == true;
 
     /// <summary>
     /// Matches a file name against a simple Glob pattern.

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -222,6 +222,57 @@ namespace GeneralUpdate.Core.FileSystem
         }
 
         /// <summary>
+        /// Cleans up temporary directories created by previous runs that are older than <paramref name="maxAge"/>.
+        /// These directories match the pattern "generalupdate_*" created by <see cref="GetTempDirectory"/>.
+        /// </summary>
+        /// <param name="maxAge">Maximum age to retain. Defaults to 24 hours.</param>
+        /// <remarks>
+        /// This is safe to call at application startup or update cycle start to prevent disk
+        /// accumulation from silent-mode polling or crashed update processes.
+        /// Only directories belonging to OTHER processes (different PID) are cleaned —
+        /// the current process's temp directory is left untouched.
+        /// </remarks>
+        public static void CleanupOldTempDirectories(TimeSpan? maxAge = null)
+        {
+            maxAge ??= TimeSpan.FromHours(24);
+            var cutoff = DateTime.UtcNow - maxAge.Value;
+            var currentPid = System.Diagnostics.Process.GetCurrentProcess().Id;
+
+            try
+            {
+                foreach (var dir in Directory.GetDirectories(Path.GetTempPath(), "generalupdate_*"))
+                {
+                    try
+                    {
+                        var dirInfo = new DirectoryInfo(dir);
+                        var dirName = dirInfo.Name;
+
+                        // Parse timestamp from "generalupdate_yyyy-MM-dd-HHmmss-fff_PID_name"
+                        // If the PID segment matches the current process, skip it.
+                        var parts = dirName.Split('_');
+                        if (parts.Length >= 4 && int.TryParse(parts[3], out var pid) && pid == currentPid)
+                            continue;
+
+                        if (dirInfo.CreationTimeUtc < cutoff)
+                        {
+                            try { DeleteDirectory(dir); }
+                            catch (Exception ex)
+                            {
+                                GeneralTracer.Warn($"StorageManager.CleanupOldTempDirectories: failed to delete old temp '{dir}': {ex.Message}");
+                            }
+                        }
+                    }
+                    catch (UnauthorizedAccessException) { /* skip */ }
+                    catch (DirectoryNotFoundException) { /* raced away */ }
+                }
+            }
+            catch (Exception ex)
+            {
+                GeneralTracer.Warn($"StorageManager.CleanupOldTempDirectories: enumeration failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Generates a timestamp-based backup directory name in the format "backup-{yyyyMMddHHmmss}".
         /// </summary>
         /// <returns>A backup directory name string, e.g. "backup-20260606235200".</returns>
@@ -292,18 +343,46 @@ namespace GeneralUpdate.Core.FileSystem
         /// </remarks>
         public static void DeleteDirectory(string targetDir)
         {
+            // Enumerate then delete with per-item exception handling.
+            // Between enumeration and deletion, concurrent processes may add/remove
+            // files — handle these races gracefully instead of crashing.
             foreach (var file in Directory.GetFiles(targetDir))
             {
-                File.SetAttributes(file, FileAttributes.Normal);
-                File.Delete(file);
+                try
+                {
+                    File.SetAttributes(file, FileAttributes.Normal);
+                    File.Delete(file);
+                }
+                catch (FileNotFoundException) { /* raced away — already deleted */ }
+                catch (DirectoryNotFoundException) { /* raced away */ }
+                catch (UnauthorizedAccessException ex)
+                {
+                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete file '{Path.GetFileName(file)}': {ex.Message}");
+                }
             }
 
             foreach (var dir in Directory.GetDirectories(targetDir))
             {
-                DeleteDirectory(dir);
+                try
+                {
+                    DeleteDirectory(dir);
+                }
+                catch (DirectoryNotFoundException) { /* raced away */ }
+                catch (UnauthorizedAccessException ex)
+                {
+                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(dir)}': {ex.Message}");
+                }
             }
 
-            Directory.Delete(targetDir, false);
+            try
+            {
+                Directory.Delete(targetDir, false);
+            }
+            catch (DirectoryNotFoundException) { /* raced away */ }
+            catch (UnauthorizedAccessException ex)
+            {
+                GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(targetDir)}': {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
+++ b/src/c#/GeneralUpdate.Core/FileSystem/StorageManager.cs
@@ -248,9 +248,10 @@ namespace GeneralUpdate.Core.FileSystem
                         var dirName = dirInfo.Name;
 
                         // Parse timestamp from "generalupdate_yyyy-MM-dd-HHmmss-fff_PID_name"
+                        // Splitting by '_': [0]=prefix, [1]=timestamp, [2]=PID, [3..]=name.
                         // If the PID segment matches the current process, skip it.
                         var parts = dirName.Split('_');
-                        if (parts.Length >= 4 && int.TryParse(parts[3], out var pid) && pid == currentPid)
+                        if (parts.Length >= 3 && int.TryParse(parts[2], out var pid) && pid == currentPid)
                             continue;
 
                         if (dirInfo.CreationTimeUtc < cutoff)
@@ -346,42 +347,58 @@ namespace GeneralUpdate.Core.FileSystem
             // Enumerate then delete with per-item exception handling.
             // Between enumeration and deletion, concurrent processes may add/remove
             // files — handle these races gracefully instead of crashing.
-            foreach (var file in Directory.GetFiles(targetDir))
-            {
-                try
-                {
-                    File.SetAttributes(file, FileAttributes.Normal);
-                    File.Delete(file);
-                }
-                catch (FileNotFoundException) { /* raced away — already deleted */ }
-                catch (DirectoryNotFoundException) { /* raced away */ }
-                catch (UnauthorizedAccessException ex)
-                {
-                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete file '{Path.GetFileName(file)}': {ex.Message}");
-                }
-            }
-
-            foreach (var dir in Directory.GetDirectories(targetDir))
-            {
-                try
-                {
-                    DeleteDirectory(dir);
-                }
-                catch (DirectoryNotFoundException) { /* raced away */ }
-                catch (UnauthorizedAccessException ex)
-                {
-                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(dir)}': {ex.Message}");
-                }
-            }
-
             try
             {
-                Directory.Delete(targetDir, false);
+                foreach (var file in Directory.GetFiles(targetDir))
+                {
+                    try
+                    {
+                        File.SetAttributes(file, FileAttributes.Normal);
+                        File.Delete(file);
+                    }
+                    catch (FileNotFoundException) { /* raced away — already deleted */ }
+                    catch (DirectoryNotFoundException) { /* raced away */ }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete file '{Path.GetFileName(file)}': {ex.Message}");
+                    }
+                }
+
+                try
+                {
+                    foreach (var dir in Directory.GetDirectories(targetDir))
+                    {
+                        try
+                        {
+                            DeleteDirectory(dir);
+                        }
+                        catch (DirectoryNotFoundException) { /* raced away */ }
+                        catch (UnauthorizedAccessException ex)
+                        {
+                            GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(dir)}': {ex.Message}");
+                        }
+                    }
+                }
+                catch (DirectoryNotFoundException) { /* parent raced away */ }
+                catch (UnauthorizedAccessException ex)
+                {
+                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot enumerate subdirectories: {ex.Message}");
+                }
+
+                try
+                {
+                    Directory.Delete(targetDir, false);
+                }
+                catch (DirectoryNotFoundException) { /* raced away */ }
+                catch (UnauthorizedAccessException ex)
+                {
+                    GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(targetDir)}': {ex.Message}");
+                }
             }
-            catch (DirectoryNotFoundException) { /* raced away */ }
+            catch (DirectoryNotFoundException) { /* parent raced away before enumeration */ }
             catch (UnauthorizedAccessException ex)
             {
-                GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot delete directory '{Path.GetFileName(targetDir)}': {ex.Message}");
+                GeneralTracer.Warn($"StorageManager.DeleteDirectory: cannot enumerate '{targetDir}': {ex.Message}");
             }
         }
 

--- a/src/c#/GeneralUpdate.Core/GracefulExit.cs
+++ b/src/c#/GeneralUpdate.Core/GracefulExit.cs
@@ -61,7 +61,7 @@ public static class GracefulExit
             // a no-op, but the process will exit when the async call stack unwinds.
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                var p = Process.GetCurrentProcess();
+                using var p = Process.GetCurrentProcess();
                 if (!p.HasExited)
                     p.CloseMainWindow();
             }

--- a/src/c#/GeneralUpdate.Core/GracefulExit.cs
+++ b/src/c#/GeneralUpdate.Core/GracefulExit.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
@@ -39,10 +40,39 @@ public static class GracefulExit
             process.Kill(); // Last resort
     }
 
-    /// <summary>Shutdown the current process gracefully.</summary>
-    public static async Task CurrentProcessAsync(int timeoutMs = 3000)
+    /// <summary>Exit the current process gracefully.</summary>
+    /// <remarks>
+    /// <para>
+    /// For external processes, <see cref="ShutdownAsync"/> sends WM_CLOSE then waits.
+    /// For self-shutdown (the current process), calling <c>CloseMainWindow</c> + <c>Kill</c>
+    /// on oneself is harmful — <c>Kill</c> skips finally blocks, <c>CloseMainWindow</c> is a
+    /// no-op for console apps, and the 3-second wait is wasted.
+    /// </para>
+    /// <para>
+    /// Instead, this method signals the process to exit naturally.
+    /// Callers must dispose their own resources (tracer, etc.) before calling this method.
+    /// </para>
+    /// </remarks>
+    public static Task CurrentProcessAsync(int timeoutMs = 3000)
     {
-        var p = Process.GetCurrentProcess();
-        await ShutdownAsync(p, timeoutMs).ConfigureAwait(false);
+        try
+        {
+            // Signal GUI windows to close. For console/background processes this is
+            // a no-op, but the process will exit when the async call stack unwinds.
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                var p = Process.GetCurrentProcess();
+                if (!p.HasExited)
+                    p.CloseMainWindow();
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exiting — nothing to do.
+        }
+
+        // The process exits naturally when the async call stack completes.
+        // Callers should have already disposed critical resources (tracer, etc.).
+        return Task.CompletedTask;
     }
 }

--- a/src/c#/GeneralUpdate.Core/Network/VersionService.cs
+++ b/src/c#/GeneralUpdate.Core/Network/VersionService.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Security;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -64,47 +62,17 @@ namespace GeneralUpdate.Core.Network
     /// </remarks>
     public class VersionService
     {
-        private static readonly HttpClient _sharedClient;
-        private static volatile ISslValidationPolicy _globalSslPolicy = new StrictSslValidationPolicy();
-
         private readonly IHttpAuthProvider _authProvider;
         private readonly TimeSpan _timeout;
         private readonly int _maxRetryAttempts;
 
         /// <summary>
-        /// Static constructor: initializes the static members of <see cref="VersionService"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Execution flow:
-        /// <list type="number">
-        ///   <item><description>Creates an <see cref="HttpClientHandler"/> with a custom SSL validation callback.</description></item>
-        ///   <item><description>The SSL validation logic is delegated to <see cref="ISslValidationPolicy"/>,
-        ///   which can be replaced globally via <see cref="SetSslValidationPolicy"/>.</description></item>
-        ///   <item><description>Initializes the static shared <see cref="HttpClient"/> instance using the handler.</description></item>
-        /// </list>
-        /// </para>
-        /// </remarks>
-        static VersionService()
-        {
-            var handler = new HttpClientHandler();
-            handler.ServerCertificateCustomValidationCallback = SharedCertValidation;
-            _sharedClient = new HttpClient(handler, disposeHandler: false);
-        }
-
-        /// <summary>
         /// Sets the global SSL certificate validation policy.
+        /// Delegates to <see cref="HttpClientProvider.SetSslValidationPolicy"/> so there is
+        /// only one SSL policy for all HTTP traffic in the framework.
         /// </summary>
-        /// <remarks>
-        /// This policy affects all HTTPS requests made by <see cref="VersionService"/> instances.
-        /// The default is <see cref="StrictSslValidationPolicy"/>, i.e., strict mode.
-        /// Pass a custom <see cref="ISslValidationPolicy"/> implementation to relax or replace
-        /// the validation logic.
-        /// </remarks>
-        /// <param name="policy">The SSL validation policy instance. Must not be null.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="policy"/> is null.</exception>
         public static void SetSslValidationPolicy(ISslValidationPolicy policy)
-            => _globalSslPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
+            => HttpClientProvider.SetSslValidationPolicy(policy);
 
         /// <summary>
         /// Sets the global default HTTP authentication provider.
@@ -115,24 +83,9 @@ namespace GeneralUpdate.Core.Network
         /// <see cref="HttpUpdateReporter"/> and other components using
         /// <see cref="HttpClientProvider.Shared"/> share the same global authentication.
         /// </para>
-        /// <para>
-        /// When a global authentication provider is set, all requests made via the static APIs
-        /// (<see cref="Validate(string, string, AppType, string, PlatformType, string, string, string, CancellationToken)"/>
-        /// and <see cref="Report(string, int, int, int?, string, string, CancellationToken)"/>)
-        /// will preferentially use this provider, overriding the authentication instance
-        /// created by <see cref="HttpAuthProviderFactory.Create"/>.
-        /// </para>
-        /// <para>
-        /// Passing null clears the global authentication provider, reverting to the factory method.
-        /// </para>
         /// </remarks>
-        /// <param name="provider">The global authentication provider instance, or null to clear the global configuration.</param>
         public static void SetDefaultAuthProvider(IHttpAuthProvider? provider)
             => HttpClientProvider.DefaultAuthProvider = provider;
-
-        private static bool SharedCertValidation(HttpRequestMessage m, X509Certificate2? c,
-            X509Chain? ch, SslPolicyErrors e)
-            => _globalSslPolicy.ValidateCertificate(c, ch, e);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionService"/> class.
@@ -353,7 +306,7 @@ namespace GeneralUpdate.Core.Network
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(t);
             cts.CancelAfter(_timeout);
-            var r = await _sharedClient.SendAsync(req, cts.Token).ConfigureAwait(false);
+            var r = await HttpClientProvider.Shared.SendAsync(req, cts.Token).ConfigureAwait(false);
             r.EnsureSuccessStatusCode();
             var rj = await r.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize(rj, ti);

--- a/src/c#/GeneralUpdate.Core/Pipeline/HashMiddleware.cs
+++ b/src/c#/GeneralUpdate.Core/Pipeline/HashMiddleware.cs
@@ -32,6 +32,9 @@ namespace GeneralUpdate.Core.Pipeline;
 /// </remarks>
 public class HashMiddleware : IMiddleware
 {
+    // Reusable thread-safe algorithm instance. SHA256.Create is stateless
+    // once initialized; individual calls compute on their own input stream.
+    private static readonly Sha256HashAlgorithm HashAlgorithm = new();
     /// <summary>
     /// Asynchronously executes the hash verification logic.
     /// </summary>
@@ -95,8 +98,7 @@ public class HashMiddleware : IMiddleware
     {
         return Task.Run(() =>
         {
-            var hashAlgorithm = new Sha256HashAlgorithm();
-            var hashSha256 = hashAlgorithm.ComputeHash(path);
+            var hashSha256 = HashAlgorithm.ComputeHash(path);
             return string.Equals(hash, hashSha256, StringComparison.OrdinalIgnoreCase);
         });
     }

--- a/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/AbstractStrategy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.FileSystem;
 using GeneralUpdate.Core.Event;
@@ -46,6 +47,12 @@ namespace GeneralUpdate.Core.Strategy
     public abstract class AbstractStrategy : IStrategy
     {
         private const string Patchs = "patchs";
+
+        /// <summary>Guard against re-entrant <see cref="ExecuteAsync"/> calls.</summary>
+        private int _executing;
+
+        /// <summary>Tracks whether at least one version was applied successfully in the current batch.</summary>
+        private bool _appliedAnyVersion;
 
         /// <summary>
         /// Global configuration information containing parameters such as update package path, temporary directory, report URL, and version list.
@@ -141,10 +148,18 @@ namespace GeneralUpdate.Core.Strategy
         /// </remarks>
         public virtual async Task ExecuteAsync()
         {
+            if (Interlocked.Exchange(ref _executing, 1) == 1)
+            {
+                GeneralTracer.Warn("AbstractStrategy.ExecuteAsync: re-entrant call ignored.");
+                AllPackagesSucceeded = false;
+                return;
+            }
+
             var patchRoot = string.Empty;
             try
             {
                 AllPackagesSucceeded = true;
+                _appliedAnyVersion = false;
                 var status = ReportType.None;
                 patchRoot = StorageManager.GetTempDirectory(Patchs);
 
@@ -185,6 +200,7 @@ namespace GeneralUpdate.Core.Strategy
                         var context = CreatePipelineContext(version, patchPath);
                         var pipelineBuilder = BuildPipeline(context);
                         await pipelineBuilder.Build();
+                        _appliedAnyVersion = true;
                         status = ReportType.Success;
                     }
                     catch (Exception e) when (version.PackageType == (int)PackageType.Chain
@@ -212,6 +228,7 @@ namespace GeneralUpdate.Core.Strategy
                         try
                         {
                             await fallbackBuilder.Build();
+                            _appliedAnyVersion = true;
                             status = ReportType.Success;
                             // Record the fallback full package version so subsequent
                             // chain packages ≤ this version are skipped.
@@ -236,7 +253,12 @@ namespace GeneralUpdate.Core.Strategy
                         status = ReportType.Failure;
                         AllPackagesSucceeded = false;
                         HandleExecuteException(e);
-                        TryRollback();
+                        // Only rollback when NO version has succeeded yet in this batch.
+                        // If a previous version was already applied successfully,
+                        // rolling back would undo valid work and leave the app in
+                        // a downgraded state across version boundaries.
+                        if (!_appliedAnyVersion)
+                            TryRollback();
                     }
                     finally
                     {
@@ -258,6 +280,7 @@ namespace GeneralUpdate.Core.Strategy
             }
             finally
             {
+                Interlocked.Exchange(ref _executing, 0);
                 if (!string.IsNullOrEmpty(patchRoot))
                     Clear(patchRoot);
             }
@@ -522,6 +545,14 @@ namespace GeneralUpdate.Core.Strategy
         private void DeleteVersionZip(VersionEntry version)
         {
             if (string.IsNullOrWhiteSpace(_configinfo.TempPath)) return;
+
+            // Guard: version.Name must not be null or empty, otherwise the path
+            // would resolve to TempPath/.zip which could delete an unrelated file.
+            if (string.IsNullOrWhiteSpace(version.Name))
+            {
+                GeneralTracer.Warn($"AbstractStrategy: cannot delete zip for version {version.Version ?? "null"} — Name is empty.");
+                return;
+            }
 
             var zipPath = Path.Combine(_configinfo.TempPath, $"{version.Name}{_configinfo.Format.ToExtension()}");
             try

--- a/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/ClientStrategy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
@@ -857,17 +856,7 @@ public class ClientStrategy : IStrategy
     /// <para>If neither matches, a <see cref="PlatformNotSupportedException"/> is thrown.</para>
     /// </remarks>
     private IStrategy ResolveOsStrategy()
-    {
-        if (_customOsStrategy != null)
-            return _customOsStrategy;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return new WindowsStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return new LinuxStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            return new MacStrategy();
-        throw new PlatformNotSupportedException("The current operating system is not supported!");
-    }
+        => OsStrategyResolver.Resolve(_customOsStrategy);
 
     /// <summary>
     /// Initializes the file blacklist configuration. Used to exclude files, formats, and directories that do not need processing
@@ -880,14 +869,12 @@ public class ClientStrategy : IStrategy
     /// </remarks>
     private void InitBlackPolicy()
     {
-        var effectiveConfig = new BlackPolicy(
-            _configInfo!.Files?.Count > 0 ? _configInfo.Files : BlackDefaults.DefaultFiles,
-            _configInfo.Formats?.Count > 0 ? _configInfo.Formats : BlackDefaults.DefaultFormats,
-            _configInfo.Directories?.Count > 0
-                ? _configInfo.Directories
-                : BlackDefaults.DefaultDirectories
-        );
-        StorageManager.BlackMatcher = new BlackMatcher(effectiveConfig);
+        StorageManager.BlackMatcher = new BlackMatcher(
+            BlackDefaults.CreatePolicyWithDefaults(
+                _configInfo!.Files,
+                _configInfo.Formats,
+                _configInfo.Directories
+            ));
     }
 
     /// <summary>
@@ -951,22 +938,9 @@ public class ClientStrategy : IStrategy
         return failVersion >= versionParsed;
     }
 
-    /// <summary>
     /// Gets the platform type for the current running OS.
-    /// </summary>
-    /// <returns>The current platform type (<see cref="PlatformType.Windows"/>, <see cref="PlatformType.Linux"/>,
-    /// <see cref="PlatformType.MacOS"/>, or <see cref="PlatformType.Unknown"/>).</returns>
-    /// <remarks>
-    /// Uses <c>RuntimeInformation.IsOSPlatform</c> for runtime detection.
-    /// The return value is used to inform the server of the client platform when constructing <c>HttpDownloadSource</c>.
-    /// </remarks>
     private static PlatformType GetPlatform()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return PlatformType.Windows;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformType.Linux;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return PlatformType.MacOS;
-        return PlatformType.Unknown;
-    }
+        => OsStrategyResolver.GetPlatform();
 
     /// <summary>
     /// After upgrade packages have been applied in-place, writes the latest upgrade version

--- a/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/MacStrategy.cs
@@ -76,8 +76,11 @@ public class MacStrategy : AbstractStrategy
             {
                 GeneralTracer.Info($"MacStrategy.StartApp: launching app={mainApp}");
                 using var process = System.Diagnostics.Process.Start(mainApp);
-                if (process == null || process.HasExited)
+                if (process == null)
                     throw new InvalidOperationException($"Failed to start application: {mainApp}");
+                // Do NOT check process.HasExited here — a fast-starting app may
+                // have already exited by the time we check, causing a false failure.
+                // Process.Start returning non-null confirms the OS created the process.
                 GeneralTracer.Info($"MacStrategy.StartApp: app launched successfully (PID: {process.Id}).");
             }
             else

--- a/src/c#/GeneralUpdate.Core/Strategy/OsStrategyResolver.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/OsStrategyResolver.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GeneralUpdate.Core.Strategy;
+
+/// <summary>
+/// Shared OS platform strategy resolver. Eliminates the duplicate
+/// <c>ResolveOsStrategy()</c> method in <see cref="ClientStrategy"/>
+/// and <see cref="UpdateStrategy"/>.
+/// </summary>
+internal static class OsStrategyResolver
+{
+    /// <summary>
+    /// Resolves the platform-specific strategy for the current OS.
+    /// </summary>
+    /// <param name="customOsStrategy">
+    /// An optional custom OS strategy. When non-null, returned as-is.
+    /// </param>
+    /// <exception cref="PlatformNotSupportedException">
+    /// Thrown when the current OS is not Windows, Linux, or macOS and no custom strategy was provided.
+    /// </exception>
+    internal static IStrategy Resolve(IStrategy? customOsStrategy = null)
+    {
+        if (customOsStrategy != null)
+            return customOsStrategy;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return new WindowsStrategy();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return new LinuxStrategy();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return new MacStrategy();
+
+        throw new PlatformNotSupportedException("The current operating system is not supported!");
+    }
+
+    /// <summary>
+    /// Resolves the platform type for the current OS.
+    /// </summary>
+    internal static Configuration.PlatformType GetPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Configuration.PlatformType.Windows;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return Configuration.PlatformType.Linux;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return Configuration.PlatformType.MacOS;
+        return Configuration.PlatformType.Unknown;
+    }
+}

--- a/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/UpdateStrategy.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using GeneralUpdate.Core.Configuration;
 using GeneralUpdate.Core.Event;
@@ -213,17 +212,7 @@ public class UpdateStrategy : IStrategy
     #region Helpers
 
     private IStrategy ResolveOsStrategy()
-    {
-        if (_customOsStrategy != null)
-            return _customOsStrategy;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return new WindowsStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return new LinuxStrategy();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            return new MacStrategy();
-        throw new PlatformNotSupportedException("The current operating system is not supported!");
-    }
+        => OsStrategyResolver.Resolve(_customOsStrategy);
 
     private Hooks.HookContext BuildUpdateContext()
     {
@@ -239,7 +228,7 @@ public class UpdateStrategy : IStrategy
     private async Task<bool> SafeOnBeforeUpdateAsync(Hooks.HookContext ctx)
     {
         try { return await Hooks.OnBeforeUpdateAsync(ctx).ConfigureAwait(false); }
-        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}"); return true; }
+        catch (Exception ex) { GeneralTracer.Warn($"OnBeforeUpdateAsync hook failed: {ex.Message}"); return false; }
     }
 
     private async Task SafeOnAfterUpdateAsync(Hooks.HookContext ctx)

--- a/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
+++ b/src/c#/GeneralUpdate.Core/Strategy/WindowsStrategy.cs
@@ -109,8 +109,11 @@ namespace GeneralUpdate.Core.Strategy
 
                 GeneralTracer.Info($"GeneralUpdate.Core.WindowsStrategy.StartApp: launching app={appPath}");
                 using var appProcess = Process.Start(appPath);
-                if (appProcess == null || appProcess.HasExited)
+                if (appProcess == null)
                     throw new InvalidOperationException($"Failed to start application: {appPath}");
+                // Do NOT check appProcess.HasExited here — a fast-starting app may
+                // have already exited by the time we check, causing a false failure.
+                // Process.Start returning non-null confirms the OS created the process.
                 appLaunched = true;
                 GeneralTracer.Info($"GeneralUpdate.Core.WindowsStrategy.StartApp: app launched successfully (PID: {appProcess.Id}).");
 


### PR DESCRIPTION
## Summary

Fixes 16 findings from the Core audit (issue #528). Covers race conditions, rollback logic, null-safety, design inconsistencies, repeated/duplicated code, and performance hot-spots.

## Changes

### Bug Fixes
- **Race condition in Process.Start** (WindowsStrategy, MacStrategy): Removed the `HasExited` check after `Process.Start()` — a fast-starting app can exit before we inspect it, causing a false failure.
- **Rollback destroys valid updates** (AbstractStrategy): `TryRollback()` is now guarded by `_appliedAnyVersion` — only rollback when no version has been applied yet in this batch.
- **Null version.Name in DeleteVersionZip** (AbstractStrategy): Added null/whitespace guard.
- **Semaphore timeout logging** (DefaultDownloadOrchestrator): Reduced timeout from 5min to 1min, added active-slots diagnostic to the warning message.
- **Concurrent DeleteDirectory** (StorageManager): Each file/dir operation is now wrapped in try-catch to handle concurrent modification races gracefully.
- **Re-entry guard for ExecuteAsync** (AbstractStrategy): Added `Interlocked.Exchange` guard to prevent corrupt state from concurrent calls.

### Design Improvements
- **XML doc mismatch** (UpdateRequest): Updated doc to only list the fields actually validated.
- **Dual SSL policy** (VersionService): Removed independent `_sharedClient` and `_globalSslPolicy`; delegates entirely to `HttpClientProvider`.
- **GracefulExit self-Kill** (GracefulExit): `CurrentProcessAsync()` no longer calls `Kill()` on the current process — lets the async stack unwind naturally.
- **Over-broad directory skip** (BlackMatcher): Changed `IndexOf` to `StartsWith` prefix matching to avoid false-positive directory skips.
- **Global lock in Option** (Option): Replaced `lock` + `TryGetValue` with `ConcurrentDictionary.GetOrAdd`.

### Glue Code Removal
- **BlackPolicy init duplicated** (Bootstrap, ClientStrategy): Extracted `BlackDefaults.CreatePolicyWithDefaults()` shared helper.
- **Bowl shutdown duplicated** (Bootstrap, ClientStrategy): Removed the redundant `CallSmallBowlHomeAsync` from Bootstrap; ClientStrategy already handles it.
- **OS strategy resolution duplicated** (ClientStrategy, UpdateStrategy): Extracted shared `OsStrategyResolver` class.
- **Hook semantics inconsistent** (UpdateStrategy): `SafeOnBeforeUpdateAsync` now returns `false` on exception (abort), matching ClientStrategy behavior.

### Performance
- **Repeated version parsing** (DownloadPlanBuilder): Pre-parse all asset versions into a dictionary and use a local `Lookup()` helper.
- **Repeated hash instance** (HashMiddleware): Made `Sha256HashAlgorithm` a `static readonly` field.
- **Temp directory accumulation** (StorageManager): Added `CleanupOldTempDirectories()` called at bootstrap startup, cleaning dirs older than 24h.

## Testing
- All changes compile on `netstandard2.0`, `net8.0`, and `net10.0` with 0 errors, 0 warnings.
- No functional changes to the public API surface.

Closes #528
